### PR TITLE
Fix missing curl for healthcheck

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,6 +21,9 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# install curl so the healthcheck can run
+RUN apt-get update && apt-get install -y curl
+
 # bring in the venv & code
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /app/backend /app/backend


### PR DESCRIPTION
## Summary
- add curl install step to backend Dockerfile so healthcheck works

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68832fca81d88327a1cdb8572f7ab79f