### PR TITLE
Fix POST /pricelists without trailing slash

### DIFF
--- a/backend/routers/pricelist.py
+++ b/backend/routers/pricelist.py
@@ -26,6 +26,7 @@ def get_pricelists():
     return [{"id": r[0], "name": r[1], "is_demo": r[2]} for r in rows]
 
 @router.post("/", response_model=Pricelist, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=Pricelist, status_code=status.HTTP_201_CREATED, include_in_schema=False)
 def create_pricelists(item: PricelistCreate):
     """
     Создать новый прайс-лист.


### PR DESCRIPTION
## Summary
- allow creating pricelists when requests omit the trailing slash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c5cbec8f48327886e16c1dd9f17be