### PR TITLE
Add purchase info view and endpoint

### DIFF
--- a/tests/test_admin_purchases.py
+++ b/tests/test_admin_purchases.py
@@ -31,6 +31,36 @@ class DummyCursor:
                 datetime(2025, 8, 9, 12, 0, 0),
                 "online",
             )]
+        if "FROM ticket" in self.query:
+            return [(
+                1,
+                10,
+                5,
+                2,
+                1,
+                2,
+                1,
+                0,
+            )]
+        if "FROM sales" in self.query:
+            return [
+                (
+                    1,
+                    datetime(2025, 8, 9, 12, 0, 0),
+                    "ticket_sale",
+                    52.0,
+                    1,
+                    None,
+                ),
+                (
+                    2,
+                    datetime(2025, 8, 9, 13, 0, 0),
+                    "refund",
+                    0.0,
+                    1,
+                    None,
+                ),
+            ]
         return []
     def close(self):
         pass
@@ -73,3 +103,13 @@ def test_admin_purchase_list(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data and data[0]['id'] == 1
+
+
+def test_admin_purchase_info(client):
+    resp = client.get('/admin/purchases/1')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data['tickets']) == 1
+    assert data['tickets'][0]['id'] == 1
+    assert len(data['sales']) == 2
+    assert data['sales'][0]['category'] == 'ticket_sale'


### PR DESCRIPTION
## Summary
- add `/admin/purchases/{purchase_id}` endpoint returning sales logs and tickets
- show Info button on purchases page to toggle detailed order info
- cover admin purchase info with tests

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68945f00dc28832788327a1f5eb12f78