### PR TITLE
Fix Postgres port in docker compose

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,8 @@
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=test
-POSTGRES_PORT=5433
-DATABASE_URL=postgresql://postgres:postgres@db:5433/test1
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://postgres:postgres@db:5432/test1
 
 # Привяжем сервисы к этим именам
 DB_HOST=db

--- a/backend/.env
+++ b/backend/.env
@@ -2,8 +2,8 @@
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=test
-POSTGRES_PORT=5433
-DATABASE_URL=postgresql://postgres:postgres@db:5433/test1
+POSTGRES_PORT=5432
+DATABASE_URL=postgresql://postgres:postgres@db:5432/test1
 
 # Привяжем сервисы к этим именам
 DB_HOST=db

--- a/backend/database.py
+++ b/backend/database.py
@@ -4,10 +4,10 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 # Read the URL from the environment; if it's not set (e.g. in Docker),
-# fall back to pointing at the "db" service on port 5433.
+# fall back to pointing at the "db" service on port 5432.
 DATABASE_URL = os.getenv(
     "DATABASE_URL",
-    "postgresql://postgres:postgres@db:5433/test1"
+    "postgresql://postgres:postgres@db:5432/test1"
 )
 
 # --- SQLAlchemy setup (if you use it elsewhere) ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - pgdata:/var/lib/postgresql/data
       - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     ports:
-      - "5433:5433"
+      # expose container's default port 5432 on host port 5433
+      - "5433:5432"
 
   backend:
     build:


### PR DESCRIPTION
## Summary
- fix docker-compose postgres port mapping
- update `.env` files to use port 5432 inside compose
- update `database.py` fallback URL

## Testing
- `python -m py_compile backend/*.py backend/routers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68692ef1f4188327a6554bb2aa4eed82