### PR TITLE
feat(search): enforce calendar date restrictions

### DIFF
--- a/frontend/src/components/Calendar.js
+++ b/frontend/src/components/Calendar.js
@@ -5,7 +5,8 @@ import '../styles/Calendar.css';
 // `activeDates` - array of ISO date strings that are selectable.
 // `selectedDate` - currently chosen date (ISO string).
 // `onSelect` - callback when user chooses a date.
-export default function Calendar({ activeDates = [], selectedDate = '', onSelect }) {
+// `minDate` - ISO date string that acts as the earliest selectable day.
+export default function Calendar({ activeDates = [], selectedDate = '', onSelect, minDate }) {
   // initial month/year based on selected date or first active date
   const initial = selectedDate
     ? new Date(selectedDate)
@@ -67,7 +68,8 @@ export default function Calendar({ activeDates = [], selectedDate = '', onSelect
     // ensures that the day number corresponds to the calendar day shown,
     // preventing a shift by one day in locales ahead/behind UTC.
     const date = new Date(Date.UTC(year, month, d)).toISOString().slice(0, 10);
-    const isActive = activeDates.includes(date);
+    const isAfterMin = !minDate || date >= minDate;
+    const isActive = activeDates.includes(date) && isAfterMin;
     const isSelected = selectedDate === date;
     days.push({ key: date, day: d, date, active: isActive, selected: isSelected });
   }

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -41,6 +41,11 @@ export default function SearchPage() {
   const [loading, setLoading] = useState(false);
   const [purchaseId, setPurchaseId] = useState(null);
 
+  const today = new Date().toISOString().slice(0, 10);
+  const returnMinDate = selectedDepartDate
+    ? new Date(new Date(selectedDepartDate).getTime() + 86400000).toISOString().slice(0, 10)
+    : today;
+
   useEffect(() => {
     setPassengerNames(Array(seatCount).fill(""));
     setSelectedOutboundSeats([]);
@@ -343,7 +348,14 @@ export default function SearchPage() {
           <Calendar
             activeDates={departDates}
             selectedDate={selectedDepartDate}
-            onSelect={d => { setSelectedDepartDate(d); setShowDepartCal(false); }}
+            minDate={today}
+            onSelect={d => {
+              setSelectedDepartDate(d);
+              setShowDepartCal(false);
+              if (selectedReturnDate && selectedReturnDate <= d) {
+                setSelectedReturnDate('');
+              }
+            }}
           />
         </div>
       )}
@@ -353,6 +365,7 @@ export default function SearchPage() {
           <Calendar
             activeDates={returnDates}
             selectedDate={selectedReturnDate}
+            minDate={returnMinDate}
             onSelect={d => { setSelectedReturnDate(d); setShowReturnCal(false); }}
           />
         </div>


### PR DESCRIPTION
## Summary
- enforce minimum selectable date in calendar component
- restrict search page to today-or-later outbound and later return dates

## Testing
- `pytest`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68947f75f82c8327ba5eba369eb7d077