### PR TITLE
Fix route and route stop editing

### DIFF
--- a/tests/test_route_stop_delete.py
+++ b/tests/test_route_stop_delete.py
@@ -2,7 +2,7 @@ import importlib
 import pytest
 
 
-def test_delete_route_stop_uses_stop_id(monkeypatch):
+def test_delete_route_stop_uses_id(monkeypatch):
     record = {}
 
     class DummyCursor:
@@ -31,4 +31,6 @@ def test_delete_route_stop_uses_stop_id(monkeypatch):
     response = route.delete_route_stop(1, 2)
     assert response['deleted_id'] == 123
     assert record['params'] == (1, 2)
-    assert 'stop_id' in record['query'].lower()
+    query = record['query'].lower()
+    assert 'stop_id' not in query
+    assert 'and id=%s' in query


### PR DESCRIPTION
## Summary
- allow updating routes with new `PUT /routes/{route_id}` endpoint
- identify route stops by their own id for updates and deletes
- adjust tests for new route stop id behaviour

## Testing
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a323e1fac08327aee697bcac64940a