### PR TITLE
feat: improve calendar component

### DIFF
--- a/frontend/src/components/Calendar.js
+++ b/frontend/src/components/Calendar.js
@@ -1,18 +1,51 @@
 import React, { useState, useEffect } from 'react';
 import '../styles/Calendar.css';
 
-export default function Calendar({ activeDates = [], onSelect }) {
-  const initial = activeDates.length ? new Date(activeDates[0]) : new Date();
+// Calendar with month navigation and date selection.
+// `activeDates` - array of ISO date strings that are selectable.
+// `selectedDate` - currently chosen date (ISO string).
+// `onSelect` - callback when user chooses a date.
+export default function Calendar({ activeDates = [], selectedDate = '', onSelect }) {
+  // initial month/year based on selected date or first active date
+  const initial = selectedDate
+    ? new Date(selectedDate)
+    : activeDates.length
+      ? new Date(activeDates[0])
+      : new Date();
+
   const [year, setYear] = useState(initial.getFullYear());
   const [month, setMonth] = useState(initial.getMonth());
 
+  // When the list of active dates or selected date changes, make sure
+  // the calendar shows the month that contains that date
   useEffect(() => {
-    if (activeDates.length) {
-      const first = new Date(activeDates[0]);
-      setYear(first.getFullYear());
-      setMonth(first.getMonth());
+    const src = selectedDate || (activeDates.length ? activeDates[0] : null);
+    if (src) {
+      const d = new Date(src);
+      setYear(d.getFullYear());
+      setMonth(d.getMonth());
     }
-  }, [activeDates]);
+  }, [activeDates, selectedDate]);
+
+  const prevMonth = () => {
+    setMonth((m) => {
+      if (m === 0) {
+        setYear((y) => y - 1);
+        return 11;
+      }
+      return m - 1;
+    });
+  };
+
+  const nextMonth = () => {
+    setMonth((m) => {
+      if (m === 11) {
+        setYear((y) => y + 1);
+        return 0;
+      }
+      return m + 1;
+    });
+  };
 
   const months = [
     'Январь','Февраль','Март','Апрель','Май','Июнь',
@@ -32,7 +65,8 @@ export default function Calendar({ activeDates = [], onSelect }) {
   for (let d = 1; d <= daysInMonth; d++) {
     const date = new Date(year, month, d).toISOString().slice(0, 10);
     const isActive = activeDates.includes(date);
-    days.push({ key: date, day: d, date, active: isActive });
+    const isSelected = selectedDate === date;
+    days.push({ key: date, day: d, date, active: isActive, selected: isSelected });
   }
 
   const handleSelect = (date) => {
@@ -43,7 +77,11 @@ export default function Calendar({ activeDates = [], onSelect }) {
 
   return (
     <div id="calendar">
-      <div className="header">{months[month]} {year}</div>
+      <div className="header">
+        <button className="nav prev" onClick={prevMonth}>&lt;</button>
+        <span>{months[month]} {year}</span>
+        <button className="nav next" onClick={nextMonth}>&gt;</button>
+      </div>
       <div className="weekdays">
         {weekdays.map((w) => (
           <div key={w}>{w}</div>
@@ -52,11 +90,17 @@ export default function Calendar({ activeDates = [], onSelect }) {
       <div className="days">
         {days.map((item) => (
           item.empty ? (
-            <div key={item.key} className="inactive" />
+            <div key={item.key} className="empty" />
           ) : (
             <div
               key={item.key}
-              className={item.active ? 'active' : 'inactive'}
+              className={
+                item.selected
+                  ? 'selected'
+                  : item.active
+                    ? 'active'
+                    : 'inactive'
+              }
               onClick={item.active ? () => handleSelect(item.date) : undefined}
             >
               {item.day}

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -216,7 +216,11 @@ export default function SearchPage() {
 
     {dates.length > 0 && (
       <div style={{ marginBottom: 20 }}>
-        <Calendar activeDates={dates} onSelect={setSelectedDate} />
+        <Calendar
+          activeDates={dates}
+          selectedDate={selectedDate}
+          onSelect={setSelectedDate}
+        />
       </div>
     )}
 

--- a/frontend/src/styles/Calendar.css
+++ b/frontend/src/styles/Calendar.css
@@ -9,12 +9,23 @@
 }
 
 #calendar .header {
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font-size: 1.3em;
   font-weight: 600;
   color: #2676e0;
   margin-bottom: 12px;
   letter-spacing: 1px;
+}
+
+#calendar .header .nav {
+  background: none;
+  border: none;
+  color: #2676e0;
+  cursor: pointer;
+  font-size: 1em;
+  padding: 4px 8px;
 }
 
 #calendar .weekdays, #calendar .days {
@@ -41,6 +52,19 @@
 
 #calendar .days .inactive {
   color: #ddd;
+}
+
+#calendar .days .selected {
+  background: #ff9800;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 1px 8px rgba(255,152,0,0.15);
+}
+
+#calendar .days .empty {
+  visibility: hidden;
+  pointer-events: none;
 }
 
 #calendar .days .active {


### PR DESCRIPTION
## Summary
- add month navigation and single-date selection to calendar component
- style calendar days for active, inactive, and selected states
- expose selected date prop in search page calendar usage

## Testing
- `pytest`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_689312ce01f0832782bea034e378de91