### PR TITLE
Fix route stop deletion

### DIFF
--- a/backend/routers/route.py
+++ b/backend/routers/route.py
@@ -202,9 +202,9 @@ def update_route_stop(route_id: int, stop_id: int, data: RouteStopCreate):
     cur = conn.cursor()
     cur.execute(
         'UPDATE routestop SET stop_id=%s, "order"=%s, arrival_time=%s, departure_time=%s '
-        'WHERE id=%s AND route_id=%s '
+        'WHERE route_id=%s AND stop_id=%s '
         'RETURNING id, route_id, stop_id, "order", arrival_time, departure_time;',
-        (data.stop_id, data.order, data.arrival_time, data.departure_time, stop_id, route_id)
+        (data.stop_id, data.order, data.arrival_time, data.departure_time, route_id, stop_id)
     )
     row = cur.fetchone()
     conn.commit()
@@ -228,7 +228,10 @@ def delete_route_stop(route_id: int, stop_id: int):
     """
     conn = get_connection()
     cur = conn.cursor()
-    cur.execute("DELETE FROM routestop WHERE id=%s AND route_id=%s RETURNING id;", (stop_id, route_id))
+    cur.execute(
+        "DELETE FROM routestop WHERE route_id=%s AND stop_id=%s RETURNING id;",
+        (route_id, stop_id),
+    )
     deleted = cur.fetchone()
     conn.commit()
     cur.close()

--- a/tests/test_route_stop_delete.py
+++ b/tests/test_route_stop_delete.py
@@ -1,0 +1,34 @@
+import importlib
+import pytest
+
+
+def test_delete_route_stop_uses_stop_id(monkeypatch):
+    record = {}
+
+    class DummyCursor:
+        def execute(self, query, params=None):
+            record['query'] = query
+            record['params'] = params
+        def fetchone(self):
+            return (123,)
+        def close(self):
+            pass
+
+    class DummyConn:
+        def cursor(self):
+            return DummyCursor()
+        def commit(self):
+            pass
+        def close(self):
+            pass
+
+    # Patch psycopg2.connect before importing router module
+    monkeypatch.setattr('psycopg2.connect', lambda *a, **kw: DummyConn())
+    route = importlib.reload(importlib.import_module('backend.routers.route'))
+    # Ensure router uses our dummy connection
+    monkeypatch.setattr(route, 'get_connection', lambda: DummyConn())
+
+    response = route.delete_route_stop(1, 2)
+    assert response['deleted_id'] == 123
+    assert record['params'] == (1, 2)
+    assert 'stop_id' in record['query'].lower()


### PR DESCRIPTION
## Summary
- Ensure route stop deletion uses route_id and stop_id rather than routestop id
- Align update logic for route stops
- Add regression test for deleting a stop from a route

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c919cf3cc83279b726c5fc1f8fbe3