### PR TITLE
Fix missing GET /pricelists endpoint

### DIFF
--- a/backend/routers/pricelist.py
+++ b/backend/routers/pricelist.py
@@ -12,6 +12,7 @@ router = APIRouter(
 )
 
 @router.get("/", response_model=List[Pricelist])
+@router.get("", response_model=List[Pricelist], include_in_schema=False)
 def get_pricelists():
     """
     Получить все прайс-листы.


### PR DESCRIPTION
## Summary
- allow GET `/pricelists` without a trailing slash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c6707ac608327a2a5cac6f0159dd8