### PR TITLE
Add purchase and sales tracking

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+import threading
+import time
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 import os
@@ -16,6 +18,7 @@ from .routers import (
     seat,
     search,
     ticket,
+    purchase,
     auth,
 )
 from .routers.ticket_admin import router as admin_tickets_router
@@ -48,12 +51,45 @@ app.include_router(prices.router)
 app.include_router(tour.router)
 app.include_router(passenger.router)
 app.include_router(ticket.router)
+app.include_router(purchase.router)
 app.include_router(report.router)
 app.include_router(available.router)
 app.include_router(seat.router)
 app.include_router(search.router)
 app.include_router(admin_tickets_router)
 app.include_router(auth.router)
+
+
+def _cancel_expired_loop():
+    while True:
+        time.sleep(60)
+        from .database import get_connection
+        conn = get_connection()
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                """
+                UPDATE purchase
+                   SET status='cancelled', updated_at=NOW()
+                 WHERE status='reserved'
+                   AND created_at < NOW() - INTERVAL '1 hour'
+                 RETURNING id
+                """
+            )
+            for row in cur.fetchall():
+                cur.execute(
+                    "INSERT INTO sales (purchase_id, status) VALUES (%s, 'cancelled')",
+                    (row[0],),
+                )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+        finally:
+            cur.close()
+            conn.close()
+
+
+threading.Thread(target=_cancel_expired_loop, daemon=True).start()
 
 # Serve React static files
 # app.mount("/", StaticFiles(directory="frontend/build", html=True), name="static")

--- a/backend/models.py
+++ b/backend/models.py
@@ -76,6 +76,7 @@ class TourBase(BaseModel):
     pricelist_id: int
     date: date
     layout_variant: int  # избран вариант на разположение (напр. 1 – Neoplan, 2 – Travego)
+    booking_terms: str | None = None
 
 class TourCreate(TourBase):
     active_seats: List[int]  # номера на активните места за продажба
@@ -108,6 +109,8 @@ class TicketBase(BaseModel):
     passenger_id: int
     departure_stop_id: int
     arrival_stop_id: int
+    purchase_id: Optional[int] = None
+    extra_baggage: bool = False
 
 class TicketCreate(TicketBase):
     pass
@@ -158,5 +161,29 @@ class UserCreate(UserBase):
 class User(UserBase):
     id: int
     hashed_password: str
+    class Config:
+        from_attributes = True
+
+# --- Модели за Purchase и Sales ---
+
+class PurchaseBase(BaseModel):
+    status: str
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+class PurchaseCreate(PurchaseBase):
+    pass
+
+class Purchase(PurchaseBase):
+    id: int
+    class Config:
+        from_attributes = True
+
+
+class Sales(BaseModel):
+    id: int
+    purchase_id: int
+    status: str
+    changed_at: datetime
     class Config:
         from_attributes = True

--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -1,0 +1,144 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, EmailStr
+from datetime import datetime, timedelta
+from ..database import get_connection
+
+router = APIRouter(prefix="/purchase", tags=["purchase"])
+
+class PurchaseCreate(BaseModel):
+    tour_id: int
+    seat_num: int
+    passenger_name: str
+    passenger_phone: str
+    passenger_email: EmailStr
+    departure_stop_id: int
+    arrival_stop_id: int
+    extra_baggage: bool = False
+
+class PurchaseOut(BaseModel):
+    purchase_id: int
+
+
+def _log_status(cur, purchase_id: int, status: str) -> None:
+    cur.execute(
+        "INSERT INTO sales (purchase_id, status) VALUES (%s, %s)",
+        (purchase_id, status),
+    )
+
+
+@router.post("/", response_model=PurchaseOut)
+def create_purchase(data: PurchaseCreate):
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        # 1) create passenger
+        cur.execute(
+            "INSERT INTO passenger (name, phone, email) VALUES (%s,%s,%s) RETURNING id",
+            (data.passenger_name, data.passenger_phone, data.passenger_email),
+        )
+        passenger_id = cur.fetchone()[0]
+
+        # 2) create purchase record
+        cur.execute(
+            "INSERT INTO purchase (status) VALUES ('reserved') RETURNING id",
+        )
+        purchase_id = cur.fetchone()[0]
+
+        # 3) delegate to ticket creation logic
+        cur.execute(
+            "SELECT id FROM seat WHERE tour_id=%s AND seat_num=%s",
+            (data.tour_id, data.seat_num),
+        )
+        seat_row = cur.fetchone()
+        if not seat_row:
+            raise HTTPException(404, "Seat not found")
+        seat_id = seat_row[0]
+
+        cur.execute(
+            """
+            INSERT INTO ticket
+              (tour_id, seat_id, passenger_id, departure_stop_id, arrival_stop_id, purchase_id, extra_baggage)
+            VALUES (%s,%s,%s,%s,%s,%s,%s)
+            RETURNING id
+            """,
+            (
+                data.tour_id,
+                seat_id,
+                passenger_id,
+                data.departure_stop_id,
+                data.arrival_stop_id,
+                purchase_id,
+                data.extra_baggage,
+            ),
+        )
+        cur.fetchone()
+
+        _log_status(cur, purchase_id, "reserved")
+        conn.commit()
+        return {"purchase_id": purchase_id}
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:
+        conn.rollback()
+        raise HTTPException(500, str(exc))
+    finally:
+        cur.close()
+        conn.close()
+
+
+@router.post("/{purchase_id}/pay", status_code=204)
+def pay_purchase(purchase_id: int):
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "UPDATE purchase SET status='paid', updated_at=NOW() WHERE id=%s",
+            (purchase_id,),
+        )
+        if cur.rowcount == 0:
+            raise HTTPException(404, "Purchase not found")
+        _log_status(cur, purchase_id, "paid")
+        conn.commit()
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:
+        conn.rollback()
+        raise HTTPException(500, str(exc))
+    finally:
+        cur.close()
+        conn.close()
+
+
+@router.post("/{purchase_id}/cancel", status_code=204)
+def cancel_purchase(purchase_id: int):
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        # find ticket
+        cur.execute(
+            "SELECT id, seat_id FROM ticket WHERE purchase_id=%s",
+            (purchase_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(404, "Purchase not found")
+        ticket_id, seat_id = row
+
+        cur.execute("DELETE FROM ticket WHERE id=%s", (ticket_id,))
+        cur.execute(
+            "UPDATE purchase SET status='cancelled', updated_at=NOW() WHERE id=%s",
+            (purchase_id,),
+        )
+        _log_status(cur, purchase_id, "cancelled")
+        conn.commit()
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:
+        conn.rollback()
+        raise HTTPException(500, str(exc))
+    finally:
+        cur.close()
+        conn.close()

--- a/backend/routers/ticket.py
+++ b/backend/routers/ticket.py
@@ -10,11 +10,13 @@ router = APIRouter(prefix="/tickets", tags=["tickets"])
 class TicketCreate(BaseModel):
     tour_id: int
     seat_num: int
+    purchase_id: int | None = None
     passenger_name: str
     passenger_phone: str
     passenger_email: EmailStr
     departure_stop_id: int
     arrival_stop_id: int
+    extra_baggage: bool = False
 
 
 class TicketOut(BaseModel):
@@ -84,8 +86,8 @@ def create_ticket(data: TicketCreate):
         cur.execute(
             """
             INSERT INTO ticket
-              (tour_id, seat_id, passenger_id, departure_stop_id, arrival_stop_id)
-            VALUES (%s, %s, %s, %s, %s)
+              (tour_id, seat_id, passenger_id, departure_stop_id, arrival_stop_id, purchase_id, extra_baggage)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -94,6 +96,8 @@ def create_ticket(data: TicketCreate):
                 passenger_id,
                 data.departure_stop_id,
                 data.arrival_stop_id,
+                data.purchase_id,
+                data.extra_baggage,
             ),
         )
         ticket_id = cur.fetchone()[0]

--- a/backend/routers/tour.py
+++ b/backend/routers/tour.py
@@ -20,6 +20,7 @@ class TourCreate(BaseModel):
     date: date
     layout_variant: int
     active_seats: List[int]
+    booking_terms: str | None = None
 
 
 class TourOut(BaseModel):
@@ -63,10 +64,17 @@ def create_tour(tour: TourCreate):
         # Вставляем запись рейса
         cur.execute(
             """
-            INSERT INTO tour (route_id, pricelist_id, date, seats, layout_variant)
-            VALUES (%s, %s, %s, %s, %s) RETURNING id
+            INSERT INTO tour (route_id, pricelist_id, date, seats, layout_variant, booking_terms)
+            VALUES (%s, %s, %s, %s, %s, %s) RETURNING id
             """,
-            (tour.route_id, tour.pricelist_id, tour.date, total_seats, tour.layout_variant),
+            (
+                tour.route_id,
+                tour.pricelist_id,
+                tour.date,
+                total_seats,
+                tour.layout_variant,
+                tour.booking_terms,
+            ),
         )
         tour_id = cur.fetchone()[0]
 
@@ -172,7 +180,7 @@ def update_tour(tour_id: int, tour_data: TourCreate):
         cur.execute(
             """
             UPDATE tour
-               SET route_id=%s, pricelist_id=%s, date=%s, layout_variant=%s
+               SET route_id=%s, pricelist_id=%s, date=%s, layout_variant=%s, booking_terms=%s
              WHERE id=%s
              RETURNING id
             """,
@@ -181,6 +189,7 @@ def update_tour(tour_id: int, tour_data: TourCreate):
                 tour_data.pricelist_id,
                 tour_data.date,
                 tour_data.layout_variant,
+                tour_data.booking_terms,
                 tour_id,
             ),
         )
@@ -243,6 +252,7 @@ def update_tour(tour_id: int, tour_data: TourCreate):
             "pricelist_id": tour_data.pricelist_id,
             "date": tour_data.date,
             "layout_variant": tour_data.layout_variant,
+            "booking_terms": tour_data.booking_terms,
         }
 
     except HTTPException:

--- a/db/init.sql
+++ b/db/init.sql
@@ -351,7 +351,9 @@ CREATE TABLE public.ticket (
     seat_id integer NOT NULL,
     passenger_id integer NOT NULL,
     departure_stop_id integer NOT NULL,
-    arrival_stop_id integer NOT NULL
+    arrival_stop_id integer NOT NULL,
+    purchase_id integer,
+    extra_baggage boolean DEFAULT FALSE
 );
 
 
@@ -393,7 +395,8 @@ CREATE TABLE public.tour (
     pricelist_id integer NOT NULL,
     date date NOT NULL,
     seats integer NOT NULL,
-    layout_variant integer DEFAULT 1 NOT NULL
+    layout_variant integer DEFAULT 1 NOT NULL,
+    booking_terms text
 );
 
 
@@ -422,6 +425,22 @@ ALTER SEQUENCE public.tour_id_seq OWNER TO postgres;
 --
 
 ALTER SEQUENCE public.tour_id_seq OWNED BY public.tour.id;
+
+-- Нови таблици за покупки и журнал на продажбите
+
+CREATE TABLE IF NOT EXISTS public.purchase (
+    id SERIAL PRIMARY KEY,
+    status VARCHAR(20) NOT NULL DEFAULT 'reserved',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS public.sales (
+    id SERIAL PRIMARY KEY,
+    purchase_id INTEGER NOT NULL REFERENCES public.purchase(id),
+    status VARCHAR(20) NOT NULL,
+    changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
 
 
 --
@@ -996,6 +1015,9 @@ ALTER TABLE ONLY public.ticket
 
 ALTER TABLE ONLY public.ticket
     ADD CONSTRAINT ticket_tour_id_fkey FOREIGN KEY (tour_id) REFERENCES public.tour(id);
+
+ALTER TABLE ONLY public.ticket
+    ADD CONSTRAINT ticket_purchase_id_fkey FOREIGN KEY (purchase_id) REFERENCES public.purchase(id);
 
 
 --

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -1,0 +1,75 @@
+import importlib
+import os
+import sys
+from fastapi.testclient import TestClient
+import pytest
+
+class DummyCursor:
+    def __init__(self):
+        self.queries = []
+        self.query = ""
+        self.rowcount = 1
+    def execute(self, query, params=None):
+        self.query = query
+        self.queries.append((query, params))
+    def fetchone(self):
+        if "SELECT id, seat_id FROM ticket" in self.query:
+            return [1, 1]
+        return [1]
+    def fetchall(self):
+        return []
+    def close(self):
+        pass
+
+class DummyConn:
+    def __init__(self):
+        self.cursor_obj = DummyCursor()
+    def cursor(self):
+        return self.cursor_obj
+    def commit(self):
+        pass
+    def rollback(self):
+        pass
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client(monkeypatch):
+    last = {}
+    def fake_get_connection():
+        conn = DummyConn()
+        last['cursor'] = conn.cursor_obj
+        return conn
+    monkeypatch.setattr('psycopg2.connect', lambda *a, **kw: DummyConn())
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    import importlib
+    import backend.database
+    monkeypatch.setattr('backend.database.get_connection', fake_get_connection)
+    if 'backend.main' in sys.modules:
+        importlib.reload(sys.modules['backend.main'])
+    else:
+        importlib.import_module('backend.main')
+    app = sys.modules['backend.main'].app
+    monkeypatch.setattr('backend.routers.purchase.get_connection', fake_get_connection)
+    return TestClient(app), last
+
+
+def test_purchase_flow(client):
+    cli, store = client
+    resp = cli.post('/purchase/', json={
+        'tour_id': 1,
+        'seat_num': 1,
+        'passenger_name': 'A',
+        'passenger_phone': '1',
+        'passenger_email': 'a@b.com',
+        'departure_stop_id': 1,
+        'arrival_stop_id': 2,
+    })
+    assert any('INSERT INTO sales' in q[0] for q in store['cursor'].queries)
+
+    resp = cli.post('/purchase/1/pay')
+    assert any('INSERT INTO sales' in q[0] for q in store['cursor'].queries)
+
+    resp = cli.post('/purchase/1/cancel')
+    assert any('INSERT INTO sales' in q[0] for q in store['cursor'].queries)


### PR DESCRIPTION
## Summary
- create `purchase` table and `sales` log table
- expand ticket and tour fields
- implement purchase router with payment and cancel endpoints
- log purchase status changes
- auto-cancel expired purchases
- add Pydantic models for purchases
- tests for purchase flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888941f47008327b2630fc9e91bdf18