### PR TITLE
Replace text action buttons with icons

### DIFF
--- a/frontend/src/components/IconButton.js
+++ b/frontend/src/components/IconButton.js
@@ -1,8 +1,8 @@
 // src/components/IconButton.js
 import React from 'react';
 
-const IconButton = ({ icon, alt, onClick }) => (
-  <button className="icon-btn" onClick={onClick}>
+const IconButton = ({ icon, alt, onClick, type = "button", className = "" }) => (
+  <button type={type} className={`icon-btn ${className}`.trim()} onClick={onClick}>
     <img src={icon} alt={alt} />
   </button>
 );

--- a/frontend/src/components/SortableStop.jsx
+++ b/frontend/src/components/SortableStop.jsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import IconButton from "./IconButton";
+import deleteIcon from "../assets/icons/delete.png";
 
 export function SortableStop({
   id,
@@ -51,7 +53,11 @@ export function SortableStop({
         />
       </div>
       <div style={{ marginTop: "8px" }}>
-        <button onClick={() => onDeleteStop(routeStop.id)}>Удалить</button>
+        <IconButton
+          icon={deleteIcon}
+          alt="Удалить"
+          onClick={() => onDeleteStop(routeStop.id)}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/PricelistsPage.js
+++ b/frontend/src/pages/PricelistsPage.js
@@ -1,8 +1,11 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
+import IconButton from "../components/IconButton";
 import editIcon from "../assets/icons/edit.png";
 import deleteIcon from "../assets/icons/delete.png";
 import addIcon from "../assets/icons/add.png";
+import saveIcon from "../assets/icons/save.png";
+import cancelIcon from "../assets/icons/cancel.png";
 
 import { API } from "../config";
 
@@ -175,8 +178,8 @@ function PricelistPage() {
                   onChange={e => setEditingPricelistName(e.target.value)}
                   required
                 />
-                <button type="submit">✅</button>
-                <button type="button" onClick={handleCancelEditPricelist}>❌</button>
+                <IconButton type="submit" icon={saveIcon} alt="Сохранить" />
+                <IconButton type="button" onClick={handleCancelEditPricelist} icon={cancelIcon} alt="Отмена" />
               </form>
             ) : (
               <>
@@ -239,8 +242,8 @@ function PricelistPage() {
                   <td className="actions-cell">
                     {editingPriceId === p.id ? (
                       <>
-                        <button onClick={handleUpdatePrice}>✅</button>
-                        <button onClick={() => setEditingPriceId(null)}>❌</button>
+                        <IconButton onClick={handleUpdatePrice} icon={saveIcon} alt="Сохранить" />
+                        <IconButton onClick={() => setEditingPriceId(null)} icon={cancelIcon} alt="Отмена" />
                       </>
                     ) : (
                       <>

--- a/frontend/src/pages/RoutesPage.js
+++ b/frontend/src/pages/RoutesPage.js
@@ -2,6 +2,10 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 
 import { API } from "../config";
+import IconButton from "../components/IconButton";
+import addIcon from "../assets/icons/add.png";
+import editIcon from "../assets/icons/edit.png";
+import deleteIcon from "../assets/icons/delete.png";
 // dnd-kit
 import {
   DndContext,
@@ -220,8 +224,16 @@ export default function RoutesPage() {
               demo
             </label>
             <div style={{ marginLeft: 'auto', display: 'flex', gap: 8 }}>
-              <button className="btn btn--primary btn--sm" onClick={() => handleRenameRoute(route)}>Переименовать</button>
-              <button className="btn btn--danger btn--sm" onClick={() => handleDeleteRoute(route.id)}>Удалить</button>
+              <IconButton
+                icon={editIcon}
+                alt="Переименовать маршрут"
+                onClick={() => handleRenameRoute(route)}
+              />
+              <IconButton
+                icon={deleteIcon}
+                alt="Удалить маршрут"
+                onClick={() => handleDeleteRoute(route.id)}
+              />
             </div>
           </li>
         ))}
@@ -236,7 +248,7 @@ export default function RoutesPage() {
           value={newRouteName}
           onChange={(e) => setNewRouteName(e.target.value)}
         />
-        <button className="btn btn--success">Создать</button>
+        <IconButton type="submit" icon={addIcon} alt="Создать маршрут" className="btn--success" />
       </form>
   
       {selectedRoute && (
@@ -289,7 +301,12 @@ export default function RoutesPage() {
               value={newStop.departure_time}
               onChange={(e) => setNewStop({ ...newStop, departure_time: e.target.value })}
             />
-            <button type="submit" className="btn btn--success btn--sm">Добавить остановку</button>
+            <IconButton
+              type="submit"
+              icon={addIcon}
+              alt="Добавить остановку"
+              className="btn--success btn--sm"
+            />
           </form>
         </>
       )}
@@ -341,16 +358,16 @@ function SortableStop({ id, routeStop, getStopName, onDeleteStop, onUpdateTime }
         />
       </div>
   
-      <button
-        onPointerDown={(e) => e.stopPropagation()}
+      <IconButton
+        className="btn--danger btn--sm"
         onClick={(e) => {
           e.stopPropagation();
           onDeleteStop(id);
         }}
-        className="btn btn--danger btn--sm"
-      >
-        Удалить
-      </button>
+        onPointerDown={(e) => e.stopPropagation()}
+        icon={deleteIcon}
+        alt="Удалить остановку"
+      />
     </div>
   );
   

--- a/frontend/src/pages/StopsPage.js
+++ b/frontend/src/pages/StopsPage.js
@@ -6,6 +6,8 @@ import IconButton from "../components/IconButton";
 import editIcon from "../assets/icons/edit.png";
 import deleteIcon from "../assets/icons/delete.png";
 import addIcon from "../assets/icons/add.png";
+import saveIcon from "../assets/icons/save.png";
+import cancelIcon from "../assets/icons/cancel.png";
 
 const LANGS = ["ru", "en", "bg", "ua"];
 
@@ -39,7 +41,7 @@ function useLangNames(initial) {
   return { names, setFor, packToPayload };
 }
 
-function StopForm({ initial, onSubmit, onCancel, submitText = "Сохранить" }) {
+function StopForm({ initial, onSubmit, onCancel, submitIcon, submitAlt }) {
   const [active, setActive] = useState("ru");
   const { names, setFor, packToPayload } = useLangNames(initial || emptyStop);
   const [description, setDescription] = useState(initial.description || "");
@@ -103,7 +105,7 @@ function StopForm({ initial, onSubmit, onCancel, submitText = "Сохранит�
       </div>
 
       <div className="actions">
-        <button className="btn primary" type="submit">{submitText}</button>
+        <IconButton type="submit" icon={submitIcon} alt={submitAlt} />
         {onCancel && (
           <button className="btn" type="button" onClick={onCancel}>
             Отмена
@@ -158,7 +160,8 @@ export default function StopsPage() {
                 initial={stop}
                 onSubmit={handleUpdate}
                 onCancel={() => setEditingId(null)}
-                submitText="Сохранить"
+                submitIcon={saveIcon}
+                submitAlt="Сохранить"
               />
             ) : (
               <>
@@ -197,19 +200,19 @@ export default function StopsPage() {
       </ul>
 
       <div className="create-wrap">
-        <button
-          className="btn primary"
+        <IconButton
+          icon={creatingOpen ? cancelIcon : addIcon}
+          alt={creatingOpen ? "Скрыть" : "Добавить остановку"}
           onClick={() => setCreatingOpen((v) => !v)}
-        >
-          {creatingOpen ? "Скрыть" : "Добавить остановку"}
-        </button>
+        />
 
         {creatingOpen && (
           <div className="card-row">
             <StopForm
               initial={emptyStop}
               onSubmit={handleCreate}
-              submitText="Добавить"
+              submitIcon={addIcon}
+              submitAlt="Добавить"
             />
           </div>
         )}

--- a/frontend/src/pages/ToursPage.js
+++ b/frontend/src/pages/ToursPage.js
@@ -4,6 +4,12 @@ import React, { useState, useEffect } from "react";
 import axios from "axios";
 
 import { API } from "../config";
+import IconButton from "../components/IconButton";
+import editIcon from "../assets/icons/edit.png";
+import deleteIcon from "../assets/icons/delete.png";
+import saveIcon from "../assets/icons/save.png";
+import addIcon from "../assets/icons/add.png";
+import cancelIcon from "../assets/icons/cancel.png";
 
 import BusLayoutNeoplan from "../components/busLayouts/BusLayoutNeoplan";
 import BusLayoutTravego  from "../components/busLayouts/BusLayoutTravego";
@@ -360,12 +366,12 @@ export default function ToursPage() {
                 <td>
                   {editing
                     ? <>
-                        <button className="btn btn--primary btn--sm" onClick={saveEdit}>Сохранить</button>
-                        <button className="btn btn--ghost btn--sm" onClick={cancelEdit}>Отмена</button>
+                        <IconButton className="btn--primary btn--sm" onClick={saveEdit} icon={saveIcon} alt="Сохранить" />
+                        <IconButton className="btn--ghost btn--sm" onClick={cancelEdit} icon={cancelIcon} alt="Отмена" />
                       </>
                     : <>
-                        <button className="btn btn--primary btn--sm" onClick={()=>startEdit(t)}>Редактировать</button>
-                        <button className="btn btn--danger btn--sm" onClick={()=>handleDelete(t.id)}>Удалить</button>
+                        <IconButton className="btn--primary btn--sm" onClick={()=>startEdit(t)} icon={editIcon} alt="Редактировать" />
+                        <IconButton className="btn--danger btn--sm" onClick={()=>handleDelete(t.id)} icon={deleteIcon} alt="Удалить" />
                       </>
                   }
                 </td>
@@ -471,10 +477,10 @@ export default function ToursPage() {
                     <td>
                       {isEd
                         ? <>
-                            <button className="btn btn--primary btn--sm" onClick={saveTicketEdit}>Сохранить</button>
-                            <button className="btn btn--ghost btn--sm" onClick={cancelTicketEdit}>Отмена</button>
+                            <IconButton className="btn--primary btn--sm" onClick={saveTicketEdit} icon={saveIcon} alt="Сохранить" />
+                            <IconButton className="btn--ghost btn--sm" onClick={cancelTicketEdit} icon={cancelIcon} alt="Отмена" />
                           </>
-                        : <button className="btn btn--primary btn--sm" onClick={()=>startTicketEdit(ticket)}>Редактировать</button>
+                        : <IconButton className="btn--primary btn--sm" onClick={()=>startTicketEdit(ticket)} icon={editIcon} alt="Редактировать" />
                       }
                     </td>
                   </tr>
@@ -486,7 +492,12 @@ export default function ToursPage() {
       )}
 
         <div style={{ marginTop:40 }}>
-          <button className="btn btn--primary" onClick={()=>setShowForm(s=>!s)}>{showForm ? 'Скрыть форму' : 'Добавить рейс'}</button>
+          <IconButton
+            className="btn--primary"
+            icon={showForm ? cancelIcon : addIcon}
+            alt={showForm ? 'Скрыть форму' : 'Добавить рейс'}
+            onClick={()=>setShowForm(s=>!s)}
+          />
           {showForm && (
             <>
               <h3 style={{ marginTop:20 }}>Создать новый рейс</h3>
@@ -541,7 +552,7 @@ export default function ToursPage() {
                         />}
                   </div>
                 )}
-                <button type="submit" className="btn btn--success">Создать рейс</button>
+                <IconButton type="submit" icon={addIcon} alt="Создать рейс" className="btn--success" />
               </form>
             </>
           )}


### PR DESCRIPTION
## Summary
- render IconButton with configurable type and classes
- switch add/edit/delete/save buttons to icons across stops, routes, pricelists and tours pages
- use icon for removable stop in SortableStop component

## Testing
- `cd frontend && CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b25e100188327b80d6b136686cb6c