### PR TITLE
Restrict frontend to authenticated users

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from pydantic import BaseModel
 
 from passlib.context import CryptContext
 
 from ..database import get_connection
 from ..jwt_utils import create_token
+from ..auth import get_current_user
 import hashlib
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -71,3 +72,8 @@ def login(data: LoginIn):
 
     token = create_token({"user_id": user_id, "role": role})
     return {"token": token}
+
+
+@router.get("/verify")
+def verify(_: dict = Depends(get_current_user)):
+    return {"status": "ok"}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { BrowserRouter as Router, Routes, Route, NavLink } from "react-router-dom";
+import axios from "axios";
 import StopsPage from "./pages/StopsPage";
 import RoutesPage from "./pages/RoutesPage";
 import PricelistsPage from "./pages/PricelistsPage";
@@ -23,6 +24,19 @@ function App() {
     localStorage.removeItem("token");
     setToken(null);
   };
+
+  useEffect(() => {
+    const verify = async () => {
+      if (token) {
+        try {
+          await axios.get("/auth/verify");
+        } catch (err) {
+          handleLogout();
+        }
+      }
+    };
+    verify();
+  }, [token]);
 
   if (!token) {
     return <LoginPage onLogin={handleLogin} />;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -14,5 +14,16 @@ axios.interceptors.request.use((config) => {
   return config;
 });
 
+axios.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem("token");
+      window.location.href = "/";
+    }
+    return Promise.reject(error);
+  }
+);
+
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(<App />);


### PR DESCRIPTION
## Summary
- add backend route to verify JWT token
- verify token and handle 401 responses in frontend
- redirect to login when token invalid or missing

## Testing
- `pytest`
- `npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6891b79fe86c83278f3bd04b5b4bd6bb