### PR TITLE
feat: add calendar to search page

### DIFF
--- a/frontend/src/components/Calendar.js
+++ b/frontend/src/components/Calendar.js
@@ -1,0 +1,69 @@
+import React, { useState, useEffect } from 'react';
+import '../styles/Calendar.css';
+
+export default function Calendar({ activeDates = [], onSelect }) {
+  const initial = activeDates.length ? new Date(activeDates[0]) : new Date();
+  const [year, setYear] = useState(initial.getFullYear());
+  const [month, setMonth] = useState(initial.getMonth());
+
+  useEffect(() => {
+    if (activeDates.length) {
+      const first = new Date(activeDates[0]);
+      setYear(first.getFullYear());
+      setMonth(first.getMonth());
+    }
+  }, [activeDates]);
+
+  const months = [
+    'Январь','Февраль','Март','Апрель','Май','Июнь',
+    'Июль','Август','Сентябрь','Октябрь','Ноябрь','Декабрь'
+  ];
+  const weekdays = ['Пн','Вт','Ср','Чт','Пт','Сб','Вс'];
+
+  const firstDay = new Date(year, month, 1);
+  const lastDay = new Date(year, month + 1, 0);
+  const startDay = (firstDay.getDay() + 6) % 7;
+  const daysInMonth = lastDay.getDate();
+
+  const days = [];
+  for (let i = 0; i < startDay; i++) {
+    days.push({ key: `e${i}`, empty: true });
+  }
+  for (let d = 1; d <= daysInMonth; d++) {
+    const date = new Date(year, month, d).toISOString().slice(0, 10);
+    const isActive = activeDates.includes(date);
+    days.push({ key: date, day: d, date, active: isActive });
+  }
+
+  const handleSelect = (date) => {
+    if (onSelect) {
+      onSelect(date);
+    }
+  };
+
+  return (
+    <div id="calendar">
+      <div className="header">{months[month]} {year}</div>
+      <div className="weekdays">
+        {weekdays.map((w) => (
+          <div key={w}>{w}</div>
+        ))}
+      </div>
+      <div className="days">
+        {days.map((item) => (
+          item.empty ? (
+            <div key={item.key} className="inactive" />
+          ) : (
+            <div
+              key={item.key}
+              className={item.active ? 'active' : 'inactive'}
+              onClick={item.active ? () => handleSelect(item.date) : undefined}
+            >
+              {item.day}
+            </div>
+          )
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -6,6 +6,7 @@ import axios from "axios";
 import SeatClient from "../components/SeatClient";
 import Loader from "../components/Loader";
 import Alert from "../components/Alert";
+import Calendar from "../components/Calendar";
 
 import { API } from "../config";
 
@@ -60,6 +61,7 @@ export default function SearchPage() {
       setDates([]);
       setTours([]);
       setSelectedTour(null);
+      setSelectedDate("");
     } else {
       axios.get(`${API}/search/dates`, {
         params: {
@@ -209,19 +211,16 @@ export default function SearchPage() {
         ))}
       </select>
 
-      <select
-        value={selectedDate}
-        onChange={e => setSelectedDate(e.target.value)}
-        disabled={!selectedDeparture || !selectedArrival}
-      >
-        <option value="">Дата</option>
-        {dates.map(d => (
-          <option key={d} value={d}>{d}</option>
-        ))}
-      </select>
-
       <button type="submit">Найти</button>
     </form>
+
+    {dates.length > 0 && (
+      <div style={{ marginBottom: 20 }}>
+        <Calendar activeDates={dates} onSelect={setSelectedDate} />
+      </div>
+    )}
+
+    {selectedDate && <p>Выбранная дата: {selectedDate}</p>}
 
     {loading && <Loader />}
 

--- a/frontend/src/styles/Calendar.css
+++ b/frontend/src/styles/Calendar.css
@@ -1,0 +1,56 @@
+#calendar {
+  width: 340px;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 2px 18px rgba(0,0,0,0.07);
+  padding: 18px;
+  font-family: 'Segoe UI', Arial, sans-serif;
+  margin: 0 auto;
+}
+
+#calendar .header {
+  text-align: center;
+  font-size: 1.3em;
+  font-weight: 600;
+  color: #2676e0;
+  margin-bottom: 12px;
+  letter-spacing: 1px;
+}
+
+#calendar .weekdays, #calendar .days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 6px;
+  text-align: center;
+}
+
+#calendar .weekdays div {
+  color: #b0b0b0;
+  font-size: 1em;
+  font-weight: 500;
+  margin-bottom: 4px;
+}
+
+#calendar .days div {
+  padding: 8px 0;
+  border-radius: 50%;
+  font-size: 1.05em;
+  transition: 0.14s;
+  cursor: default;
+}
+
+#calendar .days .inactive {
+  color: #ddd;
+}
+
+#calendar .days .active {
+  background: #2676e0;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 1px 8px rgba(38,118,224,0.10);
+  font-weight: 600;
+}
+
+#calendar .days .active:hover {
+  background: #184a90;
+}


### PR DESCRIPTION
## Summary
- add styled calendar component to highlight available trip dates
- switch search page to calendar-based date selection

## Testing
- `CI=true npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68930a38ff58832792df4cf5b37c0d1f