### PR TITLE
Fix admin purchase list duplication for round trips

### DIFF
--- a/tests/test_admin_purchases.py
+++ b/tests/test_admin_purchases.py
@@ -15,17 +15,14 @@ class DummyCursor:
         return None
     def fetchall(self):
         if "FROM purchase" in self.query:
+            # The admin purchase list now returns one row per purchase without
+            # joining ticket data. The dummy row mimics the new column order.
             return [(
                 1,
                 datetime(2025, 8, 10, 10, 0, 0),
                 "Ivan",
                 "ivan@example.com",
                 "+123",
-                datetime(2025, 8, 10).date(),
-                "Route",
-                "A",
-                "B",
-                [12],
                 52.0,
                 "reserved",
                 datetime(2025, 8, 9, 12, 0, 0),


### PR DESCRIPTION
## Summary
- simplify admin purchase list query to return one row per purchase, avoiding duplicates for return trips
- adjust admin purchases test stub for new query format

## Testing
- `pip install -r requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899d43fdd648327aac5cd1e36f6512e