### PR TITLE
Compute and return ticket prices

### DIFF
--- a/frontend/src/pages/BookingPage.js
+++ b/frontend/src/pages/BookingPage.js
@@ -37,8 +37,8 @@ function BookingPage(props) {
     axios
       .post(`${API}/book`, {
         tour_id: tourId,
-        seat_num: selectedSeat,
-        passenger_name: passengerData.name,
+        seat_nums: [selectedSeat],
+        passenger_names: [passengerData.name],
         passenger_phone: passengerData.phone,
         passenger_email: passengerData.email,
         departure_stop_id: departureStopId,
@@ -46,7 +46,7 @@ function BookingPage(props) {
         extra_baggage: extraBaggage
       })
       .then(function(res) {
-        setBookingMessage(`Билет успешно забронирован! Purchase ID: ${res.data.purchase_id}`);
+        setBookingMessage(`Билет успешно забронирован! Purchase ID: ${res.data.purchase_id}. Сумма: ${res.data.amount_due.toFixed(2)}`);
         setPurchaseId(res.data.purchase_id);
         setBookingType("success");
         setSelectedSeat(null);

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -218,6 +218,7 @@ export default function SearchPage() {
         departure_stop_id: Number(selectedDeparture),
         arrival_stop_id:   Number(selectedArrival)
       });
+      let total = outRes.data.amount_due;
       let ids = [outRes.data.purchase_id];
       if (selectedReturnTour) {
         const retRes = await axios.post(`${API}/${endpoint}`, {
@@ -227,11 +228,12 @@ export default function SearchPage() {
           departure_stop_id: Number(selectedArrival),
           arrival_stop_id:   Number(selectedDeparture)
         });
+        total += retRes.data.amount_due;
         ids.push(retRes.data.purchase_id);
       }
       const msg = action === 'purchase'
-        ? `Билеты куплены! Purchase ID: ${ids.join(', ')}`
-        : `Билеты забронированы! Purchase ID: ${ids.join(', ')}`;
+        ? `Билеты куплены! Purchase ID: ${ids.join(', ')}. Сумма: ${total.toFixed(2)}`
+        : `Билеты забронированы! Purchase ID: ${ids.join(', ')}. Сумма: ${total.toFixed(2)}`;
       setPurchaseId(ids[ids.length - 1]);
       setMessage(msg);
       setMessageType("success");

--- a/tests/test_booking_flow.py
+++ b/tests/test_booking_flow.py
@@ -81,6 +81,7 @@ def test_booking_flow(client):
     })
     assert any('reserved' in q[0].lower() for q in store['cursor'].queries)
     assert any('insert into sales' in q[0].lower() for q in store['cursor'].queries)
+    assert 'amount_due' in resp.json()
 
     store['cursor'].queries.clear()
 
@@ -103,6 +104,7 @@ def test_booking_flow(client):
     })
     assert any('paid' in q[0].lower() for q in store['cursor'].queries)
     assert any('insert into sales' in q[0].lower() for q in store['cursor'].queries)
+    assert 'amount_due' in resp.json()
 
     store['cursor'].queries.clear()
 

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -74,6 +74,7 @@ def test_purchase_flow(client):
         'arrival_stop_id': 2,
     })
     assert resp.status_code == 200
+    assert 'amount_due' in resp.json()
     assert any('INSERT INTO sales' in q[0] for q in store['cursor'].queries)
 
     store['cursor'].queries.clear()
@@ -95,6 +96,7 @@ def test_purchase_flow(client):
         'arrival_stop_id': 2,
     })
     assert resp.status_code == 200
+    assert 'amount_due' in resp.json()
     assert any('INSERT INTO purchase' in q[0] for q in store['cursor'].queries)
     assert any('INSERT INTO sales' in q[0] for q in store['cursor'].queries)
 


### PR DESCRIPTION
## Summary
- calculate purchase price from pricelist and store in `purchase.amount_due`
- return price from purchase endpoints and show total cost in booking UIs
- add tests for new price info in purchase responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68934be933f8832785ed91dd08cf8c1e