### PR TITLE
Fix calendar date offset and calendar toggling

### DIFF
--- a/frontend/src/components/Calendar.js
+++ b/frontend/src/components/Calendar.js
@@ -63,7 +63,10 @@ export default function Calendar({ activeDates = [], selectedDate = '', onSelect
     days.push({ key: `e${i}`, empty: true });
   }
   for (let d = 1; d <= daysInMonth; d++) {
-    const date = new Date(year, month, d).toISOString().slice(0, 10);
+    // Build an ISO date string without local timezone offset. Using Date.UTC
+    // ensures that the day number corresponds to the calendar day shown,
+    // preventing a shift by one day in locales ahead/behind UTC.
+    const date = new Date(Date.UTC(year, month, d)).toISOString().slice(0, 10);
     const isActive = activeDates.includes(date);
     const isSelected = selectedDate === date;
     days.push({ key: date, day: d, date, active: isActive, selected: isSelected });

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -301,7 +301,7 @@ export default function SearchPage() {
           readOnly
           placeholder="Дата туда"
           value={selectedDepartDate}
-          onClick={() => setShowDepartCal(v => !v)}
+          onClick={() => { setShowDepartCal(v => !v); setShowReturnCal(false); }}
         />
 
         <input
@@ -309,7 +309,12 @@ export default function SearchPage() {
           readOnly
           placeholder="Дата обратно"
           value={selectedReturnDate}
-          onClick={() => setShowReturnCal(v => !v)}
+          onClick={() => {
+            if (returnDates.length) {
+              setShowReturnCal(v => !v);
+              setShowDepartCal(false);
+            }
+          }}
           disabled={!returnDates.length}
         />
 


### PR DESCRIPTION
## Summary
- fix calendar date calculation to avoid day offset caused by timezone
- switch between departure and return calendars when clicking date fields

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933496c520832794c4b170ae654bc9