### PR TITLE
Expose stop details in selected route endpoint

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -236,6 +236,10 @@ class LangRequest(BaseModel):
 class LocalizedStop(BaseModel):
     id: int
     name: str
+    description: Optional[str] = None
+    location: Optional[str] = None
+    arrival_time: Optional[str] = None
+    departure_time: Optional[str] = None
 
 class LocalizedRoute(BaseModel):
     id: int

--- a/backend/routers/bundle.py
+++ b/backend/routers/bundle.py
@@ -125,12 +125,23 @@ def _get_route(cur, route_id: int, col: str):
     row = cur.fetchone()
     name = row[0] if row else ""
     cur.execute(
-        f'SELECT s.id, COALESCE(s.{col}, s.stop_name) '
+        f'SELECT s.id, COALESCE(s.{col}, s.stop_name), s.description, s.location, '
+        f'rs.arrival_time, rs.departure_time '
         f'FROM routestop rs JOIN stop s ON rs.stop_id=s.id '
         f'WHERE rs.route_id=%s ORDER BY rs."order"',
         (route_id,),
     )
-    stops = [{"id": r[0], "name": r[1]} for r in cur.fetchall()]
+    stops = [
+        {
+            "id": r[0],
+            "name": r[1],
+            "description": r[2],
+            "location": r[3],
+            "arrival_time": r[4],
+            "departure_time": r[5],
+        }
+        for r in cur.fetchall()
+    ]
     return {"id": route_id, "name": name, "stops": stops}
 
 

--- a/tests/test_bundle_public.py
+++ b/tests/test_bundle_public.py
@@ -23,10 +23,14 @@ class DummyCursor:
     def fetchall(self):
         if "from routestop" in self.query:
             rid = self.params[0]
+            stops = [
+                (10, "A_en", "DescA", "LocA", "10:00", "10:05"),
+                (20, "B_en", "DescB", "LocB", "11:00", "11:05"),
+            ]
             if rid == 1:
-                return [(10, "A_en"), (20, "B_en")]
+                return stops
             else:
-                return [(20, "B_en"), (10, "A_en")]
+                return list(reversed(stops))
         if "from prices" in self.query:
             return [(10, "A_en", 20, "B_en", 9.9)]
         return []
@@ -66,7 +70,12 @@ def test_routes_bundle(client):
     resp = client.post("/selected_route", json={"lang": "en"})
     assert resp.status_code == 200
     data = resp.json()
-    assert data["forward"]["stops"][0]["name"] == "A_en"
+    stop = data["forward"]["stops"][0]
+    assert stop["name"] == "A_en"
+    assert stop["description"] == "DescA"
+    assert stop["location"] == "LocA"
+    assert stop["arrival_time"] == "10:00"
+    assert stop["departure_time"] == "10:05"
 
 def test_pricelist_bundle(client):
     resp = client.post("/selected_pricelist", json={"lang": "en"})


### PR DESCRIPTION
## Summary
- include stop description, location, arrival and departure times in `/selected_route` response
- model LocalizedStop updated to hold new fields
- tests adjusted for expanded stop data

## Testing
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2dfde49708327a2581a1649155159