### PR TITLE
Extend seat data and tests for 49 seats

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -651,6 +651,9 @@ COPY public.seat (id, tour_id, seat_num, available) FROM stdin;
 458	10	44	0
 459	10	45	0
 460	10	46	0
+461	10	47	0
+462	10	48	0
+463	10	49	0
 \.
 
 
@@ -749,7 +752,7 @@ SELECT pg_catalog.setval('public.routestop_id_seq', 4, true);
 -- Name: seat_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('public.seat_id_seq', 460, true);
+SELECT pg_catalog.setval('public.seat_id_seq', 463, true);
 
 
 --

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -104,7 +104,38 @@ def test_admin_routes_with_and_without_token(client):
 
     resp = client.put(
         "/seat/block",
+        params={"tour_id": 1, "seat_num": 49, "block": True},
+        headers=headers,
+    )
+    assert resp.status_code != 401
+
+    resp = client.put(
+        "/seat/block",
         params={"tour_id": 1, "seat_num": 1, "block": True},
         headers=bad_headers,
     )
     assert resp.status_code == 401
+
+    resp = client.put(
+        "/seat/block",
+        params={"tour_id": 1, "seat_num": 49, "block": True},
+        headers=bad_headers,
+    )
+    assert resp.status_code == 401
+
+
+def test_ticket_create_accepts_high_seat_num(client):
+    resp = client.post(
+        "/tickets/",
+        json={
+            "tour_id": 1,
+            "seat_num": 49,
+            "passenger_name": "A",
+            "passenger_phone": "1",
+            "passenger_email": "a@b.com",
+            "departure_stop_id": 1,
+            "arrival_stop_id": 2,
+        },
+    )
+    # Pydantic validation should allow seat_num=49
+    assert resp.status_code != 422


### PR DESCRIPTION
## Summary
- add seats 47–49 in `init.sql`
- update sequence to match new seats
- expand admin route tests to check seat number 49
- ensure ticket creation allows seat_num 49

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688751fbd0408327b392ae58efefc520