### PR TITLE
Update default DB name to test1

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # Database
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-POSTGRES_DB=test
+POSTGRES_DB=test1
 POSTGRES_PORT=5432
 DATABASE_URL=postgresql://postgres:postgres@db:5432/test1
 POSTGRES_HOST_PORT=5433

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ docker compose down
 `POSTGRES_HOST_PORT`:
 - **host:** `localhost`
 - **port:** `5433` (или выбранный вами `POSTGRES_HOST_PORT`)
-- **database:** `test`
+- **database:** `test1`
 - **user:** `postgres`
 - **password:** `postgres`
 
 URL подключения доступен в переменной окружения `DATABASE_URL`. Например,
 можно подключиться через `psql`:
 ```bash
-psql postgresql://postgres:postgres@localhost:${POSTGRES_HOST_PORT:-5433}/test
+psql postgresql://postgres:postgres@localhost:${POSTGRES_HOST_PORT:-5433}/test1
 ```
 
 ## Локальный запуск без Docker

--- a/backend/.env
+++ b/backend/.env
@@ -1,7 +1,7 @@
 # Database
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
-POSTGRES_DB=test
+POSTGRES_DB=test1
 POSTGRES_PORT=5432
 DATABASE_URL=postgresql://postgres:postgres@db:5432/test1
 POSTGRES_HOST_PORT=5433


### PR DESCRIPTION
## Summary
- update `.env` and `backend/.env` to use `POSTGRES_DB=test1`
- refresh README to document the new DB name

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880dad2d6f48327aec1f23a662bf051