### PR TITLE
Add horizontal bus layout

### DIFF
--- a/frontend/src/assets/icons/door.svg
+++ b/frontend/src/assets/icons/door.svg
@@ -1,0 +1,4 @@
+<svg width="40" height="60" viewBox="0 0 40 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="30" height="50" rx="2" fill="#d8d8d8" stroke="#555" stroke-width="2"/>
+  <circle cx="27" cy="30" r="3" fill="#555"/>
+</svg>

--- a/frontend/src/components/SeatAdmin.js
+++ b/frontend/src/components/SeatAdmin.js
@@ -7,6 +7,7 @@ import styles from "./SeatAdmin.module.css";
 
 import BusLayoutNeoplan from "./busLayouts/BusLayoutNeoplan";
 import BusLayoutTravego  from "./busLayouts/BusLayoutTravego";
+import BusLayoutHorizontal from "./busLayouts/BusLayoutHorizontal";
 
 import {
   DndContext,
@@ -99,10 +100,13 @@ export default function SeatAdmin({
 
   return (
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-      {layoutVariant === 1
-        ? <BusLayoutNeoplan renderCell={renderCell} />
-        : <BusLayoutTravego  renderCell={renderCell} />
-      }
+      {layoutVariant === 1 ? (
+        <BusLayoutNeoplan renderCell={renderCell} />
+      ) : layoutVariant === 2 ? (
+        <BusLayoutTravego renderCell={renderCell} />
+      ) : (
+        <BusLayoutHorizontal renderCell={renderCell} />
+      )}
     </DndContext>
   );
 }

--- a/frontend/src/components/SeatClient.js
+++ b/frontend/src/components/SeatClient.js
@@ -5,6 +5,7 @@ import axios from "axios";
 
 import BusLayoutNeoplan from "./busLayouts/BusLayoutNeoplan";
 import BusLayoutTravego  from "./busLayouts/BusLayoutTravego";
+import BusLayoutHorizontal from "./busLayouts/BusLayoutHorizontal";
 
 import { API } from "../config";
 
@@ -104,7 +105,9 @@ export default function SeatClient({
 
   const Layout = layoutVariant === 1
     ? BusLayoutNeoplan
-    : BusLayoutTravego;
+    : layoutVariant === 2
+      ? BusLayoutTravego
+      : BusLayoutHorizontal;
 
   // Рендерим только skeleton-режим с renderCell
   return <Layout renderCell={renderCell} />;

--- a/frontend/src/components/busLayouts/BusLayoutHorizontal.js
+++ b/frontend/src/components/busLayouts/BusLayoutHorizontal.js
@@ -1,0 +1,39 @@
+import React from "react";
+import doorIcon from "../../assets/icons/door.svg";
+import wheelIcon from "../../assets/icons/wheel.svg";
+
+// build two horizontal rows, door at [0] of top row, wheel at [0] of bottom row, wc at end of top row
+const topRow = ["door", ...Array.from({length:24}, (_,i)=>i+1), "wc"];
+const bottomRow = ["wheel", ...Array.from({length:25}, (_,i)=>i+25)];
+const layout = [topRow, bottomRow];
+
+export default function BusLayoutHorizontal({ renderCell }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      {layout.map((row,rowIdx)=>(
+        <div key={rowIdx} style={{ display:"flex", gap:4 }}>
+          {row.map((cell,cellIdx)=>{
+            if (cell === "door") {
+              return <img key={cellIdx} src={doorIcon} alt="Door" style={{width:40,height:40}} />;
+            }
+            if (cell === "wheel") {
+              return <img key={cellIdx} src={wheelIcon} alt="Steering wheel" style={{width:40,height:40}} />;
+            }
+            if (cell === "wc") {
+              return (
+                <div key={cellIdx} style={{width:40,height:40,display:"flex",alignItems:"center",justifyContent:"center",border:"1px solid #888",borderRadius:4}}>
+                  WC
+                </div>
+              );
+            }
+            return (
+              <React.Fragment key={cellIdx}>
+                {typeof renderCell === "function" ? renderCell(cell) : cell}
+              </React.Fragment>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/busLayouts/BusLayoutSlelector.js
+++ b/frontend/src/components/busLayouts/BusLayoutSlelector.js
@@ -1,6 +1,7 @@
 import React from "react";
 import BusLayoutNeoplan from "./BusLayoutNeoplan";
 import BusLayoutTravego from "./BusLayoutTravego";
+import BusLayoutHorizontal from "./BusLayoutHorizontal";
 
 const BusLayoutSelector = ({ layout_variant, seats, onSelect, interactive }) => {
   if (layout_variant === 1) {
@@ -8,6 +9,9 @@ const BusLayoutSelector = ({ layout_variant, seats, onSelect, interactive }) => 
   }
   if (layout_variant === 2) {
     return <BusLayoutTravego seats={seats} onSelect={onSelect} interactive={interactive} />;
+  }
+  if (layout_variant === 3) {
+    return <BusLayoutHorizontal seats={seats} onSelect={onSelect} interactive={interactive} />;
   }
   return <div>Layout не выбран</div>;
 };


### PR DESCRIPTION
## Summary
- create a simple door icon
- implement BusLayoutHorizontal component
- wire new layout into SeatClient and SeatAdmin
- allow BusLayoutSelector to pick the new layout

## Testing
- `npm install`
- `npm test --silent --yes` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_688751eddedc8327ad67effe7ba0097a