### PR TITLE
Add explicit sales categories

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -78,7 +78,7 @@ def _cancel_expired_loop():
             )
             for row in cur.fetchall():
                 cur.execute(
-                    "INSERT INTO sales (purchase_id, category, amount) VALUES (%s, 'refund', 0)",
+                    "INSERT INTO sales (purchase_id, category, amount) VALUES (%s, 'cancel', 0)",
                     (row[0],),
                 )
             conn.commit()


### PR DESCRIPTION
## Summary
- add explicit booking/payment/cancel/refund constants
- log booking/payment/cancellation/refund events when purchases change state
- track expired reservations as `cancel`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a1f6d66048327946303d573861682