### PR TITLE
feat: enhance purchase display

### DIFF
--- a/backend/routers/purchase_admin.py
+++ b/backend/routers/purchase_admin.py
@@ -113,6 +113,7 @@ def list_purchases(
 class TicketInfo(BaseModel):
     id: int
     tour_id: int
+    tour_date: Optional[str]
     seat_id: int
     seat_num: int
     passenger_id: int
@@ -135,12 +136,13 @@ def purchase_info(purchase_id: int):
     try:
         cur.execute(
             """
-            SELECT t.id, t.tour_id, t.seat_id, s.seat_num, t.passenger_id, p.name,
+            SELECT t.id, t.tour_id, tr.date, t.seat_id, s.seat_num, t.passenger_id, p.name,
                    t.departure_stop_id, t.arrival_stop_id,
                    t.purchase_id, t.extra_baggage
             FROM ticket t
             LEFT JOIN seat s ON s.id = t.seat_id
             LEFT JOIN passenger p ON p.id = t.passenger_id
+            LEFT JOIN tour tr ON tr.id = t.tour_id
             WHERE t.purchase_id=%s
             """,
             (purchase_id,),
@@ -150,14 +152,15 @@ def purchase_info(purchase_id: int):
             {
                 "id": r[0],
                 "tour_id": r[1],
-                "seat_id": r[2],
-                "seat_num": r[3],
-                "passenger_id": r[4],
-                "passenger_name": r[5],
-                "departure_stop_id": r[6],
-                "arrival_stop_id": r[7],
-                "purchase_id": r[8],
-                "extra_baggage": r[9],
+                "tour_date": r[2].isoformat() if r[2] else None,
+                "seat_id": r[3],
+                "seat_num": r[4],
+                "passenger_id": r[5],
+                "passenger_name": r[6],
+                "departure_stop_id": r[7],
+                "arrival_stop_id": r[8],
+                "purchase_id": r[9],
+                "extra_baggage": r[10],
             }
             for r in t_rows
         ]

--- a/frontend/src/pages/PurchasesPage.js
+++ b/frontend/src/pages/PurchasesPage.js
@@ -2,26 +2,38 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import { API } from "../config";
 
-const formatDeadline = (deadline) => {
-  if (!deadline) return "";
-  const d = new Date(deadline);
+const formatDateShort = (date) => {
+  if (!date) return "";
+  const d = new Date(date);
   const pad = (n) => String(n).padStart(2, "0");
-  return `${pad(d.getHours())}:${pad(d.getMinutes())} ${pad(d.getDate())}/${pad(
-    d.getMonth() + 1
-  )}/${d.getFullYear()}`;
+  return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}`;
 };
 
 export default function PurchasesPage() {
   const [items, setItems] = useState([]);
   const [status, setStatus] = useState("");
   const [info, setInfo] = useState({});
+  const [expanded, setExpanded] = useState({});
 
   const load = () => {
     const params = {};
     if (status) params.status = status;
     axios
       .get(`${API}/admin/purchases`, { params })
-      .then((r) => setItems(r.data))
+      .then(async (r) => {
+        setItems(r.data);
+        const map = {};
+        await Promise.all(
+          r.data.map((p) =>
+            axios
+              .get(`${API}/admin/purchases/${p.id}`)
+              .then((res) => {
+                map[p.id] = res.data;
+              })
+          )
+        );
+        setInfo(map);
+      })
       .catch((e) => console.error(e));
   };
 
@@ -40,23 +52,16 @@ export default function PurchasesPage() {
   };
 
   const toggleInfo = (id) => {
-    if (info[id]) {
-      setInfo((prev) => ({ ...prev, [id]: null }));
-    } else {
-      axios
-        .get(`${API}/admin/purchases/${id}`)
-        .then((r) => setInfo((prev) => ({ ...prev, [id]: r.data })))
-        .catch(console.error);
-    }
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
   };
 
   return (
     <div>
-      <h2>Purchases</h2>
+      <h2>Покупки</h2>
       <label>
-        Status:
+        Статус:
         <select value={status} onChange={(e) => setStatus(e.target.value)}>
-          <option value="">All</option>
+          <option value="">Все</option>
           <option value="reserved">reserved</option>
           <option value="paid">paid</option>
           <option value="cancelled">cancelled</option>
@@ -66,15 +71,15 @@ export default function PurchasesPage() {
       <table border="1" cellPadding="4" style={{ marginTop: 10 }}>
         <thead>
           <tr>
-            <th>ID</th>
-            <th>Client</th>
-            <th>Route</th>
-            <th>Seats</th>
-            <th>Amount</th>
-            <th>Status</th>
-            <th>Deadline</th>
-            <th>Payment</th>
-            <th>Actions</th>
+            <th>№</th>
+            <th>Клиент</th>
+            <th>Кол-во пассажиров</th>
+            <th>Кол-во билетов</th>
+            <th>Даты рейсов</th>
+            <th>Сумма</th>
+            <th>Статус</th>
+            <th>Оплата</th>
+            <th>Действия</th>
           </tr>
         </thead>
         <tbody>
@@ -83,25 +88,34 @@ export default function PurchasesPage() {
               <tr>
                 <td>{p.id}</td>
                 <td>
-                  {p.customer_name}
-                  <br />
-                  {p.customer_email}
-                  <br />
-                  {p.customer_phone}
+                  {(() => {
+                    const passengers = info[p.id]
+                      ? Array.from(new Set(info[p.id].tickets.map((t) => t.passenger_name)))
+                      : [];
+                    return passengers.join(", ");
+                  })()}
                 </td>
                 <td>
-                  {p.tour_date} {p.route_name}
-                  <br />
-                  {p.departure_stop} - {p.arrival_stop}
+                  {info[p.id]
+                    ? Array.from(new Set(info[p.id].tickets.map((t) => t.passenger_id))).length
+                    : ""}
                 </td>
-                <td>{(p.seats || []).join(", ")}</td>
+                <td>{info[p.id] ? info[p.id].tickets.length : ""}</td>
+                <td>
+                  {info[p.id]
+                    ? Array.from(
+                        new Set(
+                          info[p.id].tickets.map((t) => formatDateShort(t.tour_date))
+                        )
+                      ).join(", ")
+                    : ""}
+                </td>
                 <td>{p.amount_due}</td>
                 <td>{p.status}</td>
-                <td>{formatDeadline(p.deadline)}</td>
                 <td>{p.payment_method}</td>
                 <td>
                   <button onClick={() => toggleInfo(p.id)}>
-                    {info[p.id] ? "Hide" : "Info"}
+                    {expanded[p.id] ? "Скрыть" : "Детали"}
                   </button>
                   {p.status === "reserved" && (
                     <>
@@ -114,25 +128,69 @@ export default function PurchasesPage() {
                   )}
                 </td>
               </tr>
-              {info[p.id] && (
+              {expanded[p.id] && info[p.id] && (
                 <tr>
                   <td colSpan="9">
-                    <strong>Sales:</strong>
-                    <ul>
-                      {info[p.id].sales.map((s) => (
-                        <li key={s.id}>
-                          {new Date(s.date).toLocaleString('ru-RU')} - {s.category} {s.amount}
-                        </li>
-                      ))}
-                    </ul>
-                    <strong>Tickets:</strong>
-                    <ul>
-                      {info[p.id].tickets.map((t) => (
-                        <li key={t.id}>
-                          Ticket {t.id}: seat {t.seat_num}, passenger {t.passenger_name}
-                        </li>
-                      ))}
-                    </ul>
+                    <div>
+                      <strong>Пассажиры и билеты:</strong>
+                      <table border="1" cellPadding="4">
+                        <thead>
+                          <tr>
+                            <th>Пассажир</th>
+                            <th>Туда</th>
+                            <th>Обратно</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {(() => {
+                            const byPassenger = {};
+                            info[p.id].tickets.forEach((t) => {
+                              if (!byPassenger[t.passenger_name]) byPassenger[t.passenger_name] = [];
+                              byPassenger[t.passenger_name].push(t);
+                            });
+                            return Object.entries(byPassenger).map(([name, tickets]) => {
+                              tickets.sort(
+                                (a, b) => new Date(a.tour_date) - new Date(b.tour_date)
+                              );
+                              const formatTicket = (tt) =>
+                                tt
+                                  ? `${formatDateShort(tt.tour_date)}, ${tt.seat_num}, багаж ${
+                                      tt.extra_baggage ? "✓" : "✗"
+                                    }`
+                                  : "";
+                              return (
+                                <tr key={name}>
+                                  <td>{name}</td>
+                                  <td>{formatTicket(tickets[0])}</td>
+                                  <td>{formatTicket(tickets[1])}</td>
+                                </tr>
+                              );
+                            });
+                          })()}
+                        </tbody>
+                      </table>
+                      <strong>Логи (sales):</strong>
+                      <table border="1" cellPadding="4">
+                        <thead>
+                          <tr>
+                            <th>Событие</th>
+                            <th>Дата/время</th>
+                            <th>Способ оплаты</th>
+                            <th>Сумма</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {info[p.id].sales.map((s) => (
+                            <tr key={s.id}>
+                              <td>{s.category}</td>
+                              <td>{new Date(s.date).toLocaleString('ru-RU')}</td>
+                              <td>{s.comment || ""}</td>
+                              <td>{s.amount}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
                   </td>
                 </tr>
               )}

--- a/tests/test_admin_purchases.py
+++ b/tests/test_admin_purchases.py
@@ -35,6 +35,7 @@ class DummyCursor:
             return [(
                 1,
                 10,
+                datetime(2025, 8, 10).date(),
                 5,
                 12,
                 2,


### PR DESCRIPTION
## Summary
- show passenger and ticket counts with flight dates on purchases page
- include ticket tour dates in purchase info API
- adjust admin purchase test data

## Testing
- `pytest -q`
- `cd frontend && CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6895ccdc5980832789c21b8c9fe58c34