### PR TITLE
feat: unify button styles and chips

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -382,7 +382,48 @@ tbody tr:hover {
 .field input, .field textarea { border:1px solid #dfe3ee; border-radius:10px; padding:10px 12px; outline:none; }
 .field input:focus, .field textarea:focus { border-color:#2947d3; box-shadow:0 0 0 3px rgba(41,71,211,.12); }
 .actions { display:flex; gap:8px; justify-content:flex-end; }
-.btn { padding:8px 12px; border:1px solid #d1d5db; background:#fff; border-radius:10px; cursor:pointer; }
-.btn.primary { border-color:#1f4bd8; color:#fff; background:#1f4bd8; }
-.btn.primary:hover { filter:brightness(0.95); }
 .create-wrap { margin-top:18px; display:flex; flex-direction:column; gap:12px; }
+
+/* ===== КНОПКИ (текстовые) ===== */
+.btn {
+  display:inline-flex; align-items:center; gap:8px;
+  padding:8px 12px; border-radius:10px;
+  border:1px solid #d1d5db; background:#fff; color:#1f2937;
+  font:14px/1.2 system-ui, -apple-system, Arial; cursor:pointer;
+  transition:background .12s, border-color .12s, color .12s, transform .02s;
+}
+.btn:hover { background:#f9fafb; }
+.btn:active { transform:translateY(1px); }
+.btn:disabled { opacity:.55; cursor:not-allowed; }
+
+/* варианты */
+.btn--primary   { border-color:#1f4bd8; color:#1f4bd8; }
+.btn--primary:hover { background:#f2f5ff; }
+.btn--success   { border-color:#159957; color:#159957; }
+.btn--warning   { border-color:#b26a00; color:#b26a00; }
+.btn--danger    { border-color:#b91c1c; color:#b91c1c; }
+.btn--ghost     { border-color:transparent; background:transparent; color:#374151; }
+.btn--ghost:hover { background:#f3f4f6; }
+
+/* размеры */
+.btn--sm { padding:6px 10px; font-size:13px; }
+.btn--lg { padding:10px 16px; font-size:15px; }
+
+/* ===== ЧИПЫ (для маршрута/прайслиста/статусов) ===== */
+.chip{
+  display:inline-flex; align-items:center; gap:6px;
+  padding:5px 10px; border-radius:999px; border:1px solid #e5e7eb;
+  background:#fff; color:#111827; font:13px/1 system-ui, Arial;
+}
+.chip--muted   { background:#f9fafb; color:#4b5563; }
+.chip--route   { background:#eef4ff; color:#1f4bd8; border-color:#dbe4ff; }
+.chip--price   { background:#f5fff6; color:#159957; border-color:#d9f7e6; }
+.chip--status-reserved { background:#fff7e6; color:#b26a00; border-color:#fde6bd; }
+.chip--status-paid     { background:#eafff3; color:#117a37; border-color:#cbf1db; }
+
+/* ===== INPUT ===== */
+.input{
+  border:1px solid #d1d5db; border-radius:10px; padding:8px 10px;
+  background:#fff; font:14px system-ui, Arial; min-width:140px;
+}
+.input:focus{ outline:none; border-color:#1f4bd8; box-shadow:0 0 0 3px rgba(31,75,216,.12); }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -81,7 +81,7 @@ function App() {
             </NavLink>
           </li>
           <li>
-            <button onClick={handleLogout}>Logout</button>
+            <button className="btn btn--ghost btn--sm" onClick={handleLogout}>Logout</button>
           </li>
         </ul>
       </nav>

--- a/frontend/src/pages/RoutesPage.js
+++ b/frontend/src/pages/RoutesPage.js
@@ -18,8 +18,6 @@ import {
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-import deleteIcon from "../assets/icons/delete.png";
-
 export default function RoutesPage() {
   const [routes, setRoutes] = useState([]);
   const [stops, setStops] = useState([]);
@@ -73,6 +71,20 @@ export default function RoutesPage() {
         setRouteStops([]);
       }
     });
+  };
+
+  const handleRenameRoute = (route) => {
+    const name = prompt("Новое название", route.name);
+    if (!name || !name.trim() || name === route.name) return;
+    axios
+      .put(`${API}/routes/${route.id}`, { name, is_demo: route.is_demo })
+      .then((res) => {
+        setRoutes(routes.map((r) => (r.id === route.id ? res.data : r)));
+        if (selectedRoute && selectedRoute.id === route.id) {
+          setSelectedRoute(res.data);
+        }
+      })
+      .catch((err) => console.error("Ошибка переименования маршрута:", err));
   };
 
   const handleToggleDemo = (route) => {
@@ -188,16 +200,17 @@ export default function RoutesPage() {
     <div className="container">
       <h1>Маршруты</h1>
   
-      <div className="routes-wrapper">
+      <ul className="routes-wrapper" style={{ listStyle: 'none', padding: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
         {routes.map((route) => (
-          <div key={route.id} className="route-item">
-            <button
-              className={`route-btn ${selectedRoute?.id === route.id ? "active" : ""}`}
+          <li key={route.id} className="card-row" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span
+              className="chip chip--route"
+              style={{ cursor: 'pointer' }}
               onClick={() => handleSelectRoute(route)}
             >
               {route.name}
-            </button>
-            <label style={{ marginLeft: '4px' }}>
+            </span>
+            <label className="chip chip--muted">
               <input
                 type="checkbox"
                 checked={route.is_demo}
@@ -206,26 +219,25 @@ export default function RoutesPage() {
               />
               demo
             </label>
-            <button
-              className="icon-btn"
-              onClick={() => handleDeleteRoute(route.id)}
-            >
-              <img src={deleteIcon} alt="Удалить маршрут" width={20} />
-            </button>
-          </div>
+            <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
+              <button className="btn btn--primary btn--sm" onClick={() => handleRenameRoute(route)}>Переименовать</button>
+              <button className="btn btn--danger btn--sm" onClick={() => handleDeleteRoute(route.id)}>Удалить</button>
+            </div>
+          </li>
         ))}
-      </div>
+      </ul>
 
   
-      <div style={{ marginBottom: "2rem", display: 'flex', gap: '8px' }}>
+      <form onSubmit={e => { e.preventDefault(); handleCreateRoute(); }} style={{ marginBottom: "2rem", display: 'flex', gap: '8px' }}>
         <input
+          className="input"
           type="text"
           placeholder="Название маршрута"
           value={newRouteName}
           onChange={(e) => setNewRouteName(e.target.value)}
         />
-        <button onClick={handleCreateRoute}>Создать</button>
-      </div>
+        <button className="btn btn--success">Создать</button>
+      </form>
   
       {selectedRoute && (
         <>
@@ -256,6 +268,7 @@ export default function RoutesPage() {
           <h3>Добавить остановку</h3>
           <form onSubmit={handleAddStop} className="add-stop-form">
             <select
+              className="input"
               value={newStop.stop_id}
               onChange={(e) => setNewStop({ ...newStop, stop_id: e.target.value })}
             >
@@ -265,16 +278,18 @@ export default function RoutesPage() {
               ))}
             </select>
             <input
+              className="input"
               type="time"
               value={newStop.arrival_time}
               onChange={(e) => setNewStop({ ...newStop, arrival_time: e.target.value })}
             />
             <input
+              className="input"
               type="time"
               value={newStop.departure_time}
               onChange={(e) => setNewStop({ ...newStop, departure_time: e.target.value })}
             />
-            <button type="submit">Добавить остановку</button>
+            <button type="submit" className="btn btn--success btn--sm">Добавить остановку</button>
           </form>
         </>
       )}
@@ -332,9 +347,9 @@ function SortableStop({ id, routeStop, getStopName, onDeleteStop, onUpdateTime }
           e.stopPropagation();
           onDeleteStop(id);
         }}
-        className="icon-btn"
+        className="btn btn--danger btn--sm"
       >
-        <img src={deleteIcon} alt="Удалить" width="20"/>
+        Удалить
       </button>
     </div>
   );

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -312,8 +312,12 @@ export default function SearchPage() {
   return (
     <div className="container" style={{ padding: 20 }}>
       <h2>Поиск рейсов</h2>
-      <form onSubmit={handleSearchTours} style={{ display:"flex", gap:8, marginBottom:20, flexWrap:'wrap' }}>
+      <form
+        onSubmit={handleSearchTours}
+        style={{ display: 'flex', gap: 10, flexWrap: 'wrap', alignItems: 'center', marginBottom: 20 }}
+      >
         <select
+          className="input"
           value={selectedDeparture}
           onChange={e => setSelectedDeparture(e.target.value)}
         >
@@ -324,6 +328,7 @@ export default function SearchPage() {
         </select>
 
         <select
+          className="input"
           value={selectedArrival}
           onChange={e => setSelectedArrival(e.target.value)}
           disabled={!selectedDeparture}
@@ -335,6 +340,7 @@ export default function SearchPage() {
         </select>
 
         <input
+          className="input"
           type="number"
           min="1"
           value={seatCount}
@@ -343,6 +349,7 @@ export default function SearchPage() {
         />
 
         <input
+          className="input"
           type="text"
           readOnly
           placeholder="Дата туда"
@@ -351,6 +358,7 @@ export default function SearchPage() {
         />
 
         <input
+          className="input"
           type="text"
           readOnly
           placeholder="Дата обратно"
@@ -364,7 +372,7 @@ export default function SearchPage() {
           disabled={!returnDates.length}
         />
 
-        <button type="submit">Найти</button>
+        <button type="submit" className="btn btn--primary">Поиск</button>
       </form>
 
       {showDepartCal && (

--- a/frontend/src/pages/ToursPage.js
+++ b/frontend/src/pages/ToursPage.js
@@ -9,10 +9,6 @@ import BusLayoutNeoplan from "../components/busLayouts/BusLayoutNeoplan";
 import BusLayoutTravego  from "../components/busLayouts/BusLayoutTravego";
 import SeatAdmin         from "../components/SeatAdmin";
 
-import editIcon   from "../assets/icons/edit.png";
-import deleteIcon from "../assets/icons/delete.png";
-import saveIcon   from "../assets/icons/save.png";
-import cancelIcon from "../assets/icons/cancel.png";
 
 const BOOKING_OPTIONS = [
   { value: 0, label: "Сгорает через 48 ч после бронирования" },
@@ -64,16 +60,6 @@ export default function ToursPage() {
 
   // — force‐reload key for SeatAdmin —
   const [seatReload, setSeatReload] = useState(0);
-
-  // — icon button styles —
-  const iconBtn = {
-    width:40, height:40, margin:"0 4px", padding:0,
-    backgroundColor:"#f0f0f5", border:"1px solid #ccc",
-    borderRadius:4, display:"inline-flex", alignItems:"center",
-    justifyContent:"center", cursor:"pointer",
-    transition:"background-color .2s, transform .1s"
-  };
-  const iconImg = { width:20, height:20 };
 
   const fetchTours = (pageParam = page) => {
     const params = {
@@ -278,21 +264,21 @@ export default function ToursPage() {
       <h2>Рейсы</h2>
 
       <div style={{ margin: '16px 0' }}>
-        <button onClick={()=>switchTab('upcoming')} disabled={tab==='upcoming'}>Предстоящие</button>
-        <button onClick={()=>switchTab('past')} disabled={tab==='past'} style={{marginLeft:8}}>Прошедшие</button>
+        <button className="btn btn--ghost btn--sm" onClick={()=>switchTab('upcoming')} disabled={tab==='upcoming'}>Предстоящие</button>
+        <button className="btn btn--ghost btn--sm" onClick={()=>switchTab('past')} disabled={tab==='past'} style={{marginLeft:8}}>Прошедшие</button>
       </div>
 
       <form onSubmit={applyFilters} style={{ display:'flex', gap:8, flexWrap:'wrap', marginBottom:20 }}>
-        <input type="date" value={filterDate} onChange={e=>setFilterDate(e.target.value)} />
-        <select value={filterRoute} onChange={e=>setFilterRoute(e.target.value)}>
+        <input className="input" type="date" value={filterDate} onChange={e=>setFilterDate(e.target.value)} />
+        <select className="input" value={filterRoute} onChange={e=>setFilterRoute(e.target.value)}>
           <option value="">Маршрут</option>
           {routes.map(r=><option key={r.id} value={r.id}>{r.name}</option>)}
         </select>
-        <select value={filterBooking} onChange={e=>setFilterBooking(e.target.value)}>
+        <select className="input" value={filterBooking} onChange={e=>setFilterBooking(e.target.value)}>
           <option value="">Условия брони</option>
           {BOOKING_OPTIONS.map(o=>(<option key={o.value} value={o.value}>{o.label}</option>))}
         </select>
-        <button type="submit">Поиск</button>
+        <button type="submit" className="btn btn--primary btn--sm">Поиск</button>
       </form>
 
       {/* — Tours list — */}
@@ -310,30 +296,33 @@ export default function ToursPage() {
                 <td>
                   {editing
                     ? <select
+                        className="input"
                         value={editingTourData.route_id}
                         onChange={e=>setEditingTourData({...editingTourData,route_id:e.target.value})}
                       >
                         <option value="">—</option>
                         {routes.map(r=><option key={r.id} value={r.id}>{r.name}</option>)}
                       </select>
-                    : routes.find(r=>r.id===t.route_id)?.name || "-"
+                    : <span className="chip chip--route">{routes.find(r=>r.id===t.route_id)?.name || "-"}</span>
                   }
                 </td>
                 <td>
                   {editing
                     ? <select
+                        className="input"
                         value={editingTourData.pricelist_id}
                         onChange={e=>setEditingTourData({...editingTourData,pricelist_id:e.target.value})}
                       >
                         <option value="">—</option>
                         {pricelists.map(p=><option key={p.id} value={p.id}>{p.name}</option>)}
                       </select>
-                    : pricelists.find(p=>p.id===t.pricelist_id)?.name || "-"
+                    : <span className="chip chip--price">{pricelists.find(p=>p.id===t.pricelist_id)?.name || "-"}</span>
                   }
                 </td>
                 <td>
                   {editing
                     ? <input
+                        className="input"
                         type="date"
                         value={editingTourData.date}
                         onChange={e=>setEditingTourData({...editingTourData,date:e.target.value})}
@@ -344,6 +333,7 @@ export default function ToursPage() {
                 <td>
                   {editing
                     ? <select
+                        className="input"
                         value={editingTourData.layout_variant}
                         onChange={e=>setEditingTourData({...editingTourData,layout_variant:e.target.value})}
                       >
@@ -357,6 +347,7 @@ export default function ToursPage() {
                 <td>
                   {editing
                     ? <select
+                        className="input"
                         value={editingTourData.booking_terms}
                         onChange={e=>setEditingTourData({...editingTourData,booking_terms:e.target.value})}
                       >
@@ -369,20 +360,12 @@ export default function ToursPage() {
                 <td>
                   {editing
                     ? <>
-                        <button style={iconBtn} onClick={saveEdit}>
-                          <img style={iconImg} src={saveIcon} alt="Save"/>
-                        </button>
-                        <button style={iconBtn} onClick={cancelEdit}>
-                          <img style={iconImg} src={cancelIcon} alt="Cancel"/>
-                        </button>
+                        <button className="btn btn--primary btn--sm" onClick={saveEdit}>Сохранить</button>
+                        <button className="btn btn--ghost btn--sm" onClick={cancelEdit}>Отмена</button>
                       </>
                     : <>
-                        <button style={iconBtn} onClick={()=>startEdit(t)}>
-                          <img style={iconImg} src={editIcon} alt="Edit"/>
-                        </button>
-                        <button style={iconBtn} onClick={()=>handleDelete(t.id)}>
-                          <img style={iconImg} src={deleteIcon} alt="Delete"/>
-                        </button>
+                        <button className="btn btn--primary btn--sm" onClick={()=>startEdit(t)}>Редактировать</button>
+                        <button className="btn btn--danger btn--sm" onClick={()=>handleDelete(t.id)}>Удалить</button>
                       </>
                   }
                 </td>
@@ -392,17 +375,17 @@ export default function ToursPage() {
         </tbody>
       </table>
 
-      <div style={{ margin: '16px 0' }}>
-        <button disabled={page===1} onClick={()=>setPage(p=>p-1)}>Назад</button>
+      <div style={{ margin: '16px 0', display:'flex', alignItems:'center', gap:4 }}>
+        <button className="btn btn--sm" disabled={page===1} onClick={()=>setPage(p=>p-1)}>Назад</button>
         {Array.from({length: totalPages}, (_, i) => (
           <button
+            className="btn btn--sm"
             key={i+1}
             disabled={page===i+1}
             onClick={()=>setPage(i+1)}
-            style={{ marginLeft:4 }}
           >{i+1}</button>
         ))}
-        <button disabled={page===totalPages || totalPages===0} onClick={()=>setPage(p=>p+1)} style={{marginLeft:4}}>Вперёд</button>
+        <button className="btn btn--sm" disabled={page===totalPages || totalPages===0} onClick={()=>setPage(p=>p+1)}>Вперёд</button>
       </div>
 
       {/* — SeatAdmin with drag‐n‐drop — */}
@@ -488,16 +471,10 @@ export default function ToursPage() {
                     <td>
                       {isEd
                         ? <>
-                            <button style={iconBtn} onClick={saveTicketEdit}>
-                              <img style={iconImg} src={saveIcon} alt="Save"/>
-                            </button>
-                            <button style={iconBtn} onClick={cancelTicketEdit}>
-                              <img style={iconImg} src={cancelIcon} alt="Cancel"/>
-                            </button>
+                            <button className="btn btn--primary btn--sm" onClick={saveTicketEdit}>Сохранить</button>
+                            <button className="btn btn--ghost btn--sm" onClick={cancelTicketEdit}>Отмена</button>
                           </>
-                        : <button style={iconBtn} onClick={()=>startTicketEdit(ticket)}>
-                            <img style={iconImg} src={editIcon} alt="Edit"/>
-                          </button>
+                        : <button className="btn btn--primary btn--sm" onClick={()=>startTicketEdit(ticket)}>Редактировать</button>
                       }
                     </td>
                   </tr>
@@ -509,37 +486,37 @@ export default function ToursPage() {
       )}
 
         <div style={{ marginTop:40 }}>
-          <button onClick={()=>setShowForm(s=>!s)}>{showForm ? 'Скрыть форму' : 'Добавить рейс'}</button>
+          <button className="btn btn--primary" onClick={()=>setShowForm(s=>!s)}>{showForm ? 'Скрыть форму' : 'Добавить рейс'}</button>
           {showForm && (
             <>
               <h3 style={{ marginTop:20 }}>Создать новый рейс</h3>
               <form onSubmit={handleCreate} style={{ display:"flex", gap:8, flexWrap:"wrap" }}>
-                <select required
+                <select className="input" required
                   value={newTour.route_id}
                   onChange={e=>setNewTour({...newTour,route_id:e.target.value})}
                 >
                   <option value="">Маршрут</option>
                   {routes.map(r=><option key={r.id} value={r.id}>{r.name}</option>)}
                 </select>
-                <select required
+                <select className="input" required
                   value={newTour.pricelist_id}
                   onChange={e=>setNewTour({...newTour,pricelist_id:e.target.value})}
                 >
                   <option value="">Прайс-лист</option>
                   {pricelists.map(p=><option key={p.id} value={p.id}>{p.name}</option>)}
                 </select>
-                <input required type="date"
+                <input className="input" required type="date"
                   value={newTour.date}
                   onChange={e=>setNewTour({...newTour,date:e.target.value})}
                 />
-                <select required
+                <select className="input" required
                   value={newTour.booking_terms}
                   onChange={e=>setNewTour({...newTour,booking_terms:e.target.value})}
                 >
                   <option value="">Условия брони</option>
                   {BOOKING_OPTIONS.map(o=>(<option key={o.value} value={o.value}>{o.label}</option>))}
                 </select>
-                <select required
+                <select className="input" required
                   value={newTour.layout_variant}
                   onChange={e=>setNewTour({...newTour,layout_variant:e.target.value})}
                 >
@@ -564,12 +541,7 @@ export default function ToursPage() {
                         />}
                   </div>
                 )}
-                <button type="submit" style={{
-                  padding:"8px 16px", backgroundColor:"#4caf50",
-                  color:"#fff", border:"none", borderRadius:4, cursor:"pointer"
-                }}>
-                  Создать рейс
-                </button>
+                <button type="submit" className="btn btn--success">Создать рейс</button>
               </form>
             </>
           )}


### PR DESCRIPTION
## Summary
- add shared .btn, .chip and .input styles
- switch Tours, Routes and Search pages to new button/chip classes
- use unified logout button styling

## Testing
- `npm test -- --watchAll=false`
- `pytest` *(fails: The starlette.testclient module requires the httpx package to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689b2003050483279f205998f67c95d9