### PR TITLE
Adjust timezone to Bulgarian UTC+3 for logs

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -49,8 +49,16 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 # --- psycopg2 helper for your existing routers ---
 
 def get_connection():
-    """Returns a new psycopg2 connection using DATABASE_URL."""
-    return psycopg2.connect(DATABASE_URL)
+    """Returns a new psycopg2 connection using DATABASE_URL.
+
+    The connection's timezone is explicitly set to Bulgarian local time so that
+    any timestamps produced by PostgreSQL (e.g. via ``NOW()``) reflect
+    the desired ``UTC+3`` offset.
+    """
+    conn = psycopg2.connect(DATABASE_URL)
+    with conn.cursor() as cur:
+        cur.execute("SET TIME ZONE 'Europe/Sofia'")
+    return conn
 
 from pathlib import Path
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 import os
 
+# Ensure application runs in Bulgarian time (UTC+3) so all logs and time-based
+# functions reflect the expected timezone.
+os.environ.setdefault("TZ", "Europe/Sofia")
+time.tzset()
+
 # Импортируем все роутеры
 from .routers import (
     stop,


### PR DESCRIPTION
## Summary
- enforce Bulgarian timezone globally so application logs use UTC+3
- set PostgreSQL session timezone to Europe/Sofia

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ef41b6fc48327b55c8a9c1eae5a80