### PR TITLE
Centralize seat colors

### DIFF
--- a/frontend/src/components/SeatAdmin.js
+++ b/frontend/src/components/SeatAdmin.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import Button from "@mui/material/Button";
 import styles from "./SeatAdmin.module.css";
+import { ADMIN_COLORS } from "./seatColors";
 
 import BusLayoutNeoplan from "./busLayouts/BusLayoutNeoplan";
 import BusLayoutTravego  from "./busLayouts/BusLayoutTravego";
@@ -78,7 +79,8 @@ export default function SeatAdmin({
         ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
         : undefined,
       zIndex: isDragging ? 10 : 1,
-      opacity: isOccupied ? 0.6 : 1
+      opacity: isOccupied ? 0.6 : 1,
+      backgroundColor: ADMIN_COLORS[status]
     };
 
     return (
@@ -88,7 +90,7 @@ export default function SeatAdmin({
           {...listeners}
           {...attributes}
           onClick={() => onToggle && onToggle(seatNum)}
-          className={`${styles.seatButton} ${styles[status]} ${isOver ? styles.over : ""}`}
+          className={`${styles.seatButton} ${isOver ? styles.over : ""}`}
           style={style}
         >
           {seatNum}

--- a/frontend/src/components/SeatAdmin.module.css
+++ b/frontend/src/components/SeatAdmin.module.css
@@ -11,17 +11,6 @@
   cursor: pointer;
 }
 
-.available {
-  background-color: #a2d5ab;
-}
-
-.occupied {
-  background-color: #e27c7c;
-}
-
-.blocked {
-  background-color: #cccccc;
-}
 
 .over {
   box-shadow: 0 0 0 2px #333;

--- a/frontend/src/components/SeatClient.js
+++ b/frontend/src/components/SeatClient.js
@@ -7,13 +7,7 @@ import BusLayoutNeoplan from "./busLayouts/BusLayoutNeoplan";
 import BusLayoutTravego  from "./busLayouts/BusLayoutTravego";
 
 import { API } from "../config";
-
-// Цвета для клиента
-const CLIENT_COLORS = {
-  blocked:   "#ddd",    // недоступное
-  available: "#4caf50", // зелёное
-  selected:  "#2196f3"  // синим помеченное выбранное
-};
+import { CLIENT_COLORS } from "./seatColors";
 
 /**
  * SeatClient — для страницы покупки билета.

--- a/frontend/src/components/seatColors.js
+++ b/frontend/src/components/seatColors.js
@@ -1,0 +1,11 @@
+export const CLIENT_COLORS = {
+  blocked: '#ddd',
+  available: '#4caf50',
+  selected: '#2196f3'
+};
+
+export const ADMIN_COLORS = {
+  available: '#a2d5ab',
+  occupied: '#e27c7c',
+  blocked: '#cccccc'
+};


### PR DESCRIPTION
## Summary
- share seat color constants across components
- use color constants in SeatClient and SeatAdmin
- drop hardcoded colors from SeatAdmin.module.css

## Testing
- `pytest -q`
- `npm test --silent -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688751f75bf08327b40ce7bf7cce9f76