### PR TITLE
feat: expose localized bundle endpoints for clients

### DIFF
--- a/backend/routers/bundle.py
+++ b/backend/routers/bundle.py
@@ -134,9 +134,8 @@ def _get_route(cur, route_id: int, col: str):
     return {"id": route_id, "name": name, "stops": stops}
 
 
-@router.post("/selected_route", response_model=RoutesBundleOut)
-def selected_route(data: LangRequest):
-    lang = data.lang.lower()
+def _selected_route_impl(lang: str):
+    lang = (lang or "").lower()
     col = f"stop_{lang}" if lang in {"en", "bg", "ua"} else "stop_name"
     conn = get_connection()
     cur = conn.cursor()
@@ -156,9 +155,18 @@ def selected_route(data: LangRequest):
         conn.close()
 
 
-@router.post("/selected_pricelist", response_model=PricelistBundleOut)
-def selected_pricelist(data: LangRequest):
-    lang = data.lang.lower()
+@router.post("/selected_route", response_model=RoutesBundleOut)
+def selected_route(data: LangRequest):
+    return _selected_route_impl(data.lang)
+
+
+@router.get("/selected_route", response_model=RoutesBundleOut)
+def selected_route_get(lang: str):
+    return _selected_route_impl(lang)
+
+
+def _selected_pricelist_impl(lang: str):
+    lang = (lang or "").lower()
     col = f"stop_{lang}" if lang in {"en", "bg", "ua"} else "stop_name"
     conn = get_connection()
     cur = conn.cursor()
@@ -197,3 +205,13 @@ def selected_pricelist(data: LangRequest):
     finally:
         cur.close()
         conn.close()
+
+
+@router.post("/selected_pricelist", response_model=PricelistBundleOut)
+def selected_pricelist(data: LangRequest):
+    return _selected_pricelist_impl(data.lang)
+
+
+@router.get("/selected_pricelist", response_model=PricelistBundleOut)
+def selected_pricelist_get(lang: str):
+    return _selected_pricelist_impl(lang)

--- a/tests/test_bundle_public.py
+++ b/tests/test_bundle_public.py
@@ -63,13 +63,13 @@ def client(monkeypatch):
     return TestClient(app)
 
 def test_routes_bundle(client):
-    resp = client.post("/selected_route", json={"lang": "en"})
+    resp = client.get("/selected_route", params={"lang": "en"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["forward"]["stops"][0]["name"] == "A_en"
 
 def test_pricelist_bundle(client):
-    resp = client.post("/selected_pricelist", json={"lang": "en"})
+    resp = client.get("/selected_pricelist", params={"lang": "en"})
     assert resp.status_code == 200
     data = resp.json()
     assert data["prices"][0]["departure_name"] == "A_en"


### PR DESCRIPTION
## Summary
- allow clients to fetch selected routes and pricelists with localized stop names using GET endpoints
- cover the new paths in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894ab29c87c83279831be5d3d60a99c