### PR TITLE
Fix foreign key constraint on pricelist

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -107,7 +107,7 @@ ALTER SEQUENCE public.passenger_id_seq OWNED BY public.passenger.id;
 --
 
 CREATE TABLE public.pricelist (
-    id integer NOT NULL,
+    id integer PRIMARY KEY,
     name character varying(255) NOT NULL
 );
 
@@ -843,15 +843,6 @@ ALTER TABLE ONLY public.available
 
 ALTER TABLE ONLY public.passenger
     ADD CONSTRAINT passenger_pkey PRIMARY KEY (id);
-
-
---
--- TOC entry 4702 (class 2606 OID 16578)
--- Name: pricelist pricelist_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
---
-
-ALTER TABLE ONLY public.pricelist
-    ADD CONSTRAINT pricelist_pkey PRIMARY KEY (id);
 
 
 --


### PR DESCRIPTION
## Summary
- set `id` as `PRIMARY KEY` when creating `pricelist`
- remove later constraint addition that caused ordering issue

## Testing
- `pip install -q -r requirements.txt`
- `pip install httpx -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a01629ecc83279118734d51f59ac1