### PR TITLE
Add health endpoint

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,12 @@ from .routers.ticket_admin import router as admin_tickets_router
 
 app = FastAPI()
 
+# Healthcheck endpoint
+@app.get("/health")
+def health() -> dict[str, str]:
+    """Simple health check returning API status."""
+    return {"status": "ok"}
+
 # Настраиваем CORS (если нужно)
 origins = ["http://localhost:3000","http://10.4.4.108:3000" ]
 app.add_middleware(


### PR DESCRIPTION
## Summary
- add `/health` route for quick server checks

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e64e9e3c8327b9417afb3de2ae87