### PR TITLE
Add JWT env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ CORS_ORIGINS=http://localhost:3000
 
 # Front-end (optional)
 FRONTEND_PORT=3000
+
+# JWT settings
+SECRET_KEY=...
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ cp .env.example .env
 ```
 На Windows используйте `copy .env.example .env`. В файле `.env` можно
 изменить порты и другие переменные окружения под свои нужды.
+Также укажите параметры для JWT-токенов:
+```bash
+SECRET_KEY=...
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+```
 Команда `docker compose` читает этот файл и без него не запустит контейнеры.
 
 ## Сборка контейнеров


### PR DESCRIPTION
## Summary
- add JWT variables to `.env.example`
- document JWT variables in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836337e3508327824c1483f165687a