### PR TITLE
Improve seat drag UX

### DIFF
--- a/frontend/src/components/SeatAdmin.js
+++ b/frontend/src/components/SeatAdmin.js
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 import styles from "./SeatAdmin.module.css";
 import SeatIcon from "./SeatIcon";
+import passImg from "../assets/icons/pass.svg";
 
 import BusLayoutNeoplan from "./busLayouts/BusLayoutNeoplan";
 import BusLayoutTravego  from "./busLayouts/BusLayoutTravego";
@@ -74,25 +75,32 @@ export default function SeatAdmin({
     const { setNodeRef: dropRef, isOver } =
       useDroppable({ id: String(seatNum) });
 
-    const style = {
+    const dragStyle = {
       transform: transform
         ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
         : undefined,
       zIndex: isDragging ? 10 : 1,
-      opacity: isOccupied ? 0.6 : 1
     };
 
     return (
       <div key={seatNum} ref={dropRef} className={styles.seatContainer}>
         <button
-          ref={dragRef}
-          {...listeners}
-          {...attributes}
           onClick={() => onToggle && onToggle(seatNum)}
           className={`${styles.seatButton} ${isOver ? styles.over : ""}`}
-          style={style}
+          style={{ opacity: isOccupied ? 0.6 : 1 }}
         >
-          <SeatIcon number={seatNum} status={status} />
+          <SeatIcon seatNum={seatNum} status={status} />
+          {isOccupied && (
+            <img
+              ref={dragRef}
+              {...listeners}
+              {...attributes}
+              src={passImg}
+              alt="passenger"
+              className={styles.passengerIcon}
+              style={dragStyle}
+            />
+          )}
         </button>
       </div>
     );

--- a/frontend/src/components/SeatAdmin.module.css
+++ b/frontend/src/components/SeatAdmin.module.css
@@ -10,9 +10,19 @@
   border: none;
   background: none;
   cursor: pointer;
+  position: relative;
 }
 
 
 .over {
   box-shadow: 0 0 0 2px #333;
+}
+
+.passengerIcon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 40px;
+  height: 40px;
+  cursor: grab;
 }

--- a/frontend/src/components/SeatIcon.js
+++ b/frontend/src/components/SeatIcon.js
@@ -1,6 +1,5 @@
 // src/components/SeatIcon.js
 import React from "react";
-import passImg from "../assets/icons/pass.svg";
 
 // Цвета для статусов (можно вынести в constants.js при необходимости)
 const COLORS = {
@@ -57,21 +56,7 @@ export default function SeatIcon({ seatNum, status = "available", onClick }) {
           {seatNum}
         </text>
       </svg>
-      {/* Если занято — сверху пассажир */}
-      {status === "occupied" && (
-        <img
-          src={passImg}
-          alt="passenger"
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            width: 40,
-            height: 40,
-            pointerEvents: "none"
-          }}
-        />
-      )}
+      {/* Иконка пассажира рендерится снаружи */}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show seat number by passing correct prop
- drag passenger icon instead of seat
- support passenger overlay in SeatAdmin styles
- clean SeatIcon passenger markup

## Testing
- `pytest -q`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875eb4d3c88327a0a745d31003a452