### PR TITLE
Allow combining tickets into a single purchase

### DIFF
--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -17,6 +17,7 @@ class PurchaseCreate(BaseModel):
     departure_stop_id: int
     arrival_stop_id: int
     extra_baggage: list[bool] | None = None
+    purchase_id: int | None = None
 
 class PurchaseOut(BaseModel):
     purchase_id: int
@@ -80,23 +81,42 @@ def _create_purchase(
     )
     total_price = round(total_price, 2)
 
-    # 1) create purchase record using first passenger as customer name
-    cur.execute(
-        f"""
-        INSERT INTO purchase
-          (customer_name, customer_email, customer_phone, amount_due, deadline, status, update_at, payment_method)
-        VALUES (%s,%s,%s,%s,NOW() + interval '1 day','{status}',NOW(),%s)
-        RETURNING id
-        """,
-        (
-            data.passenger_names[0] if data.passenger_names else "",
-            data.passenger_email,
-            data.passenger_phone,
-            total_price,
-            payment_method,
-        ),
-    )
-    purchase_id = cur.fetchone()[0]
+    purchase_id = data.purchase_id
+    new_amount = total_price
+    if purchase_id is not None:
+        cur.execute(
+            "SELECT amount_due, status FROM purchase WHERE id=%s",
+            (purchase_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(404, "Purchase not found")
+        current_amount, current_status = row
+        if current_status != status:
+            raise HTTPException(400, "Mismatched purchase status")
+        new_amount = round(current_amount + total_price, 2)
+        cur.execute(
+            "UPDATE purchase SET amount_due=%s, update_at=NOW() WHERE id=%s",
+            (new_amount, purchase_id),
+        )
+    else:
+        # 1) create purchase record using first passenger as customer name
+        cur.execute(
+            f"""
+            INSERT INTO purchase
+              (customer_name, customer_email, customer_phone, amount_due, deadline, status, update_at, payment_method)
+            VALUES (%s,%s,%s,%s,NOW() + interval '1 day','{status}',NOW(),%s)
+            RETURNING id
+            """,
+            (
+                data.passenger_names[0] if data.passenger_names else "",
+                data.passenger_email,
+                data.passenger_phone,
+                total_price,
+                payment_method,
+            ),
+        )
+        purchase_id = cur.fetchone()[0]
 
     # 2) create passenger and ticket for each seat
     for seat_num, name, bag in zip(data.seat_nums, data.passenger_names, baggage_list):
@@ -173,7 +193,7 @@ def _create_purchase(
         )
 
     _log_sale(cur, purchase_id, "ticket_sale", 0)
-    return purchase_id, total_price
+    return purchase_id, new_amount
 
 @router.post("/", response_model=PurchaseOut)
 def create_purchase(data: PurchaseCreate):


### PR DESCRIPTION
## Summary
- add optional purchase_id to booking API to reuse existing purchase and update total amount
- update client to pass purchase_id between requests and allow paying or cancelling the whole set of tickets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894ae15e0448327b25fabfa80ed8a3c