### PR TITLE
Fix undefined segment list during tour creation

### DIFF
--- a/backend/routers/tour.py
+++ b/backend/routers/tour.py
@@ -7,6 +7,7 @@ from datetime import date
 from ..database import get_connection
 from ..auth import require_admin_token
 from ..models import BookingTermsEnum
+from ..ticket_utils import recalc_available
 
 router = APIRouter(
     prefix="/tours",
@@ -163,7 +164,12 @@ def create_tour(tour: TourCreate):
         if len(stops) < 2:
             raise HTTPException(400, "Route must have at least 2 stops")
 
-        # список сегментов больше не нужен здесь
+        # Формируем все возможные сегменты маршрута (i < j)
+        all_segments = [
+            (stops[i], stops[j])
+            for i in range(len(stops) - 1)
+            for j in range(i + 1, len(stops))
+        ]
 
         # Выбираем только те сегменты, что есть в данном прайслисте
         cur.execute(


### PR DESCRIPTION
## Summary
- compute segment pairs when creating tours so `available` table can be populated without errors
- import `recalc_available` to allow updating tours without crashes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a8f214d88327b362a0f9a17674c1