### PR TITLE
Show passenger name and seat number in purchase info

### DIFF
--- a/frontend/src/pages/PurchasesPage.js
+++ b/frontend/src/pages/PurchasesPage.js
@@ -121,7 +121,7 @@ export default function PurchasesPage() {
                     <ul>
                       {info[p.id].sales.map((s) => (
                         <li key={s.id}>
-                          {new Date(s.date).toLocaleString()} {s.category} {s.amount}
+                          {new Date(s.date).toLocaleString('ru-RU')} - {s.category} {s.amount}
                         </li>
                       ))}
                     </ul>
@@ -129,7 +129,7 @@ export default function PurchasesPage() {
                     <ul>
                       {info[p.id].tickets.map((t) => (
                         <li key={t.id}>
-                          Ticket {t.id}: seat {t.seat_id}, passenger {t.passenger_id}
+                          Ticket {t.id}: seat {t.seat_num}, passenger {t.passenger_name}
                         </li>
                       ))}
                     </ul>

--- a/tests/test_admin_purchases.py
+++ b/tests/test_admin_purchases.py
@@ -36,7 +36,9 @@ class DummyCursor:
                 1,
                 10,
                 5,
+                12,
                 2,
+                "Ivan",
                 1,
                 2,
                 1,
@@ -111,5 +113,7 @@ def test_admin_purchase_info(client):
     data = resp.json()
     assert len(data['tickets']) == 1
     assert data['tickets'][0]['id'] == 1
+    assert data['tickets'][0]['seat_num'] == 12
+    assert data['tickets'][0]['passenger_name'] == 'Ivan'
     assert len(data['sales']) == 2
     assert data['sales'][0]['category'] == 'ticket_sale'


### PR DESCRIPTION
## Summary
- include seat numbers and passenger names when viewing purchase details
- display sales logs with localized date/time and show passenger name and seat number on purchase page
- cover new fields in admin purchases test

## Testing
- `pytest`
- `npm test --prefix frontend -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68947da2865883279bc9738aae5704dd