### PR TITLE
Add route-pricelist bundle router

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from .routers import (
     ticket,
     purchase,
     auth,
+    bundle,
 )
 from .routers.ticket_admin import router as admin_tickets_router
 
@@ -57,6 +58,7 @@ app.include_router(report.router)
 app.include_router(available.router)
 app.include_router(seat.router)
 app.include_router(search.router)
+app.include_router(bundle.router)
 app.include_router(admin_tickets_router)
 app.include_router(auth.router)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -212,3 +212,31 @@ class Sales(BaseModel):
     comment: Optional[str] = None
     class Config:
         from_attributes = True
+
+# --- Дополнительные модели для bundle ---
+class LangRequest(BaseModel):
+    lang: str
+
+class LocalizedStop(BaseModel):
+    id: int
+    name: str
+
+class LocalizedRoute(BaseModel):
+    id: int
+    name: str
+    stops: List[LocalizedStop]
+
+class RoutesBundleOut(BaseModel):
+    forward: LocalizedRoute
+    backward: LocalizedRoute
+
+class PriceLocalized(BaseModel):
+    departure_stop_id: int
+    departure_name: str
+    arrival_stop_id: int
+    arrival_name: str
+    price: float
+
+class PricelistBundleOut(BaseModel):
+    pricelist_id: int
+    prices: List[PriceLocalized]

--- a/backend/routers/bundle.py
+++ b/backend/routers/bundle.py
@@ -1,0 +1,140 @@
+from fastapi import APIRouter, Depends, HTTPException
+from ..auth import require_admin_token
+from ..database import get_connection
+from ..models import (
+    RoutePricelistBundleCreate,
+    RoutePricelistBundle,
+    LangRequest,
+    RoutesBundleOut,
+    PricelistBundleOut,
+)
+
+router = APIRouter(tags=["bundle"])
+
+
+@router.api_route(
+    "/admin/route_pricelist_bundle/",
+    methods=["POST", "PUT"],
+    response_model=RoutePricelistBundle,
+    dependencies=[Depends(require_admin_token)],
+)
+def set_bundle(data: RoutePricelistBundleCreate):
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute("SELECT id FROM route_pricelist_bundle WHERE id=1")
+        if cur.fetchone():
+            cur.execute(
+                """
+                UPDATE route_pricelist_bundle
+                   SET route_forward_id=%s,
+                       route_backward_id=%s,
+                       pricelist_id=%s
+                 WHERE id=1
+                 RETURNING id, route_forward_id, route_backward_id, pricelist_id
+                """,
+                (data.route_forward_id, data.route_backward_id, data.pricelist_id),
+            )
+        else:
+            cur.execute(
+                """
+                INSERT INTO route_pricelist_bundle
+                        (id, route_forward_id, route_backward_id, pricelist_id)
+                VALUES (1,%s,%s,%s)
+                RETURNING id, route_forward_id, route_backward_id, pricelist_id
+                """,
+                (data.route_forward_id, data.route_backward_id, data.pricelist_id),
+            )
+        row = cur.fetchone()
+        conn.commit()
+        return {
+            "id": row[0],
+            "route_forward_id": row[1],
+            "route_backward_id": row[2],
+            "pricelist_id": row[3],
+        }
+    except Exception as e:
+        conn.rollback()
+        raise HTTPException(500, str(e))
+    finally:
+        cur.close()
+        conn.close()
+
+
+def _get_route(cur, route_id: int, col: str):
+    cur.execute("SELECT name FROM route WHERE id=%s", (route_id,))
+    row = cur.fetchone()
+    name = row[0] if row else ""
+    cur.execute(
+        f'SELECT s.id, COALESCE(s.{col}, s.stop_name) '
+        f'FROM routestop rs JOIN stop s ON rs.stop_id=s.id '
+        f'WHERE rs.route_id=%s ORDER BY rs."order"',
+        (route_id,),
+    )
+    stops = [{"id": r[0], "name": r[1]} for r in cur.fetchall()]
+    return {"id": route_id, "name": name, "stops": stops}
+
+
+@router.post("/public/routes_bundle", response_model=RoutesBundleOut)
+def public_routes_bundle(data: LangRequest):
+    lang = data.lang.lower()
+    col = f"stop_{lang}" if lang in {"en", "bg", "ua"} else "stop_name"
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT route_forward_id, route_backward_id FROM route_pricelist_bundle WHERE id=1"
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(404, "Bundle not found")
+        forward_id, backward_id = row
+        forward = _get_route(cur, forward_id, col)
+        backward = _get_route(cur, backward_id, col)
+        return {"forward": forward, "backward": backward}
+    finally:
+        cur.close()
+        conn.close()
+
+
+@router.post("/public/pricelist_bundle", response_model=PricelistBundleOut)
+def public_pricelist_bundle(data: LangRequest):
+    lang = data.lang.lower()
+    col = f"stop_{lang}" if lang in {"en", "bg", "ua"} else "stop_name"
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT pricelist_id FROM route_pricelist_bundle WHERE id=1"
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(404, "Bundle not found")
+        pricelist_id = row[0]
+        cur.execute(
+            f"""
+            SELECT p.departure_stop_id, COALESCE(s1.{col}, s1.stop_name),
+                   p.arrival_stop_id, COALESCE(s2.{col}, s2.stop_name),
+                   p.price
+              FROM prices p
+              JOIN stop s1 ON s1.id=p.departure_stop_id
+              JOIN stop s2 ON s2.id=p.arrival_stop_id
+             WHERE p.pricelist_id=%s
+             ORDER BY p.id
+            """,
+            (pricelist_id,),
+        )
+        prices = [
+            {
+                "departure_stop_id": r[0],
+                "departure_name": r[1],
+                "arrival_stop_id": r[2],
+                "arrival_name": r[3],
+                "price": r[4],
+            }
+            for r in cur.fetchall()
+        ]
+        return {"pricelist_id": pricelist_id, "prices": prices}
+    finally:
+        cur.close()
+        conn.close()

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -61,6 +61,7 @@ def test_admin_routes_require_token(client):
         ("post", "/report/"),
         ("get", "/tours/"),
         ("get", "/admin/tickets/"),
+        ("post", "/admin/route_pricelist_bundle/"),
     ]
     for method, path in routes:
         resp = getattr(client, method)(path)
@@ -89,6 +90,7 @@ def test_admin_routes_with_and_without_token(client):
         ("post", "/report/"),
         ("get", "/tours/"),
         ("get", "/admin/tickets/"),
+        ("post", "/admin/route_pricelist_bundle/"),
     ]
     for method, path in routes:
         resp = getattr(client, method)(path, headers=headers)

--- a/tests/test_bundle_public.py
+++ b/tests/test_bundle_public.py
@@ -1,0 +1,76 @@
+import os
+import sys
+import importlib
+import pytest
+from fastapi.testclient import TestClient
+
+class DummyCursor:
+    def __init__(self):
+        self.query = ""
+        self.params = None
+    def execute(self, query, params=None):
+        self.query = query.lower()
+        self.params = params
+    def fetchone(self):
+        if "route_pricelist_bundle" in self.query:
+            if "pricelist_id" in self.query:
+                return [5]
+            return [1, 2]
+        if "from route where" in self.query:
+            rid = self.params[0]
+            return [f"Route{rid}"]
+        return None
+    def fetchall(self):
+        if "from routestop" in self.query:
+            rid = self.params[0]
+            if rid == 1:
+                return [(10, "A_en"), (20, "B_en")]
+            else:
+                return [(20, "B_en"), (10, "A_en")]
+        if "from prices" in self.query:
+            return [(10, "A_en", 20, "B_en", 9.9)]
+        return []
+    def close(self):
+        pass
+
+class DummyConn:
+    def __init__(self):
+        self.cursor_obj = DummyCursor()
+    def cursor(self):
+        return self.cursor_obj
+    def commit(self):
+        pass
+    def rollback(self):
+        pass
+    def close(self):
+        pass
+
+def fake_get_connection():
+    return DummyConn()
+
+@pytest.fixture
+def client(monkeypatch):
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **kw: DummyConn())
+    import backend.database
+    monkeypatch.setattr("backend.database.get_connection", fake_get_connection)
+    if "backend.main" in sys.modules:
+        importlib.reload(sys.modules["backend.main"])
+    else:
+        importlib.import_module("backend.main")
+    app = sys.modules["backend.main"].app
+    monkeypatch.setattr("backend.routers.bundle.get_connection", fake_get_connection)
+    return TestClient(app)
+
+def test_routes_bundle(client):
+    resp = client.post("/public/routes_bundle", json={"lang": "en"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["forward"]["stops"][0]["name"] == "A_en"
+
+def test_pricelist_bundle(client):
+    resp = client.post("/public/pricelist_bundle", json={"lang": "en"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["prices"][0]["departure_name"] == "A_en"
+


### PR DESCRIPTION
## Summary
- add route-pricelist bundle router with admin and public endpoints
- add models for bundle API
- register router in main application
- adapt purchase router for tests
- add tests for bundle endpoints and update admin route tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b12964a348327ac230761d70aefb2