### PR TITLE
Allow public tour search

### DIFF
--- a/tests/test_public_search.py
+++ b/tests/test_public_search.py
@@ -1,0 +1,73 @@
+import importlib
+import os
+import sys
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyCursor:
+    def __init__(self):
+        self.query = ""
+
+    def execute(self, query, params=None):
+        self.query = query
+
+    def fetchall(self):
+        # Return one dummy tour row
+        return [(1, date(2024, 1, 1), 5, 1)]
+
+    def close(self):
+        pass
+
+
+class DummyConn:
+    def __init__(self):
+        self.cursor_obj = DummyCursor()
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client(monkeypatch):
+    def fake_conn(*args, **kwargs):
+        return DummyConn()
+
+    monkeypatch.setattr('psycopg2.connect', fake_conn)
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+    import backend.database
+    monkeypatch.setattr('backend.database.get_connection', fake_conn)
+    if 'backend.main' in sys.modules:
+        importlib.reload(sys.modules['backend.main'])
+    else:
+        importlib.import_module('backend.main')
+    app = sys.modules['backend.main'].app
+    monkeypatch.setattr('backend.routers.tour.get_connection', fake_conn)
+    return TestClient(app)
+
+
+def test_tours_search_public(client):
+    resp = client.get('/tours/search', params={
+        'departure_stop_id': 1,
+        'arrival_stop_id': 2,
+        'date': '2024-01-01',
+        'seats': 1
+    })
+    assert resp.status_code == 200
+    assert resp.json() == [{
+        'id': 1,
+        'date': '2024-01-01',
+        'seats': 5,
+        'layout_variant': 1
+    }]


### PR DESCRIPTION
## Summary
- remove router-wide admin dependency from `/tours`
- require admin token on individual tour management endpoints
- add regression test ensuring `/tours/search` works without authentication

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899d51bac948327a3d3c46065c091cc