### PR TITLE
Add JWT_SECRET variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,6 @@ ADMIN_PASSWORD=admin
 # Token returned on successful login
 ADMIN_TOKEN=adminsecret
 
+# Secret key used to sign tokens
+JWT_SECRET=changeme
+

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ cp .env.example .env
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=admin
 ADMIN_TOKEN=adminsecret
+JWT_SECRET=changeme
 ```
 Значения по умолчанию совпадают с теми, что указаны выше. Токен
 возвращается эндпоинтом `/auth/login` и используется в заголовке
 `Authorization` при обращении к административным маршрутам.
+Переменная `JWT_SECRET` задаёт ключ, которым подписываются эти токены.
 Команда `docker compose` читает этот файл и без него не запустит контейнеры.
 
 ## Сборка контейнеров


### PR DESCRIPTION
## Summary
- add JWT_SECRET placeholder to `.env.example`
- document JWT_SECRET usage in README

## Testing
- `pytest -q` *(fails: IndentationError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68837febcc548327a555af6cbc8bf92c