### PR TITLE
Handle datetime times in route bundle response

### DIFF
--- a/backend/routers/bundle.py
+++ b/backend/routers/bundle.py
@@ -1,3 +1,5 @@
+from datetime import time as dt_time
+
 from fastapi import APIRouter, Depends, HTTPException
 from ..auth import require_admin_token
 from ..database import get_connection
@@ -131,14 +133,17 @@ def _get_route(cur, route_id: int, col: str):
         f'WHERE rs.route_id=%s ORDER BY rs."order"',
         (route_id,),
     )
+    def _fmt(val):
+        return val.strftime("%H:%M") if isinstance(val, dt_time) else val
+
     stops = [
         {
             "id": r[0],
             "name": r[1],
             "description": r[2],
             "location": r[3],
-            "arrival_time": r[4],
-            "departure_time": r[5],
+            "arrival_time": _fmt(r[4]),
+            "departure_time": _fmt(r[5]),
         }
         for r in cur.fetchall()
     ]

--- a/tests/test_bundle_public.py
+++ b/tests/test_bundle_public.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import importlib
+from datetime import time
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -24,8 +26,8 @@ class DummyCursor:
         if "from routestop" in self.query:
             rid = self.params[0]
             stops = [
-                (10, "A_en", "DescA", "LocA", "10:00", "10:05"),
-                (20, "B_en", "DescB", "LocB", "11:00", "11:05"),
+                (10, "A_en", "DescA", "LocA", time(10, 0), time(10, 5)),
+                (20, "B_en", "DescB", "LocB", time(11, 0), time(11, 5)),
             ]
             if rid == 1:
                 return stops


### PR DESCRIPTION
## Summary
- Convert route stop times to `HH:MM` strings in selected route response
- Adjust bundle public test to emulate DB returning `datetime.time`

## Testing
- `pytest tests/test_bundle_public.py::test_routes_bundle -q`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2e22bb9188327ab291dae212298a4