### PR TITLE
Handle wildcard CORS origins via environment variable

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -34,11 +34,16 @@ def health() -> dict[str, str]:
     """Simple health check returning API status."""
     return {"status": "ok"}
 
-# Настраиваем CORS с помощью переменной окружения
-cors_origins = os.environ.get(
+# Настраиваем CORS из переменной окружения. Значение может быть
+# списком адресов через запятую либо "*" для разрешения всех источников.
+cors_origins = os.getenv(
     "CORS_ORIGINS", "http://localhost:3000,http://localhost:3001"
 )
-origins = [origin.strip() for origin in cors_origins.split(",") if origin.strip()]
+if cors_origins.strip() == "*":
+    origins = ["*"]
+else:
+    origins = [origin.strip() for origin in cors_origins.split(",") if origin.strip()]
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,


### PR DESCRIPTION
## Summary
- Parse `CORS_ORIGINS` env var, allowing `"*"` for any origin
- Configure FastAPI's CORS middleware once with the parsed origins

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899a5c9d5ec83278ecc3b570e8662d6