### PR TITLE
Add extra baggage support

### DIFF
--- a/backend/routers/report.py
+++ b/backend/routers/report.py
@@ -105,6 +105,7 @@ def get_report(filters: ReportFilters):
                 p.name AS passenger_name,
                 p.phone AS passenger_phone,
                 p.email AS passenger_email,
+                t.extra_baggage,
                 tr.date AS tour_date,
                 r.name AS route_name,
                 ds.stop_name AS dep_stop_name,
@@ -133,10 +134,11 @@ def get_report(filters: ReportFilters):
                 "passenger_name": row[4],
                 "passenger_phone": row[5],
                 "passenger_email": row[6],
-                "tour_date": row[7].isoformat(),
-                "route_name": row[8],
-                "departure_stop_name": row[9],
-                "arrival_stop_name": row[10]
+                "extra_baggage": bool(row[7]),
+                "tour_date": row[8].isoformat(),
+                "route_name": row[9],
+                "departure_stop_name": row[10],
+                "arrival_stop_name": row[11]
             })
 
         return {"summary": summary, "tickets": tickets}

--- a/frontend/src/components/TicketsAdmin.js
+++ b/frontend/src/components/TicketsAdmin.js
@@ -42,6 +42,7 @@ export default function TicketsAdmin({ tourId }) {
             <th>Телефон</th>
             <th>Email</th>
             <th>Откуда → Куда</th>
+            <th>Багаж</th>
           </tr>
         </thead>
         <tbody>
@@ -71,6 +72,13 @@ export default function TicketsAdmin({ tourId }) {
                 {stopsMap[t.departure_stop_id]||t.departure_stop_id}
                 {" → "}
                 {stopsMap[t.arrival_stop_id]  ||t.arrival_stop_id}
+              </td>
+              <td>
+                <input
+                  type="checkbox"
+                  checked={t.extra_baggage}
+                  onChange={e=>updateField(t.ticket_id,"extra_baggage",e.target.checked)}
+                />
               </td>
             </tr>
           ))}

--- a/frontend/src/pages/BookingPage.js
+++ b/frontend/src/pages/BookingPage.js
@@ -14,6 +14,7 @@ function BookingPage(props) {
 
   const [selectedSeat, setSelectedSeat] = useState(null);
   const [passengerData, setPassengerData] = useState({ name: "", phone: "", email: "" });
+  const [extraBaggage, setExtraBaggage] = useState(false);
   const [bookingMessage, setBookingMessage] = useState("");
   const [bookingType, setBookingType] = useState("info");
   const [loading, setLoading] = useState(false);
@@ -40,13 +41,15 @@ function BookingPage(props) {
         passenger_phone: passengerData.phone,
         passenger_email: passengerData.email,
         departure_stop_id: departureStopId,
-        arrival_stop_id: arrivalStopId
+        arrival_stop_id: arrivalStopId,
+        extra_baggage: extraBaggage
       })
       .then(function(res) {
         setBookingMessage("Билет успешно забронирован! Ticket ID: " + res.data.ticket_id);
         setBookingType("success");
         setSelectedSeat(null);
         setPassengerData({ name: "", phone: "", email: "" });
+        setExtraBaggage(false);
       })
       .catch(function(err) {
         console.error("Ошибка бронирования:", err);
@@ -95,6 +98,14 @@ function BookingPage(props) {
             value={passengerData.email}
             onChange={(e) => setPassengerData({ ...passengerData, email: e.target.value })}
           />
+          <label style={{display:'flex',alignItems:'center',gap:4}}>
+            <input
+              type="checkbox"
+              checked={extraBaggage}
+              onChange={e => setExtraBaggage(e.target.checked)}
+            />
+            Дополнительный багаж
+          </label>
           <Button variant="contained" type="submit">Забронировать</Button>
         </form>
       </div>

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -26,6 +26,7 @@ export default function SearchPage() {
   const [passengerData, setPassengerData] = useState({
     name: "", phone: "", email: ""
   });
+  const [extraBaggage, setExtraBaggage] = useState(false);
   const [message, setMessage] = useState("");
   const [messageType, setMessageType] = useState("info");
   const [loading, setLoading] = useState(false);
@@ -137,7 +138,8 @@ export default function SearchPage() {
       passenger_phone:    passengerData.phone,
       passenger_email:    passengerData.email,
       departure_stop_id:  Number(selectedDeparture),
-      arrival_stop_id:    Number(selectedArrival)
+      arrival_stop_id:    Number(selectedArrival),
+      extra_baggage:      extraBaggage
     })
     .then(res => {
       setMessage(`Билет забронирован! Ticket ID: ${res.data.ticket_id}`);
@@ -145,6 +147,7 @@ export default function SearchPage() {
       // сброс полей и перезагрузка схемы мест
       setSelectedSeat(null);
       setPassengerData({ name:"", phone:"", email:"" });
+      setExtraBaggage(false);
     })
     .catch(err => {
       console.error(err);
@@ -248,6 +251,14 @@ export default function SearchPage() {
               value={passengerData.email}
               onChange={e => setPassengerData({ ...passengerData, email: e.target.value })}
             />
+            <label style={{display:'flex',alignItems:'center',gap:4}}>
+              <input
+                type="checkbox"
+                checked={extraBaggage}
+                onChange={e => setExtraBaggage(e.target.checked)}
+              />
+              Дополнительный багаж
+            </label>
             <button type="submit">Забронировать</button>
           </form>
         </>

--- a/frontend/src/pages/ToursPage.js
+++ b/frontend/src/pages/ToursPage.js
@@ -44,7 +44,8 @@ export default function ToursPage() {
     passenger_phone: "",
     passenger_email: "",
     departure_stop_id: "",
-    arrival_stop_id: ""
+    arrival_stop_id: "",
+    extra_baggage: false
   });
 
   // — force‐reload key for SeatAdmin —
@@ -173,7 +174,8 @@ export default function ToursPage() {
       passenger_phone: ticket.passenger_phone,
       passenger_email: ticket.passenger_email,
       departure_stop_id: ticket.departure_stop_id,
-      arrival_stop_id: ticket.arrival_stop_id
+      arrival_stop_id: ticket.arrival_stop_id,
+      extra_baggage: ticket.extra_baggage
     });
   };
   const cancelTicketEdit = () => setEditingTicketId(null);
@@ -337,7 +339,7 @@ export default function ToursPage() {
             <thead>
               <tr>
                 <th>Место</th><th>Имя</th><th>Телефон</th><th>Email</th>
-                <th>Отправление</th><th>Прибытие</th><th>Действия</th>
+                <th>Отправление</th><th>Прибытие</th><th>Багаж</th><th>Действия</th>
               </tr>
             </thead>
             <tbody>
@@ -395,6 +397,16 @@ export default function ToursPage() {
                             {stops.map(s=><option key={s.id} value={s.id}>{s.stop_name}</option>)}
                           </select>
                         : stopsMap[ticket.arrival_stop_id] || ticket.arrival_stop_id
+                      }
+                    </td>
+                    <td>
+                      {isEd
+                        ? <input
+                            type="checkbox"
+                            checked={editingTicketData.extra_baggage}
+                            onChange={e=>setEditingTicketData({...editingTicketData,extra_baggage:e.target.checked})}
+                          />
+                        : (ticket.extra_baggage ? '✔' : '')
                       }
                     </td>
                     <td>


### PR DESCRIPTION
## Summary
- extend ticket admin schema and queries with `extra_baggage`
- allow updating extra baggage for tickets
- expose extra baggage in sales reports
- add extra baggage checkbox in booking and search flows
- support editing extra baggage in admin UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cabe6c87c8327bd0cb7913b858164