### PR TITLE
Improve seat selection accessibility

### DIFF
--- a/frontend/src/components/SeatSelection.css
+++ b/frontend/src/components/SeatSelection.css
@@ -8,26 +8,65 @@
 .seat {
   width: 50px;
   height: 50px;
-  background-color: #ddd;
   border-radius: 4px;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   font-weight: bold;
+  border: 1px solid #888;
   transition: background-color 0.2s ease;
 }
 
 .seat.available {
-  background-color: #c8e6c9; /* зелёный */
+  background-color: #bde5b8; /* light green */
 }
 
 .seat.occupied {
-  background-color: #ffcccc; /* красный/серый */
+  background-color: #e0e0e0; /* light grey */
+  color: #d32f2f;
   cursor: not-allowed;
 }
 
 .seat.selected {
   background-color: #4caf50;
-  color: white;
+  color: #fff;
+}
+
+.seat-legend {
+  margin-top: 10px;
+  display: flex;
+  gap: 12px;
+  font-size: 14px;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.legend-box {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  border: 1px solid #888;
+}
+
+.legend-box.available {
+  background-color: #bde5b8;
+}
+
+.legend-box.occupied {
+  background-color: #e0e0e0;
+  color: #d32f2f;
+}
+
+.legend-box.selected {
+  background-color: #4caf50;
+  color: #fff;
 }

--- a/frontend/src/components/SeatSelection.js
+++ b/frontend/src/components/SeatSelection.js
@@ -13,21 +13,57 @@ function SeatSelection({ seats = [], onSelect }) {
   };
 
   return (
-    <div className="seats-grid">
-      {seats.map((seat) => (
-        <div
-          key={seat.seat_num}
-          className={
-            "seat " +
-            (seat.available ? "available " : "occupied ") +
-            (seat.seat_num === selectedSeat ? "selected" : "")
-          }
-          onClick={() => handleClick(seat)}
-        >
-          {seat.seat_num}
+    <>
+      <div className="seats-grid">
+        {seats.map((seat) => {
+          const isSelected = seat.seat_num === selectedSeat;
+          const statusLabel = seat.available
+            ? isSelected
+              ? "selected"
+              : "available"
+            : "occupied";
+
+          return (
+            <button
+              key={seat.seat_num}
+              type="button"
+              className={
+                "seat " +
+                (seat.available ? "available " : "occupied ") +
+                (isSelected ? "selected" : "")
+              }
+              onClick={() => handleClick(seat)}
+              disabled={!seat.available}
+              aria-pressed={isSelected}
+              aria-label={`Seat ${seat.seat_num} ${statusLabel}`}
+              title={
+                seat.available
+                  ? isSelected
+                    ? "Ваш выбор"
+                    : "Свободное место"
+                  : "Место занято"
+              }
+            >
+              {isSelected ? "\u2713" : seat.available ? seat.seat_num : "\u2715"}
+            </button>
+          );
+        })}
+      </div>
+      <div className="seat-legend">
+        <div className="legend-item">
+          <span className="legend-box available" aria-hidden="true"></span>
+          <span>Свободно</span>
         </div>
-      ))}
-    </div>
+        <div className="legend-item">
+          <span className="legend-box occupied" aria-hidden="true">\u2715</span>
+          <span>Занято</span>
+        </div>
+        <div className="legend-item">
+          <span className="legend-box selected" aria-hidden="true">\u2713</span>
+          <span>Выбрано</span>
+        </div>
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- improve accessibility and colors for SeatSelection

## Testing
- `pytest -q`
- `CI=true npm test --prefix frontend --silent`

------
https://chatgpt.com/codex/tasks/task_e_688390cc81148327a9766cbc483c0d36