### PR TITLE
Remove compose version line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   db:
     image: postgres:15-alpine


### PR DESCRIPTION
## Summary
- remove the `version:` line from the Compose configuration

## Testing
- `docker-compose config`
- `docker-compose build` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68458387b87483278ba825df44e7db0d