### PR TITLE
Fix CSS merge artifacts

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -307,7 +307,6 @@ tbody tr:hover {
   background-color: #327ad6;
 }
 
-codex/add-reusable-loader-and-alert-components
 .loader-container {
   display: flex;
   justify-content: center;
@@ -346,11 +345,11 @@ codex/add-reusable-loader-and-alert-components
 .alert-error {
   background-color: #f8d7da;
   color: #721c24;
-=======
+}
+
 @media (max-width: 600px) {
   nav ul {
     flex-direction: column;
     gap: 10px;
   }
-main
 }

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -12,8 +12,8 @@ class DummyCursor:
 
     def fetchone(self):
         if "FROM users" in self.query:
-            # bcrypt hash for 'admin'
-            return [1, "$2b$12$Y.DzD5azTaGBSLNfQCbwGOpVxBmWncTZyjNOyPNJwzLneHpIh9DO2", "admin"]
+            # hashed 'admin'
+            return ["8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918", "admin"]
         return None
 
     def fetchall(self):
@@ -39,3 +39,72 @@ class DummyConn:
 
 @pytest.fixture()
 def client(monkeypatch):
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **kw: DummyConn())
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    if "backend.main" in sys.modules:
+        importlib.reload(sys.modules["backend.main"])
+    else:
+        importlib.import_module("backend.main")
+    app = sys.modules["backend.main"].app
+    return TestClient(app)
+
+
+def test_admin_routes_require_token(client):
+    routes = [
+        ("get", "/routes/"),
+        ("get", "/stops/"),
+        ("get", "/pricelists/"),
+        ("get", "/prices/"),
+        ("get", "/available/"),
+        ("post", "/report/"),
+        ("get", "/tours/"),
+        ("get", "/admin/tickets/"),
+    ]
+    for method, path in routes:
+        resp = getattr(client, method)(path)
+        assert resp.status_code == 401
+
+    resp = client.put(
+        "/seat/block",
+        params={"tour_id": 1, "seat_num": 1, "block": True},
+    )
+    assert resp.status_code == 401
+
+
+def test_admin_routes_with_and_without_token(client):
+    login = client.post("/auth/login", json={"username": "admin", "password": "admin"})
+    assert login.status_code == 200
+    token = login.json()["token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    routes = [
+        ("get", "/routes/"),
+        ("get", "/stops/"),
+        ("get", "/pricelists/"),
+        ("get", "/prices/"),
+        ("get", "/available/"),
+        ("post", "/report/"),
+        ("get", "/tours/"),
+        ("get", "/admin/tickets/"),
+    ]
+    for method, path in routes:
+        resp = getattr(client, method)(path, headers=headers)
+        assert resp.status_code != 401
+
+    bad_headers = {"Authorization": "Bearer wrong"}
+    for method, path in routes:
+        resp = getattr(client, method)(path, headers=bad_headers)
+        assert resp.status_code == 401
+
+    resp = client.put(
+        "/seat/block",
+        params={"tour_id": 1, "seat_num": 1, "block": True},
+        headers=headers,
+    )
+    assert resp.status_code != 401
+
+    resp = client.put(
+        "/seat/block",
+        params={"tour_id": 1, "seat_num": 1, "block": True},
+        headers=bad_headers,
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- repair trailing merge conflict markers in frontend CSS
- restore previous version of `test_admin_routes.py`

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688494f12de483278a7ec71759a73818