### PR TITLE
Fix init.sql for PostgreSQL 14

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -10,7 +10,6 @@
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
-SET transaction_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);


### PR DESCRIPTION
## Summary
- remove unsupported `transaction_timeout` setting from init.sql

## Testing
- `npm ci --prefix frontend`
- `npm test --prefix frontend --silent -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68832fc42fd88327bce845be34de294e