### PR TITLE
feat: add admin purchases listing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -23,6 +23,7 @@ from .routers import (
     bundle,
 )
 from .routers.ticket_admin import router as admin_tickets_router
+from .routers.purchase_admin import router as admin_purchases_router
 
 
 app = FastAPI()
@@ -60,6 +61,7 @@ app.include_router(seat.router)
 app.include_router(search.router)
 app.include_router(bundle.router)
 app.include_router(admin_tickets_router)
+app.include_router(admin_purchases_router)
 app.include_router(auth.router)
 
 

--- a/backend/routers/purchase_admin.py
+++ b/backend/routers/purchase_admin.py
@@ -1,0 +1,109 @@
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from typing import List, Optional
+from ..database import get_connection
+from ..auth import require_admin_token
+
+router = APIRouter(
+    prefix="/admin/purchases",
+    tags=["admin_purchases"],
+    dependencies=[Depends(require_admin_token)],
+)
+
+class PurchaseRow(BaseModel):
+    id: int
+    created_at: Optional[str]
+    customer_name: str
+    customer_email: str
+    customer_phone: str
+    tour_date: Optional[str]
+    route_name: Optional[str]
+    departure_stop: Optional[str]
+    arrival_stop: Optional[str]
+    seats: List[int]
+    amount_due: float
+    status: str
+    deadline: Optional[str]
+    payment_method: str
+
+@router.get("/", response_model=List[PurchaseRow])
+def list_purchases(
+    status: Optional[str] = Query(None, description="Filter by status"),
+    email: Optional[str] = Query(None, description="Filter by customer email"),
+    order_id: Optional[int] = Query(None, description="Filter by purchase id"),
+):
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        conditions = []
+        params = []
+        if status:
+            conditions.append("pu.status = %s")
+            params.append(status)
+        if email:
+            conditions.append("pu.customer_email = %s")
+            params.append(email)
+        if order_id:
+            conditions.append("pu.id = %s")
+            params.append(order_id)
+        where_clause = ""
+        if conditions:
+            where_clause = "WHERE " + " AND ".join(conditions)
+
+        cur.execute(
+            f"""
+            SELECT
+              pu.id,
+              pu.update_at,
+              pu.customer_name,
+              pu.customer_email,
+              pu.customer_phone,
+              tr.date,
+              r.name,
+              ds.stop_name,
+              as_.stop_name,
+              ARRAY_AGG(s.seat_num) AS seats,
+              pu.amount_due,
+              pu.status,
+              pu.deadline,
+              pu.payment_method
+            FROM purchase pu
+            LEFT JOIN ticket t ON t.purchase_id = pu.id
+            LEFT JOIN seat s ON s.id = t.seat_id
+            LEFT JOIN tour tr ON tr.id = t.tour_id
+            LEFT JOIN route r ON r.id = tr.route_id
+            LEFT JOIN stop ds ON ds.id = t.departure_stop_id
+            LEFT JOIN stop as_ ON as_.id = t.arrival_stop_id
+            {where_clause}
+            GROUP BY pu.id, pu.update_at, pu.customer_name, pu.customer_email, pu.customer_phone,
+                     tr.date, r.name, ds.stop_name, as_.stop_name,
+                     pu.amount_due, pu.status, pu.deadline, pu.payment_method
+            ORDER BY pu.id DESC
+            """,
+            tuple(params),
+        )
+        rows = cur.fetchall()
+        purchases = []
+        for r in rows:
+            purchases.append(
+                {
+                    "id": r[0],
+                    "created_at": r[1].isoformat() if r[1] else None,
+                    "customer_name": r[2],
+                    "customer_email": r[3],
+                    "customer_phone": r[4],
+                    "tour_date": r[5].isoformat() if r[5] else None,
+                    "route_name": r[6],
+                    "departure_stop": r[7],
+                    "arrival_stop": r[8],
+                    "seats": r[9] if r[9] is not None else [],
+                    "amount_due": float(r[10]) if r[10] is not None else 0.0,
+                    "status": r[11],
+                    "deadline": r[12].isoformat() if r[12] else None,
+                    "payment_method": r[13],
+                }
+            )
+        return purchases
+    finally:
+        cur.close()
+        conn.close()

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import PassengersPage from "./pages/PassengersPage";
 import ReportPage from "./pages/ReportPage";
 import AvailablePage from "./pages/AvailablePage";
 import LoginPage from "./pages/LoginPage";
+import PurchasesPage from "./pages/PurchasesPage";
 
 import './App.css'; 
 
@@ -87,6 +88,11 @@ function App() {
             </NavLink>
           </li>
           <li>
+            <NavLink to="/purchases" className={({ isActive }) => (isActive ? "active" : undefined)}>
+              Purchases
+            </NavLink>
+          </li>
+          <li>
             <button onClick={handleLogout}>Logout</button>
           </li>
         </ul>
@@ -100,6 +106,7 @@ function App() {
         <Route path="/report" element={<ReportPage />} />
         <Route path="/available" element={<AvailablePage />} />
         <Route path="/search" element={<SearchPage />} />
+        <Route path="/purchases" element={<PurchasesPage />} />
 
       </Routes>
     </Router>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,9 @@
 import { render, screen } from '@testing-library/react';
+jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn() }));
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /Login/i });
+  expect(heading).toBeInTheDocument();
 });

--- a/frontend/src/pages/PurchasesPage.js
+++ b/frontend/src/pages/PurchasesPage.js
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+import { API } from "../config";
+
+export default function PurchasesPage() {
+  const [items, setItems] = useState([]);
+  const [status, setStatus] = useState("");
+
+  const load = () => {
+    const params = {};
+    if (status) params.status = status;
+    axios
+      .get(`${API}/admin/purchases`, { params })
+      .then((r) => setItems(r.data))
+      .catch((e) => console.error(e));
+  };
+
+  useEffect(() => {
+    load();
+  }, [status]);
+
+  const handlePay = (id) => {
+    axios.post(`${API}/purchase/${id}/pay`).then(load).catch(console.error);
+  };
+  const handleCancel = (id) => {
+    axios.post(`${API}/purchase/${id}/cancel`).then(load).catch(console.error);
+  };
+  const handleRefund = (id) => {
+    axios.post(`${API}/purchase/${id}/refund`).then(load).catch(console.error);
+  };
+
+  return (
+    <div>
+      <h2>Purchases</h2>
+      <label>
+        Status:
+        <select value={status} onChange={(e) => setStatus(e.target.value)}>
+          <option value="">All</option>
+          <option value="reserved">reserved</option>
+          <option value="paid">paid</option>
+          <option value="cancelled">cancelled</option>
+          <option value="refunded">refunded</option>
+        </select>
+      </label>
+      <table border="1" cellPadding="4" style={{ marginTop: 10 }}>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Client</th>
+            <th>Route</th>
+            <th>Seats</th>
+            <th>Amount</th>
+            <th>Status</th>
+            <th>Deadline</th>
+            <th>Payment</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((p) => (
+            <tr key={p.id}>
+              <td>{p.id}</td>
+              <td>
+                {p.customer_name}
+                <br />
+                {p.customer_email}
+                <br />
+                {p.customer_phone}
+              </td>
+              <td>
+                {p.tour_date} {p.route_name}
+                <br />
+                {p.departure_stop} - {p.arrival_stop}
+              </td>
+              <td>{(p.seats || []).join(", ")}</td>
+              <td>{p.amount_due}</td>
+              <td>{p.status}</td>
+              <td>{p.deadline || ""}</td>
+              <td>{p.payment_method}</td>
+              <td>
+                {p.status === "reserved" && (
+                  <>
+                    <button onClick={() => handlePay(p.id)}>Pay</button>
+                    <button onClick={() => handleCancel(p.id)}>Cancel</button>
+                  </>
+                )}
+                {p.status === "paid" && (
+                  <button onClick={() => handleRefund(p.id)}>Refund</button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/tests/test_admin_purchases.py
+++ b/tests/test_admin_purchases.py
@@ -1,0 +1,75 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+import pytest
+from datetime import datetime
+
+class DummyCursor:
+    def __init__(self):
+        self.queries = []
+        self.query = ""
+    def execute(self, query, params=None):
+        self.query = query
+        self.queries.append((query, params))
+    def fetchone(self):
+        return None
+    def fetchall(self):
+        if "FROM purchase" in self.query:
+            return [(
+                1,
+                datetime(2025, 8, 10, 10, 0, 0),
+                "Ivan",
+                "ivan@example.com",
+                "+123",
+                datetime(2025, 8, 10).date(),
+                "Route",
+                "A",
+                "B",
+                [12],
+                52.0,
+                "reserved",
+                datetime(2025, 8, 9, 12, 0, 0),
+                "online",
+            )]
+        return []
+    def close(self):
+        pass
+
+class DummyConn:
+    def __init__(self):
+        self.cursor_obj = DummyCursor()
+    def cursor(self):
+        return self.cursor_obj
+    def commit(self):
+        pass
+    def rollback(self):
+        pass
+    def close(self):
+        pass
+
+@pytest.fixture
+def client(monkeypatch):
+    def fake_get_connection():
+        return DummyConn()
+    monkeypatch.setattr('psycopg2.connect', lambda *a, **kw: DummyConn())
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    import importlib
+    import backend.database
+    monkeypatch.setattr('backend.database.get_connection', fake_get_connection)
+    if 'backend.main' in sys.modules:
+        importlib.reload(sys.modules['backend.main'])
+    else:
+        importlib.import_module('backend.main')
+    app = sys.modules['backend.main'].app
+    import backend.auth
+    app.dependency_overrides[backend.auth.require_admin_token] = lambda: None
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.pop(backend.auth.require_admin_token, None)
+
+
+def test_admin_purchase_list(client):
+    resp = client.get('/admin/purchases')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data and data[0]['id'] == 1

--- a/tests/test_admin_routes.py
+++ b/tests/test_admin_routes.py
@@ -11,7 +11,7 @@ class DummyCursor:
         self.query = args[0] if args else ""
 
     def fetchone(self):
-        if "FROM users" in self.query:
+        if "from users" in self.query.lower():
             # hashed 'admin'
             return ["8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918", "admin"]
         return None
@@ -40,6 +40,9 @@ class DummyConn:
 @pytest.fixture()
 def client(monkeypatch):
     monkeypatch.setattr("psycopg2.connect", lambda *a, **kw: DummyConn())
+    monkeypatch.setattr("backend.database.get_connection", lambda: DummyConn())
+    import backend.routers.auth as auth_router
+    monkeypatch.setattr(auth_router, "get_connection", lambda: DummyConn())
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
     if "backend.main" in sys.modules:
         importlib.reload(sys.modules["backend.main"])


### PR DESCRIPTION
## Summary
- add `/admin/purchases` backend endpoint to list purchases
- expose admin purchases page with status filter and actions
- cover purchases listing with tests and adjust existing admin tests

## Testing
- `pytest`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6891f2cbf2848327b3a5762529dce54a