### PR TITLE
Update SeatClient to use SeatIcon

### DIFF
--- a/frontend/src/components/SeatClient.js
+++ b/frontend/src/components/SeatClient.js
@@ -5,15 +5,10 @@ import axios from "axios";
 
 import BusLayoutNeoplan from "./busLayouts/BusLayoutNeoplan";
 import BusLayoutTravego  from "./busLayouts/BusLayoutTravego";
+import SeatIcon from "./SeatIcon";
 
 import { API } from "../config";
-
-// Цвета для клиента
-const CLIENT_COLORS = {
-  blocked:   "#ddd",    // недоступное
-  available: "#4caf50", // зелёное
-  selected:  "#2196f3"  // синим помеченное выбранное
-};
+import { CLIENT_COLORS } from "../constants";
 
 /**
  * SeatClient — для страницы покупки билета.
@@ -72,33 +67,18 @@ export default function SeatClient({
   // renderCell для скелетного режима
   const renderCell = (seatNum) => {
     const seat = seats.find(s => s.seat_num === seatNum);
-    const status = seat ? seat.status : "blocked";
-    let bg;
-    if (status === "blocked") {
-      bg = CLIENT_COLORS.blocked;
-    } else if (seatNum === selectedSeat) {
-      bg = CLIENT_COLORS.selected;
-    } else {
-      bg = CLIENT_COLORS.available;
+    let status = seat ? seat.status : "blocked";
+    if (seatNum === selectedSeat) {
+      status = "selected";
     }
 
     return (
-      <button
+      <SeatIcon
         key={seatNum}
-        type="button"
+        seatNum={seatNum}
+        status={status}
         onClick={() => handleSelect(seatNum)}
-        style={{
-          width: 40,
-          height: 40,
-          margin: 0,
-          backgroundColor: bg,
-          border: "1px solid #888",
-          borderRadius: 4,
-          cursor: status === "available" ? "pointer" : "default"
-        }}
-      >
-        {seatNum}
-      </button>
+      />
     );
   };
 

--- a/frontend/src/components/SeatIcon.js
+++ b/frontend/src/components/SeatIcon.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { CLIENT_COLORS } from "../constants";
+
+export default function SeatIcon({ seatNum, status, onClick }) {
+  const bg = CLIENT_COLORS[status] || CLIENT_COLORS.available;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        width: 40,
+        height: 40,
+        margin: 0,
+        backgroundColor: bg,
+        border: "1px solid #888",
+        borderRadius: 4,
+        cursor: status === "blocked" ? "default" : "pointer"
+      }}
+    >
+      {seatNum}
+    </button>
+  );
+}

--- a/frontend/src/constants.js
+++ b/frontend/src/constants.js
@@ -1,0 +1,5 @@
+export const CLIENT_COLORS = {
+  blocked: "#ddd",
+  available: "#4caf50",
+  selected: "#2196f3"
+};


### PR DESCRIPTION
## Summary
- centralize seat colors
- add `SeatIcon` component to encapsulate seat rendering
- update `SeatClient` to pass `selected` status and use `SeatIcon`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688751fdc71483279d796b82c480195a