### PR TITLE
Handle missing booking terms in tour updates

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -100,7 +100,8 @@ class TourBase(BaseModel):
     pricelist_id: int
     date: date
     layout_variant: int  # избран вариант на разположение (напр. 1 – Neoplan, 2 – Travego)
-    booking_terms: str | None = None
+    # количество дней до отправления, в течение которых действует бронь
+    booking_terms: int = 0
 
 class TourCreate(TourBase):
     active_seats: List[int]  # номера на активните места за продажба

--- a/backend/routers/tour.py
+++ b/backend/routers/tour.py
@@ -20,7 +20,8 @@ class TourCreate(BaseModel):
     date: date
     layout_variant: int
     active_seats: List[int]
-    booking_terms: str | None = None
+    # параметр бронировки в днях до отправления; в БД smallint NOT NULL
+    booking_terms: int = 0
 
 
 class TourOut(BaseModel):


### PR DESCRIPTION
## Summary
- Ensure `booking_terms` uses integer default for tours
- Prevents null constraint violations during tour updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a6e5c5fc8327bd341db99e139c64