### PR TITLE
Update admin selection in price lists and routes

### DIFF
--- a/frontend/src/pages/PricelistsPage.js
+++ b/frontend/src/pages/PricelistsPage.js
@@ -20,6 +20,8 @@ function PricelistPage() {
   const [editingPricelistId, setEditingPricelistId] = useState(null);
   const [editingPricelistName, setEditingPricelistName] = useState("");
 
+  const [activePricelistId, setActivePricelistId] = useState(null);
+
   const handleToggleDemo = (pl) => {
     if (!pl.is_demo && pricelists.some(p => p.is_demo)) {
       alert("Можно выбрать только один прайс-лист");
@@ -43,6 +45,9 @@ function PricelistPage() {
     fetchPricelists();
     axios.get(`${API}/stops`)
       .then(res => setStops(res.data))
+      .catch(err => console.error(err));
+    axios.get(`${API}/admin/selected_pricelist`)
+      .then(res => setActivePricelistId(res.data.pricelist.id))
       .catch(err => console.error(err));
   }, []);
 
@@ -103,6 +108,12 @@ function PricelistPage() {
         }
         handleCancelEditPricelist();
       })
+      .catch(err => console.error(err));
+  };
+
+  const handleSetActivePricelist = (id) => {
+    setActivePricelistId(id);
+    axios.post(`${API}/admin/selected_pricelist`, { pricelist_id: id })
       .catch(err => console.error(err));
   };
 
@@ -200,6 +211,15 @@ function PricelistPage() {
                     onChange={() => handleToggleDemo(pl)}
                   />
                   demo
+                </label>
+                <label style={{ marginLeft: '4px' }}>
+                  <input
+                    type="radio"
+                    name="activePricelist"
+                    checked={activePricelistId === pl.id}
+                    onChange={() => handleSetActivePricelist(pl.id)}
+                  />
+                  active
                 </label>
                 <button className="icon-btn" onClick={() => handleEditPricelist(pl)}>
                   <img src={editIcon} alt="Редактировать прайс-лист" />

--- a/frontend/src/pages/RoutesPage.js
+++ b/frontend/src/pages/RoutesPage.js
@@ -26,6 +26,8 @@ export default function RoutesPage() {
   const [selectedRoute, setSelectedRoute] = useState(null);
   const [routeStops, setRouteStops] = useState([]);
 
+  const [activeRouteIds, setActiveRouteIds] = useState([]);
+
   const [newRouteName, setNewRouteName] = useState("");
   const [newStop, setNewStop] = useState({
     stop_id: "",
@@ -37,6 +39,9 @@ export default function RoutesPage() {
   useEffect(() => {
     axios.get(`${API}/routes`).then((res) => setRoutes(res.data));
     axios.get(`${API}/stops`).then((res) => setStops(res.data));
+    axios.get(`${API}/admin/selected_route`)
+      .then(res => setActiveRouteIds(res.data.routes.map(r => r.id)))
+      .catch(err => console.error(err));
   }, []);
 
   // 2. Загрузка остановок выбранного маршрута
@@ -88,6 +93,22 @@ export default function RoutesPage() {
       .catch((err) => {
         alert(err.response?.data?.detail || "Ошибка обновления демо статуса");
       });
+  };
+
+  const handleToggleActiveRoute = (routeId) => {
+    let newIds;
+    if (activeRouteIds.includes(routeId)) {
+      newIds = activeRouteIds.filter((id) => id !== routeId);
+    } else {
+      if (activeRouteIds.length >= 2) {
+        alert("Можно выбрать не более двух маршрутов");
+        return;
+      }
+      newIds = [...activeRouteIds, routeId];
+    }
+    setActiveRouteIds(newIds);
+    axios.post(`${API}/admin/selected_route`, { routes: newIds })
+      .catch(err => console.error(err));
   };
 
   // Выбор маршрута
@@ -203,6 +224,14 @@ export default function RoutesPage() {
                 onChange={() => handleToggleDemo(route)}
               />
               demo
+            </label>
+            <label style={{ marginLeft: '4px' }}>
+              <input
+                type="checkbox"
+                checked={activeRouteIds.includes(route.id)}
+                onChange={() => handleToggleActiveRoute(route.id)}
+              />
+              active
             </label>
             <button
               className="icon-btn"


### PR DESCRIPTION
## Summary
- connect frontend to new admin endpoints for selected price list and selected routes
- allow choosing active price list and active routes from the respective pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b6de981e08327ac2bd6e32b6a8e6c