### PR TITLE
Fix seat grid orientation

### DIFF
--- a/frontend/src/components/SeatSelection.css
+++ b/frontend/src/components/SeatSelection.css
@@ -1,6 +1,7 @@
 .seats-grid {
   display: grid;
   grid-template-columns: repeat(5, 50px);
+  grid-auto-flow: row;
   gap: 10px;
   margin-top: 20px;
 }

--- a/frontend/src/components/busLayouts/BusLayoutHorizontal.js
+++ b/frontend/src/components/busLayouts/BusLayoutHorizontal.js
@@ -16,7 +16,7 @@ export default function BusLayoutHorizontal({ renderCell }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
       {layout.map((row, rowIdx) => (
-        <div key={rowIdx} style={{ display: "flex", gap: 4 }}>
+        <div key={rowIdx} style={{ display: "flex", flexDirection: "row", gap: 4 }}>
           {row.map((cell, cellIdx) => {
             if (cell === "door") {
               return (

--- a/frontend/src/components/busLayouts/BusLayoutNeoplan.js
+++ b/frontend/src/components/busLayouts/BusLayoutNeoplan.js
@@ -32,7 +32,7 @@ export default function BusLayoutNeoplan(props) {
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         {layoutNeoplan.map((row, i) => (
-          <div key={i} style={{ display: "flex", gap: 4 }}>
+          <div key={i} style={{ display: "flex", flexDirection: "row", gap: 4 }}>
             {row.map((seatNum, j) =>
               seatNum === null
                 ? <div key={j} style={{ width: 40 }} />
@@ -56,7 +56,7 @@ export default function BusLayoutNeoplan(props) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
       {layoutNeoplan.map((row, i) => (
-        <div key={i} style={{ display: "flex", gap: 4 }}>
+        <div key={i} style={{ display: "flex", flexDirection: "row", gap: 4 }}>
           {row.map((seatNum, j) => {
             if (seatNum === null) {
               return <div key={j} style={{ width: 40 }} />;

--- a/frontend/src/components/busLayouts/BusLayoutTravego.js
+++ b/frontend/src/components/busLayouts/BusLayoutTravego.js
@@ -27,7 +27,7 @@ export default function BusLayoutTravego({ renderCell }) {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
       {layoutTravego.map((row, rowIdx) => (
-        <div key={rowIdx} style={{ display: "flex", gap: 4 }}>
+        <div key={rowIdx} style={{ display: "flex", flexDirection: "row", gap: 4 }}>
           {row.map((seatNum, cellIdx) => {
             if (seatNum === null) {
               return <div key={cellIdx} style={{ width: 40 }} />;


### PR DESCRIPTION
## Summary
- ensure bus seat row containers use `flex-direction: row`
- keep SeatSelection grid in row order

## Testing
- `npm test -- --watchAll=false` *(fails: Jest unexpected token)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688762440b388327bb573607dede02fa