### PR TITLE
Fix schema for purchase enums

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -430,6 +430,7 @@ ALTER SEQUENCE public.tour_id_seq OWNER TO postgres;
 ALTER SEQUENCE public.tour_id_seq OWNED BY public.tour.id;
 
 -- Нови таблици за покупки и журнал на продажбите
+SET search_path = public;
 
 CREATE TYPE purchase_status AS ENUM ('reserved','paid','cancelled','refunded');
 CREATE TYPE payment_method_type AS ENUM ('online','offline');


### PR DESCRIPTION
## Summary
- ensure `db/init.sql` sets `search_path` to `public` before defining purchase enums and tables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6889f0ee33f0832791c250b57ccaa48e