### PR TITLE
Update DB schema and routers

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -5,6 +5,11 @@ from typing import Optional, List
 # --- Модели за Stop ---
 class StopBase(BaseModel):
     stop_name: str
+    stop_en: Optional[str] = None
+    stop_bg: Optional[str] = None
+    stop_ua: Optional[str] = None
+    description: Optional[str] = None
+    location: Optional[str] = None
 
 class StopCreate(StopBase):
     pass
@@ -91,8 +96,6 @@ class Tour(TourBase):
 # --- Модели за Passenger ---
 class PassengerBase(BaseModel):
     name: str
-    phone: Optional[str] = None
-    email: Optional[str] = None
 
 class PassengerCreate(PassengerBase):
     pass
@@ -110,7 +113,7 @@ class TicketBase(BaseModel):
     departure_stop_id: int
     arrival_stop_id: int
     purchase_id: Optional[int] = None
-    extra_baggage: bool = False
+    extra_baggage: int = 0
 
 class TicketCreate(TicketBase):
     pass
@@ -167,9 +170,14 @@ class User(UserBase):
 # --- Модели за Purchase и Sales ---
 
 class PurchaseBase(BaseModel):
-    status: str
-    created_at: datetime | None = None
-    updated_at: datetime | None = None
+    customer_name: Optional[str] = None
+    customer_email: Optional[str] = None
+    customer_phone: Optional[str] = None
+    amount_due: Optional[float] = None
+    deadline: Optional[datetime] = None
+    status: Optional[str] = None
+    update_at: Optional[datetime] = None
+    payment_method: Optional[str] = None
 
 class PurchaseCreate(PurchaseBase):
     pass
@@ -182,8 +190,10 @@ class Purchase(PurchaseBase):
 
 class Sales(BaseModel):
     id: int
-    purchase_id: int
-    status: str
-    changed_at: datetime
+    date: datetime
+    category: str
+    amount: float
+    purchase_id: Optional[int] = None
+    comment: Optional[str] = None
     class Config:
         from_attributes = True

--- a/backend/routers/ticket.py
+++ b/backend/routers/ticket.py
@@ -74,11 +74,8 @@ def create_ticket(data: TicketCreate):
 
         # --- 5) Создаём запись в passenger ---
         cur.execute(
-            """
-            INSERT INTO passenger (name, phone, email)
-            VALUES (%s, %s, %s) RETURNING id
-            """,
-            (data.passenger_name, data.passenger_phone, data.passenger_email),
+            "INSERT INTO passenger (name) VALUES (%s) RETURNING id",
+            (data.passenger_name,),
         )
         passenger_id = cur.fetchone()[0]
 
@@ -97,7 +94,7 @@ def create_ticket(data: TicketCreate):
                 data.departure_stop_id,
                 data.arrival_stop_id,
                 data.purchase_id,
-                data.extra_baggage,
+                int(data.extra_baggage),
             ),
         )
         ticket_id = cur.fetchone()[0]

--- a/db/init.sql
+++ b/db/init.sql
@@ -70,9 +70,7 @@ ALTER SEQUENCE public.available_id_seq OWNED BY public.available.id;
 
 CREATE TABLE public.passenger (
     id integer NOT NULL,
-    name character varying(255) NOT NULL,
-    phone character varying(50),
-    email character varying(255)
+    name character varying(255) NOT NULL
 );
 
 
@@ -309,7 +307,12 @@ ALTER SEQUENCE public.seat_id_seq OWNED BY public.seat.id;
 
 CREATE TABLE public.stop (
     id integer NOT NULL,
-    stop_name character varying(255) NOT NULL
+    stop_name character varying(255) NOT NULL,
+    stop_en character varying(255),
+    stop_bg character varying(255),
+    stop_ua character varying(255),
+    description text,
+    location text
 );
 
 
@@ -353,7 +356,7 @@ CREATE TABLE public.ticket (
     departure_stop_id integer NOT NULL,
     arrival_stop_id integer NOT NULL,
     purchase_id integer,
-    extra_baggage boolean DEFAULT FALSE
+    extra_baggage integer DEFAULT 0
 );
 
 
@@ -396,7 +399,7 @@ CREATE TABLE public.tour (
     date date NOT NULL,
     seats integer NOT NULL,
     layout_variant integer DEFAULT 1 NOT NULL,
-    booking_terms text
+    booking_terms smallint DEFAULT 0 NOT NULL
 );
 
 
@@ -428,18 +431,29 @@ ALTER SEQUENCE public.tour_id_seq OWNED BY public.tour.id;
 
 -- Нови таблици за покупки и журнал на продажбите
 
+CREATE TYPE purchase_status AS ENUM ('reserved','paid','cancelled','refunded');
+CREATE TYPE payment_method_type AS ENUM ('online','offline');
+
 CREATE TABLE IF NOT EXISTS public.purchase (
     id SERIAL PRIMARY KEY,
-    status VARCHAR(20) NOT NULL DEFAULT 'reserved',
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    customer_name VARCHAR(255),
+    customer_email VARCHAR(255),
+    customer_phone VARCHAR(50),
+    amount_due DECIMAL,
+    deadline TIMESTAMP,
+    status purchase_status NOT NULL DEFAULT 'reserved',
+    update_at TIMESTAMP,
+    payment_method payment_method_type NOT NULL DEFAULT 'online'
 );
 
+CREATE TYPE sales_category AS ENUM ('ticket_sale','refund','part_refund');
 CREATE TABLE IF NOT EXISTS public.sales (
     id SERIAL PRIMARY KEY,
-    purchase_id INTEGER NOT NULL REFERENCES public.purchase(id),
-    status VARCHAR(20) NOT NULL,
-    changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    category sales_category NOT NULL,
+    amount DECIMAL NOT NULL,
+    purchase_id INTEGER REFERENCES public.purchase(id),
+    comment TEXT
 );
 
 


### PR DESCRIPTION
## Summary
- modernize SQL schema for purchase, sales, ticket, tour, passenger and stop
- adjust Pydantic models to match new DB fields
- update purchase and ticket logic for new schema
- simplify ticket admin endpoints without phone/email fields

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889d11272908327938b17765a8643a3