### PR TITLE
Secure admin routes with token auth

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,0 +1,18 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import os
+
+security = HTTPBearer(auto_error=False)
+
+
+def get_current_admin(
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+):
+    """Validate admin token from Authorization header."""
+    expected_token = os.getenv("ADMIN_TOKEN", "adminsecret")
+    if not credentials or credentials.credentials != expected_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing admin token",
+        )
+    return {"role": "admin"}

--- a/backend/routers/available.py
+++ b/backend/routers/available.py
@@ -1,8 +1,13 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from pydantic import BaseModel
 from ..database import get_connection
+from ..auth import get_current_admin
 
-router = APIRouter(prefix="/available", tags=["available"])
+router = APIRouter(
+    prefix="/available",
+    tags=["available"],
+    dependencies=[Depends(get_current_admin)],
+)
 
 class AvailableCreate(BaseModel):
     tour_id: int

--- a/backend/routers/pricelist.py
+++ b/backend/routers/pricelist.py
@@ -1,10 +1,15 @@
 # routers/pricelists.py
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Depends
+from ..auth import get_current_admin
 from typing import List
 from ..database import get_connection
 from ..models import Pricelist, PricelistCreate
 
-router = APIRouter(prefix="/pricelists", tags=["pricelists"])
+router = APIRouter(
+    prefix="/pricelists",
+    tags=["pricelists"],
+    dependencies=[Depends(get_current_admin)],
+)
 
 @router.get("/", response_model=List[Pricelist])
 def get_pricelists():

--- a/backend/routers/prices.py
+++ b/backend/routers/prices.py
@@ -1,8 +1,13 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from ..database import get_connection
 from ..models import Prices, PricesCreate
+from ..auth import get_current_admin
 
-router = APIRouter(prefix="/prices", tags=["prices"])
+router = APIRouter(
+    prefix="/prices",
+    tags=["prices"],
+    dependencies=[Depends(get_current_admin)],
+)
 
 @router.get("/", response_model=None)
 def get_prices(pricelist_id: int = None):

--- a/backend/routers/report.py
+++ b/backend/routers/report.py
@@ -1,10 +1,15 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 from typing import Optional
 from datetime import datetime
 from ..database import get_connection
+from ..auth import get_current_admin
 
-router = APIRouter(prefix="/report", tags=["report"])
+router = APIRouter(
+    prefix="/report",
+    tags=["report"],
+    dependencies=[Depends(get_current_admin)],
+)
 
 class ReportFilters(BaseModel):
     start_date: Optional[str] = None

--- a/backend/routers/route.py
+++ b/backend/routers/route.py
@@ -1,11 +1,16 @@
 # file: route.py
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from ..auth import get_current_admin
 from typing import Optional, List
 from datetime import time
 from pydantic import BaseModel
 from ..database import get_connection  # Предполагается, что у вас есть database.py
 
-router = APIRouter(prefix="/routes", tags=["routes"])
+router = APIRouter(
+    prefix="/routes",
+    tags=["routes"],
+    dependencies=[Depends(get_current_admin)],
+)
 
 #
 # --- Pydantic модели ---

--- a/backend/routers/seat.py
+++ b/backend/routers/seat.py
@@ -1,9 +1,10 @@
 # src/routers/seat.py
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from typing import List, Dict, Optional
 from pydantic import BaseModel
 from ..database import get_connection
+from ..auth import get_current_admin
 
 router = APIRouter(prefix="/seat", tags=["seat"])
 
@@ -112,6 +113,7 @@ def block_seat(
     tour_id: int   = Query(..., description="ID рейса"),
     seat_num: int  = Query(..., description="Номер места"),
     block:    bool = Query(..., description="true — блокировать, false — разблокировать"),
+    current_admin: dict = Depends(get_current_admin),
 ):
     """
     Меняет состояние места:

--- a/backend/routers/stop.py
+++ b/backend/routers/stop.py
@@ -1,8 +1,13 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from ..database import get_connection
 from ..models import Stop, StopCreate
+from ..auth import get_current_admin
 
-router = APIRouter(prefix="/stops", tags=["stops"])
+router = APIRouter(
+    prefix="/stops",
+    tags=["stops"],
+    dependencies=[Depends(get_current_admin)],
+)
 
 @router.get("/", response_model=list[Stop])
 def get_stops():

--- a/backend/routers/ticket_admin.py
+++ b/backend/routers/ticket_admin.py
@@ -1,9 +1,14 @@
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from pydantic import BaseModel, EmailStr
 from typing import List, Optional, Dict
 from ..database import get_connection
+from ..auth import get_current_admin
 
-router = APIRouter(prefix="/admin/tickets", tags=["admin_tickets"])
+router = APIRouter(
+    prefix="/admin/tickets",
+    tags=["admin_tickets"],
+    dependencies=[Depends(get_current_admin)],
+)
 
 
 class TicketInfo(BaseModel):

--- a/backend/routers/tour.py
+++ b/backend/routers/tour.py
@@ -1,12 +1,17 @@
 # backend/app/routers/tour.py
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from pydantic import BaseModel
 from typing import List
 from datetime import date
 from ..database import get_connection
+from ..auth import get_current_admin
 
-router = APIRouter(prefix="/tours", tags=["tours"])
+router = APIRouter(
+    prefix="/tours",
+    tags=["tours"],
+    dependencies=[Depends(get_current_admin)],
+)
 
 
 class TourCreate(BaseModel):

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -1,0 +1,65 @@
+import importlib
+import sys
+import os
+
+import importlib
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyCursor:
+    def execute(self, *args, **kwargs):
+        pass
+
+    def fetchone(self):
+        return None
+
+    def fetchall(self):
+        return []
+
+    def close(self):
+        pass
+
+
+class DummyConn:
+    def cursor(self):
+        return DummyCursor()
+
+    def close(self):
+        pass
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **kw: DummyConn())
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    if "backend.main" in sys.modules:
+        importlib.reload(sys.modules["backend.main"])
+    else:
+        importlib.import_module("backend.main")
+    app = sys.modules["backend.main"].app
+    return TestClient(app)
+
+
+def test_admin_routes_require_token(client):
+    routes = [
+        ("get", "/routes/"),
+        ("get", "/stops/"),
+        ("get", "/pricelists/"),
+        ("get", "/prices/"),
+        ("get", "/available/"),
+        ("post", "/report/"),
+        ("get", "/tours/"),
+        ("get", "/admin/tickets/"),
+    ]
+    for method, path in routes:
+        resp = getattr(client, method)(path)
+        assert resp.status_code == 401
+
+    resp = client.put(
+        "/seat/block",
+        params={"tour_id": 1, "seat_num": 1, "block": True},
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add simple admin token auth dependency
- apply auth dependency to admin routers
- create tests verifying unauthenticated access is denied

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68834e7d06f88327b00d5b0b868da68a