### PR TITLE
fix: sync seat availability

### DIFF
--- a/backend/ticket_utils.py
+++ b/backend/ticket_utils.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 
 def free_ticket(cur, ticket_id: int) -> None:
@@ -72,3 +72,53 @@ def free_ticket(cur, ticket_id: int) -> None:
 
     # Remove the ticket itself
     cur.execute("DELETE FROM ticket WHERE id = %s", (ticket_id,))
+
+
+def recalc_available(cur, tour_id: int) -> None:
+    """Rebuild the available table for a tour based on seat availability."""
+    cur.execute(
+        "SELECT route_id, pricelist_id FROM tour WHERE id=%s", (tour_id,)
+    )
+    row = cur.fetchone()
+    if not row:
+        return
+    route_id, pricelist_id = row
+
+    cur.execute(
+        'SELECT stop_id FROM routestop WHERE route_id=%s ORDER BY "order"',
+        (route_id,),
+    )
+    stops = [r[0] for r in cur.fetchall()]
+    if len(stops) < 2:
+        return
+
+    cur.execute(
+        "SELECT seat_num, available FROM seat WHERE tour_id=%s",
+        (tour_id,),
+    )
+    seats: List[Tuple[int, str]] = cur.fetchall()
+
+    # drop previous counters
+    cur.execute("DELETE FROM available WHERE tour_id=%s", (tour_id,))
+
+    cur.execute(
+        "SELECT departure_stop_id, arrival_stop_id FROM prices WHERE pricelist_id=%s",
+        (pricelist_id,),
+    )
+    valid_segments = cur.fetchall()
+
+    for dep, arr in valid_segments:
+        if dep not in stops or arr not in stops:
+            continue
+        i_from = stops.index(dep)
+        i_to = stops.index(arr)
+        if i_from >= i_to:
+            continue
+        required = [str(i + 1) for i in range(i_from, i_to)]
+        count = sum(
+            1 for _, avail in seats if avail and all(seg in avail for seg in required)
+        )
+        cur.execute(
+            "INSERT INTO available (tour_id, departure_stop_id, arrival_stop_id, seats) VALUES (%s,%s,%s,%s)",
+            (tour_id, dep, arr, count),
+        )

--- a/tests/test_booking_flow.py
+++ b/tests/test_booking_flow.py
@@ -15,12 +15,22 @@ class DummyCursor:
         self.queries.append((query, params))
 
     def fetchone(self):
-        if "SELECT id, seat_id FROM ticket" in self.query:
+        q = self.query.lower()
+        if "select id, seat_id from ticket" in q:
             return [1, 1]
+        if "select route_id, pricelist_id from tour" in q:
+            return [1, 1]
+        if "select id, available from seat" in q:
+            return [1, "1234"]
+        if "select price from prices" in q:
+            return [10]
         return [1]
 
     def fetchall(self):
-        if "SELECT id FROM ticket WHERE purchase_id" in self.query:
+        q = self.query.lower()
+        if "select stop_id from routestop" in q:
+            return [(1,), (2,), (3,), (4,)]
+        if "select id from ticket where purchase_id" in q:
             return [(1,)]
         return []
 

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -14,13 +14,23 @@ class DummyCursor:
         self.query = query
         self.queries.append((query, params))
     def fetchone(self):
-        if "SELECT id, seat_id FROM ticket" in self.query:
+        q = self.query.lower()
+        if "select id, seat_id from ticket" in q:
             return [1, 1]
-        if "SELECT status FROM purchase" in self.query:
+        if "select status from purchase" in q:
             return [self.status_resp]
+        if "select route_id, pricelist_id from tour" in q:
+            return [1, 1]
+        if "select id, available from seat" in q:
+            return [1, "1234"]
+        if "select price from prices" in q:
+            return [10]
         return [1]
     def fetchall(self):
-        if "SELECT id FROM ticket WHERE purchase_id" in self.query:
+        q = self.query.lower()
+        if "select stop_id from routestop" in q:
+            return [(1,), (2,), (3,), (4,)]
+        if "select id from ticket where purchase_id" in q:
             return [(1,)]
         return []
     def close(self):


### PR DESCRIPTION
## Summary
- update purchase flow to reserve seat segments and decrement availability
- recompute seat availability counters when seats are blocked/unblocked
- prevent tour updates from reopening sold seats and recalc availability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689358d0054c83279c6f3409baa95717