### PR TITLE
Fix route deletion with existing stops

### DIFF
--- a/backend/routers/route.py
+++ b/backend/routers/route.py
@@ -74,8 +74,8 @@ def delete_route(route_id: int):
     """
     conn = get_connection()
     cur = conn.cursor()
-    # Если у вас нет CASCADE, можно удалить остановки вручную:
-    # cur.execute("DELETE FROM routestop WHERE route_id = %s;", (route_id,))
+    # Удаляем связанные остановки вручную, т.к. в БД нет ON DELETE CASCADE
+    cur.execute("DELETE FROM routestop WHERE route_id = %s;", (route_id,))
     cur.execute("DELETE FROM route WHERE id=%s RETURNING id;", (route_id,))
     deleted = cur.fetchone()
     conn.commit()


### PR DESCRIPTION
## Summary
- ensure related route stops are removed before deleting a route

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68833a36ed5083279670babbc2896efd