### PR TITLE
Release seats on cancellation and hide departed tours

### DIFF
--- a/backend/ticket_utils.py
+++ b/backend/ticket_utils.py
@@ -1,0 +1,74 @@
+from typing import List
+
+
+def free_ticket(cur, ticket_id: int) -> None:
+    """Free seat availability and remove ticket record.
+
+    Restores seat.available segments and increases counters in the
+    available table for the segments covered by the ticket.
+    """
+    # Fetch ticket details
+    cur.execute(
+        """
+        SELECT tour_id, seat_id, departure_stop_id, arrival_stop_id
+          FROM ticket
+         WHERE id = %s
+        """,
+        (ticket_id,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return
+    tour_id, seat_id, dep, arr = row
+
+    # Resolve route and ordered stops
+    cur.execute("SELECT route_id FROM tour WHERE id = %s", (tour_id,))
+    r = cur.fetchone()
+    if not r:
+        return
+    route_id = r[0]
+
+    cur.execute(
+        """
+        SELECT stop_id FROM routestop
+         WHERE route_id = %s
+         ORDER BY "order"
+        """,
+        (route_id,),
+    )
+    stops = [s[0] for s in cur.fetchall()]
+    if dep not in stops or arr not in stops:
+        return
+    idx_from = stops.index(dep)
+    idx_to = stops.index(arr)
+    if idx_from >= idx_to:
+        return
+    segments: List[str] = [str(i + 1) for i in range(idx_from, idx_to)]
+
+    # Restore seat.available string
+    cur.execute("SELECT available FROM seat WHERE id = %s", (seat_id,))
+    seat_row = cur.fetchone()
+    old_avail = seat_row[0] if seat_row and seat_row[0] else ""
+    merged = sorted(set(old_avail + "".join(segments)), key=int)
+    new_avail = "".join(merged) if merged else "0"
+    cur.execute(
+        "UPDATE seat SET available = %s WHERE id = %s",
+        (new_avail, seat_id),
+    )
+
+    # Increment available.seats for each overlapping segment
+    for i in range(idx_from, idx_to):
+        d, a = stops[i], stops[i + 1]
+        cur.execute(
+            """
+            UPDATE available
+               SET seats = seats + 1
+             WHERE tour_id = %s
+               AND departure_stop_id = %s
+               AND arrival_stop_id = %s
+            """,
+            (tour_id, d, a),
+        )
+
+    # Remove the ticket itself
+    cur.execute("DELETE FROM ticket WHERE id = %s", (ticket_id,))

--- a/tests/test_booking_flow.py
+++ b/tests/test_booking_flow.py
@@ -20,6 +20,8 @@ class DummyCursor:
         return [1]
 
     def fetchall(self):
+        if "SELECT id FROM ticket WHERE purchase_id" in self.query:
+            return [(1,)]
         return []
 
     def close(self):
@@ -54,6 +56,8 @@ def client(monkeypatch):
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
     import backend.database
     monkeypatch.setattr('backend.database.get_connection', fake_get_connection)
+    monkeypatch.setattr('backend.ticket_utils.free_ticket', lambda *a, **k: None)
+    monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     if 'backend.main' in sys.modules:
         importlib.reload(sys.modules['backend.main'])
     else:

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -20,6 +20,8 @@ class DummyCursor:
             return [self.status_resp]
         return [1]
     def fetchall(self):
+        if "SELECT id FROM ticket WHERE purchase_id" in self.query:
+            return [(1,)]
         return []
     def close(self):
         pass
@@ -49,6 +51,8 @@ def client(monkeypatch):
     import importlib
     import backend.database
     monkeypatch.setattr('backend.database.get_connection', fake_get_connection)
+    monkeypatch.setattr('backend.ticket_utils.free_ticket', lambda *a, **k: None)
+    monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     if 'backend.main' in sys.modules:
         importlib.reload(sys.modules['backend.main'])
     else:


### PR DESCRIPTION
## Summary
- free all tickets and seats when cancelling purchases manually or automatically
- add background worker to remove availability after departure
- introduce utility for freeing ticket seats

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68934223fd8483279159cfed78cbb78c