### PR TITLE
Add discounted ticket pricing support

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -71,6 +71,7 @@ class PricesBase(BaseModel):
     departure_stop_id: int
     arrival_stop_id: int
     price: float
+    discount_price: Optional[float] = None
 
 class PricesCreate(PricesBase):
     pass
@@ -143,6 +144,7 @@ class TicketBase(BaseModel):
     arrival_stop_id: int
     purchase_id: Optional[int] = None
     extra_baggage: int = 0
+    discounted: bool = False
 
 class TicketCreate(TicketBase):
     pass
@@ -252,6 +254,7 @@ class PriceLocalized(BaseModel):
     arrival_stop_id: int
     arrival_name: str
     price: float
+    discount_price: Optional[float] = None
 
 class PricelistBundleOut(BaseModel):
     pricelist_id: int

--- a/backend/routers/bundle.py
+++ b/backend/routers/bundle.py
@@ -174,7 +174,8 @@ def selected_pricelist(data: LangRequest):
             f"""
             SELECT p.departure_stop_id, COALESCE(s1.{col}, s1.stop_name),
                    p.arrival_stop_id, COALESCE(s2.{col}, s2.stop_name),
-                   p.price
+                   p.price,
+                   p.discount_price
               FROM prices p
               JOIN stop s1 ON s1.id=p.departure_stop_id
               JOIN stop s2 ON s2.id=p.arrival_stop_id
@@ -190,6 +191,7 @@ def selected_pricelist(data: LangRequest):
                 "arrival_stop_id": r[2],
                 "arrival_name": r[3],
                 "price": r[4],
+                "discount_price": r[5],
             }
             for r in cur.fetchall()
         ]

--- a/backend/routers/prices.py
+++ b/backend/routers/prices.py
@@ -21,13 +21,14 @@ def get_prices(pricelist_id: int = None):
     if pricelist_id is not None:
         cur.execute(
             """
-            SELECT p.id,
+           SELECT p.id,
                    p.pricelist_id,
                    p.departure_stop_id,
                    s1.stop_name AS departure_name,
                    p.arrival_stop_id,
                    s2.stop_name AS arrival_name,
-                   p.price
+                   p.price,
+                   p.discount_price
             FROM prices p
             JOIN stop s1 ON p.departure_stop_id = s1.id
             JOIN stop s2 ON p.arrival_stop_id = s2.id
@@ -39,13 +40,14 @@ def get_prices(pricelist_id: int = None):
     else:
         cur.execute(
             """
-            SELECT p.id,
+           SELECT p.id,
                    p.pricelist_id,
                    p.departure_stop_id,
                    s1.stop_name AS departure_name,
                    p.arrival_stop_id,
                    s2.stop_name AS arrival_name,
-                   p.price
+                   p.price,
+                   p.discount_price
             FROM prices p
             JOIN stop s1 ON p.departure_stop_id = s1.id
             JOIN stop s2 ON p.arrival_stop_id = s2.id
@@ -66,7 +68,8 @@ def get_prices(pricelist_id: int = None):
             "departure_stop_name": row[3],
             "arrival_stop_id": row[4],
             "arrival_stop_name": row[5],
-            "price": row[6]
+            "price": row[6],
+            "discount_price": row[7]
         })
     return result
 
@@ -80,8 +83,8 @@ def create_price(price_data: PricesCreate):
     try:
         cur.execute(
             """
-            INSERT INTO prices (pricelist_id, departure_stop_id, arrival_stop_id, price)
-            VALUES (%s, %s, %s, %s)
+            INSERT INTO prices (pricelist_id, departure_stop_id, arrival_stop_id, price, discount_price)
+            VALUES (%s, %s, %s, %s, %s)
             RETURNING id;
             """,
             (
@@ -89,6 +92,7 @@ def create_price(price_data: PricesCreate):
                 price_data.departure_stop_id,
                 price_data.arrival_stop_id,
                 price_data.price,
+                price_data.discount_price,
             )
         )
         new_id = cur.fetchone()[0]
@@ -115,15 +119,17 @@ def update_price(price_id: int, price_data: PricesCreate):
             SET pricelist_id = %s,
                 departure_stop_id = %s,
                 arrival_stop_id = %s,
-                price = %s
+                price = %s,
+                discount_price = %s
             WHERE id = %s
-            RETURNING id, pricelist_id, departure_stop_id, arrival_stop_id, price;
+            RETURNING id, pricelist_id, departure_stop_id, arrival_stop_id, price, discount_price;
             """,
             (
                 price_data.pricelist_id,
                 price_data.departure_stop_id,
                 price_data.arrival_stop_id,
                 price_data.price,
+                price_data.discount_price,
                 price_id
             )
         )
@@ -136,7 +142,8 @@ def update_price(price_id: int, price_data: PricesCreate):
             "pricelist_id": updated_row[1],
             "departure_stop_id": updated_row[2],
             "arrival_stop_id": updated_row[3],
-            "price": updated_row[4]
+            "price": updated_row[4],
+            "discount_price": updated_row[5]
         }
     except Exception as e:
         conn.rollback()

--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -17,6 +17,7 @@ class PurchaseCreate(BaseModel):
     departure_stop_id: int
     arrival_stop_id: int
     extra_baggage: list[bool] | None = None
+    discounted: list[bool] | None = None
     purchase_id: int | None = None
 
 class PurchaseOut(BaseModel):
@@ -53,6 +54,9 @@ def _create_purchase(
     baggage_list = data.extra_baggage or [False] * len(data.seat_nums)
     if len(baggage_list) != len(data.seat_nums):
         raise HTTPException(400, "Seat numbers and extra baggage count mismatch")
+    discounted_list = data.discounted or [False] * len(data.seat_nums)
+    if len(discounted_list) != len(data.seat_nums):
+        raise HTTPException(400, "Seat numbers and discounted flags count mismatch")
 
     # Determine route/pricelist and ordered stops
     cur.execute("SELECT route_id, pricelist_id FROM tour WHERE id=%s", (data.tour_id,))
@@ -76,7 +80,7 @@ def _create_purchase(
 
     cur.execute(
         """
-        SELECT price FROM prices
+        SELECT price, discount_price FROM prices
          WHERE pricelist_id=%s AND departure_stop_id=%s AND arrival_stop_id=%s
         """,
         (pricelist_id, data.departure_stop_id, data.arrival_stop_id),
@@ -85,9 +89,15 @@ def _create_purchase(
     if not price_row:
         raise HTTPException(404, "Price not found")
     base_price = float(price_row[0])
-    total_price = base_price * (
-        len(data.seat_nums) + 0.1 * sum(1 for b in baggage_list if b)
+    discount_price = (
+        float(price_row[1]) if price_row[1] is not None else base_price
     )
+    total_price = 0.0
+    for disc, bag in zip(discounted_list, baggage_list):
+        seat_price = discount_price if disc else base_price
+        if bag:
+            seat_price *= 1.1
+        total_price += seat_price
     total_price = round(total_price, 2)
 
     purchase_id = data.purchase_id
@@ -136,7 +146,7 @@ def _create_purchase(
         purchase_id = cur.fetchone()[0]
 
     # 2) create passenger and ticket for each seat
-    for seat_num, name, bag in zip(data.seat_nums, data.passenger_names, baggage_list):
+    for seat_num, name, bag, disc in zip(data.seat_nums, data.passenger_names, baggage_list, discounted_list):
         cur.execute(
             "INSERT INTO passenger (name) VALUES (%s) RETURNING id",
             (name,),
@@ -162,8 +172,8 @@ def _create_purchase(
         cur.execute(
             """
             INSERT INTO ticket
-              (tour_id, seat_id, passenger_id, departure_stop_id, arrival_stop_id, purchase_id, extra_baggage)
-            VALUES (%s,%s,%s,%s,%s,%s,%s)
+              (tour_id, seat_id, passenger_id, departure_stop_id, arrival_stop_id, purchase_id, extra_baggage, discounted)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s)
             RETURNING id
             """,
             (
@@ -174,6 +184,7 @@ def _create_purchase(
                 data.arrival_stop_id,
                 purchase_id,
                 int(bag),
+                disc,
             ),
         )
         cur.fetchone()

--- a/backend/routers/report.py
+++ b/backend/routers/report.py
@@ -76,7 +76,7 @@ def get_report(filters: ReportFilters):
         summary_query = f"""
             SELECT 
                 COUNT(*) AS total_tickets,
-                COALESCE(SUM(pr.price), 0) AS total_sales
+                COALESCE(SUM(CASE WHEN t.discounted THEN COALESCE(pr.discount_price, pr.price) ELSE pr.price END), 0) AS total_sales
             FROM ticket t
             JOIN tour tr ON t.tour_id = tr.id
             JOIN route r ON tr.route_id = r.id
@@ -102,7 +102,7 @@ def get_report(filters: ReportFilters):
                 t.id AS ticket_id,
                 t.tour_id,
                 s.seat_num,
-                pr.price,
+                CASE WHEN t.discounted THEN COALESCE(pr.discount_price, pr.price) ELSE pr.price END AS price,
                 p.name AS passenger_name,
                 pu.customer_phone AS passenger_phone,
                 pu.customer_email AS passenger_email,

--- a/backend/routers/ticket.py
+++ b/backend/routers/ticket.py
@@ -17,6 +17,7 @@ class TicketCreate(BaseModel):
     departure_stop_id: int
     arrival_stop_id: int
     extra_baggage: bool = False
+    discounted: bool = False
 
 
 class TicketOut(BaseModel):
@@ -83,8 +84,8 @@ def create_ticket(data: TicketCreate):
         cur.execute(
             """
             INSERT INTO ticket
-              (tour_id, seat_id, passenger_id, departure_stop_id, arrival_stop_id, purchase_id, extra_baggage)
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
+              (tour_id, seat_id, passenger_id, departure_stop_id, arrival_stop_id, purchase_id, extra_baggage, discounted)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -95,6 +96,7 @@ def create_ticket(data: TicketCreate):
                 data.arrival_stop_id,
                 data.purchase_id,
                 int(data.extra_baggage),
+                data.discounted,
             ),
         )
         ticket_id = cur.fetchone()[0]

--- a/db/init.sql
+++ b/db/init.sql
@@ -149,7 +149,8 @@ CREATE TABLE public.prices (
     pricelist_id integer NOT NULL,
     departure_stop_id integer NOT NULL,
     arrival_stop_id integer NOT NULL,
-    price numeric(10,2) NOT NULL
+    price numeric(10,2) NOT NULL,
+    discount_price numeric(10,2)
 );
 
 
@@ -360,7 +361,8 @@ CREATE TABLE public.ticket (
     departure_stop_id integer NOT NULL,
     arrival_stop_id integer NOT NULL,
     purchase_id integer,
-    extra_baggage integer DEFAULT 0
+    extra_baggage integer DEFAULT 0,
+    discounted boolean DEFAULT false
 );
 
 

--- a/db/migrations/006_add_discount_price.sql
+++ b/db/migrations/006_add_discount_price.sql
@@ -1,0 +1,4 @@
+-- Add discount price support
+ALTER TABLE prices ADD COLUMN IF NOT EXISTS discount_price numeric(10,2);
+UPDATE prices SET discount_price = price WHERE discount_price IS NULL;
+ALTER TABLE ticket ADD COLUMN IF NOT EXISTS discounted boolean NOT NULL DEFAULT FALSE;

--- a/frontend/src/pages/PricelistsPage.js
+++ b/frontend/src/pages/PricelistsPage.js
@@ -13,10 +13,18 @@ function PricelistPage() {
   const [pricelists, setPricelists] = useState([]);
   const [selectedPricelist, setSelectedPricelist] = useState(null);
   const [prices, setPrices] = useState([]);
-  const [newPrice, setNewPrice] = useState({ departure_stop_id: "", arrival_stop_id: "", price: "" });
+  const [newPrice, setNewPrice] = useState({
+    departure_stop_id: "",
+    arrival_stop_id: "",
+    price: "",
+    discount_price: "",
+  });
   const [stops, setStops] = useState([]);
   const [editingPriceId, setEditingPriceId] = useState(null);
-  const [editingPriceData, setEditingPriceData] = useState({ price: "" });
+  const [editingPriceData, setEditingPriceData] = useState({
+    price: "",
+    discount_price: "",
+  });
 
   // Для создания и редактирования прайс-листов
   const [newPricelistName, setNewPricelistName] = useState("");
@@ -122,10 +130,17 @@ function PricelistPage() {
       pricelist_id: selectedPricelist.id,
       departure_stop_id: Number(newPrice.departure_stop_id),
       arrival_stop_id: Number(newPrice.arrival_stop_id),
-      price: Number(newPrice.price)
+      price: Number(newPrice.price),
+      discount_price:
+        newPrice.discount_price === "" ? null : Number(newPrice.discount_price),
     }).then(res => {
       setPrices([...prices, res.data]);
-      setNewPrice({ departure_stop_id: "", arrival_stop_id: "", price: "" });
+      setNewPrice({
+        departure_stop_id: "",
+        arrival_stop_id: "",
+        price: "",
+        discount_price: "",
+      });
     });
   };
 
@@ -136,12 +151,22 @@ function PricelistPage() {
 
   const handleEditPrice = (priceObj) => {
     setEditingPriceId(priceObj.id);
-    setEditingPriceData({ price: priceObj.price.toString() });
+    setEditingPriceData({
+      price: priceObj.price.toString(),
+      discount_price: priceObj.discount_price?.toString() || "",
+    });
   };
 
   const handleUpdatePrice = (e) => {
     e.preventDefault();
-    const updated = { ...prices.find(p => p.id === editingPriceId), price: Number(editingPriceData.price) };
+    const updated = {
+      ...prices.find(p => p.id === editingPriceId),
+      price: Number(editingPriceData.price),
+      discount_price:
+        editingPriceData.discount_price === ""
+          ? null
+          : Number(editingPriceData.discount_price),
+    };
     axios.put(`${API}/prices/${editingPriceId}`, updated)
       .then(res => {
         setPrices(prices.map(p => p.id === editingPriceId ? res.data : p));
@@ -214,6 +239,7 @@ function PricelistPage() {
                 <th>От остановки</th>
                 <th>До остановки</th>
                 <th>Цена</th>
+                <th>Льготная цена</th>
                 <th>Действия</th>
               </tr>
             </thead>
@@ -227,10 +253,31 @@ function PricelistPage() {
                       <input
                         type="number"
                         value={editingPriceData.price}
-                        onChange={e => setEditingPriceData({ price: e.target.value })}
+                        onChange={e =>
+                          setEditingPriceData({
+                            ...editingPriceData,
+                            price: e.target.value,
+                          })
+                        }
                       />
                     ) : (
                       p.price
+                    )}
+                  </td>
+                  <td>
+                    {editingPriceId === p.id ? (
+                      <input
+                        type="number"
+                        value={editingPriceData.discount_price}
+                        onChange={e =>
+                          setEditingPriceData({
+                            ...editingPriceData,
+                            discount_price: e.target.value,
+                          })
+                        }
+                      />
+                    ) : (
+                      p.discount_price ?? ""
                     )}
                   </td>
                   <td className="actions-cell">
@@ -277,6 +324,15 @@ function PricelistPage() {
               placeholder="Цена"
               value={newPrice.price}
               onChange={e => setNewPrice({ ...newPrice, price: e.target.value })}
+            />
+
+            <input
+              type="number"
+              placeholder="Льготная цена"
+              value={newPrice.discount_price}
+              onChange={e =>
+                setNewPrice({ ...newPrice, discount_price: e.target.value })
+              }
             />
 
             <IconButton type="submit" icon={addIcon} alt="Добавить цену" className="btn--primary" />

--- a/frontend/src/pages/PricesPage.js
+++ b/frontend/src/pages/PricesPage.js
@@ -15,11 +15,28 @@ function PricesPage() {
   return (
     <div>
       <h2>PricesPage</h2>
-      <ul>
-        {items.map((item, index) => (
-          <li key={index}>{JSON.stringify(item)}</li>
-        ))}
-      </ul>
+      <table className="styled-table">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>От остановки</th>
+            <th>До остановки</th>
+            <th>Цена</th>
+            <th>Льготная цена</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.id}>
+              <td>{item.id}</td>
+              <td>{item.departure_stop_name || item.departure_stop_id}</td>
+              <td>{item.arrival_stop_name || item.arrival_stop_id}</td>
+              <td>{item.price}</td>
+              <td>{item.discount_price ?? ""}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }

--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -28,7 +28,9 @@ export default function SearchPage() {
   const [selectedOutboundTour, setSelectedOutboundTour] = useState(null);
   const [selectedReturnTour, setSelectedReturnTour] = useState(null);
 
-  const [seatCount, setSeatCount] = useState(1);
+  const [regularCount, setRegularCount] = useState(1);
+  const [discountCount, setDiscountCount] = useState(0);
+  const seatCount = regularCount + discountCount;
   const [selectedOutboundSeats, setSelectedOutboundSeats] = useState([]);
   const [selectedReturnSeats, setSelectedReturnSeats] = useState([]);
   const [passengerNames, setPassengerNames] = useState([""]);
@@ -36,6 +38,7 @@ export default function SearchPage() {
   const [email, setEmail] = useState("");
   const [extraBaggageOutbound, setExtraBaggageOutbound] = useState([false]);
   const [extraBaggageReturn, setExtraBaggageReturn] = useState([false]);
+  const [discountFlags, setDiscountFlags] = useState([false]);
   const [message, setMessage] = useState("");
   const [messageType, setMessageType] = useState("info");
   const [loading, setLoading] = useState(false);
@@ -48,6 +51,10 @@ export default function SearchPage() {
 
   useEffect(() => {
     setPassengerNames(Array(seatCount).fill(""));
+    setDiscountFlags([
+      ...Array(regularCount).fill(false),
+      ...Array(discountCount).fill(true)
+    ]);
     setSelectedOutboundSeats([]);
     setSelectedReturnSeats([]);
     setSelectedDepartDate("");
@@ -216,7 +223,8 @@ export default function SearchPage() {
       const basePayload = {
         passenger_names: passengerNames,
         passenger_phone: phone,
-        passenger_email: email
+        passenger_email: email,
+        discounted: discountFlags
       };
       const outRes = await axios.post(`${API}/${endpoint}`, {
         ...basePayload,
@@ -250,6 +258,10 @@ export default function SearchPage() {
       setSelectedOutboundSeats([]);
       setSelectedReturnSeats([]);
       setPassengerNames(Array(seatCount).fill(""));
+      setDiscountFlags([
+        ...Array(regularCount).fill(false),
+        ...Array(discountCount).fill(true)
+      ]);
       setPhone("");
       setEmail("");
       setExtraBaggageOutbound(Array(seatCount).fill(false));
@@ -342,10 +354,20 @@ export default function SearchPage() {
         <input
           className="input"
           type="number"
-          min="1"
-          value={seatCount}
-          onChange={e => setSeatCount(Number(e.target.value))}
+          min="0"
+          value={regularCount}
+          onChange={e => setRegularCount(Number(e.target.value))}
           style={{ width: 60 }}
+          placeholder="Обычный"
+        />
+        <input
+          className="input"
+          type="number"
+          min="0"
+          value={discountCount}
+          onChange={e => setDiscountCount(Number(e.target.value))}
+          style={{ width: 60 }}
+          placeholder="Льготный"
         />
 
         <input
@@ -493,6 +515,18 @@ export default function SearchPage() {
                   setPassengerNames(arr);
                 }}
               />
+              <label style={{display:'flex',alignItems:'center',gap:2}}>
+                <input
+                  type="checkbox"
+                  checked={discountFlags[idx]}
+                  onChange={e => {
+                    const arr = [...discountFlags];
+                    arr[idx] = e.target.checked;
+                    setDiscountFlags(arr);
+                  }}
+                />
+                Льготный
+              </label>
               <label style={{display:'flex',alignItems:'center',gap:2}}>
                 <input
                   type="checkbox"

--- a/tests/test_book_then_purchase.py
+++ b/tests/test_book_then_purchase.py
@@ -38,8 +38,8 @@ class DummyCursor:
             return [1, 1]
         if 'select id, available from seat' in q:
             return [1, '1234']
-        if 'select price from prices' in q:
-            return [10]
+        if 'select price' in q and 'from prices' in q:
+            return [10, None]
         if 'insert into purchase' in q:
             return [1]
         if 'select id, seat_id from ticket' in q:

--- a/tests/test_booking_flow.py
+++ b/tests/test_booking_flow.py
@@ -22,8 +22,8 @@ class DummyCursor:
             return [1, 1]
         if "select id, available from seat" in q:
             return [1, "1234"]
-        if "select price from prices" in q:
-            return [10]
+        if "select price" in q and "from prices" in q:
+            return [10, None]
         return [1]
 
     def fetchall(self):

--- a/tests/test_bundle_public.py
+++ b/tests/test_bundle_public.py
@@ -28,7 +28,7 @@ class DummyCursor:
             else:
                 return [(20, "B_en"), (10, "A_en")]
         if "from prices" in self.query:
-            return [(10, "A_en", 20, "B_en", 9.9)]
+            return [(10, "A_en", 20, "B_en", 9.9, 8.8)]
         return []
     def close(self):
         pass

--- a/tests/test_multi_purchase.py
+++ b/tests/test_multi_purchase.py
@@ -30,8 +30,8 @@ class DummyCursor:
             return [1, 1]
         if 'select id, available from seat' in q:
             return [1, '1234']
-        if 'select price from prices' in q:
-            return [10]
+        if 'select price' in q and 'from prices' in q:
+            return [10, None]
         if 'select id, seat_id from ticket' in q:
             return [1, 1]
         return [1]

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -23,8 +23,8 @@ class DummyCursor:
             return [1, 1]
         if "select id, available from seat" in q:
             return [1, "1234"]
-        if "select price from prices" in q:
-            return [10]
+        if "select price" in q and "from prices" in q:
+            return [10, None]
         return [1]
     def fetchall(self):
         q = self.query.lower()

--- a/tests/test_roundtrip_purchase.py
+++ b/tests/test_roundtrip_purchase.py
@@ -25,8 +25,8 @@ class UniqueSalesCursor:
             return [1, 1]
         if "select stop_id from routestop" in q:
             return [(1,), (2,)]
-        if "select price from prices" in q:
-            return [10]
+        if "select price" in q and "from prices" in q:
+            return [10, None]
         if "select id, available from seat" in q:
             return [1, "1234"]
         if "select amount_due, status from purchase" in q:


### PR DESCRIPTION
## Summary
- allow storing discounted fares and ticket flags in the database
- calculate totals using discounted seats in purchase flow
- let users pick regular vs discounted tickets in search UI
- show discounted price alongside regular price when listing, adding, or editing prices

## Testing
- `pip install httpx`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c73f31fd48327b80d759c839de2bd