### PR TITLE
Add language-aware search endpoints

### DIFF
--- a/frontend/src/pages/SearchPage.js
+++ b/frontend/src/pages/SearchPage.js
@@ -11,6 +11,12 @@ import Calendar from "../components/Calendar";
 import { API } from "../config";
 
 export default function SearchPage() {
+  const supportedLangs = ["ru", "en", "bg", "ua"];
+  const browserLang =
+    typeof navigator !== "undefined" && navigator.language
+      ? navigator.language.slice(0, 2).toLowerCase()
+      : "ru";
+  const lang = supportedLangs.includes(browserLang) ? browserLang : "ru";
   const [departureStops, setDepartureStops] = useState([]);
   const [arrivalStops, setArrivalStops]     = useState([]);
   const [departDates, setDepartDates]       = useState([]);
@@ -60,10 +66,10 @@ export default function SearchPage() {
 
   // 1. Загрузить все отправные остановки
   useEffect(() => {
-    axios.get(`${API}/search/departures`, { params: { seats: seatCount } })
+    axios.post(`${API}/search/departures`, { seats: seatCount, lang })
       .then(res => setDepartureStops(res.data))
       .catch(console.error);
-  }, [seatCount]);
+  }, [seatCount, lang]);
 
   // 2. При выборе отправной — подгрузить конечные
   useEffect(() => {
@@ -74,13 +80,15 @@ export default function SearchPage() {
       setSelectedOutboundTour(null);
       setSelectedReturnTour(null);
     } else {
-      axios.get(`${API}/search/arrivals`, {
-        params: { departure_stop_id: selectedDeparture, seats: seatCount }
+      axios.post(`${API}/search/arrivals`, {
+        departure_stop_id: selectedDeparture,
+        seats: seatCount,
+        lang
       })
       .then(res => setArrivalStops(res.data))
       .catch(console.error);
     }
-  }, [selectedDeparture, seatCount]);
+  }, [selectedDeparture, seatCount, lang]);
 
   // 3. При выборе отправной+конечной — подгрузить доступные даты
   useEffect(() => {

--- a/tests/test_search_public.py
+++ b/tests/test_search_public.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class DummyCursor:
+    def __init__(self):
+        self.query = ""
+        self.params = None
+
+    def execute(self, query, params=None):
+        self.query = query.lower()
+        self.params = params
+
+    def fetchall(self):
+        if "select distinct departure_stop_id" in self.query:
+            return [(1,), (2,)]
+        if "select distinct arrival_stop_id" in self.query:
+            return [(1,), (2,)]
+        if "coalesce(stop_en" in self.query:
+            return [(1, "Stop1_en"), (2, "Stop2_en")]
+        if "coalesce(stop_name" in self.query:
+            return [(1, "Stop1_ru"), (2, "Stop2_ru")]
+        return []
+
+    def fetchone(self):
+        return None
+
+    def close(self):
+        pass
+
+
+class DummyConn:
+    def cursor(self):
+        return DummyCursor()
+
+    def close(self):
+        pass
+
+
+def fake_get_connection():
+    return DummyConn()
+
+
+@pytest.fixture
+def client(monkeypatch):
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **kw: DummyConn())
+    import backend.database
+    monkeypatch.setattr("backend.database.get_connection", fake_get_connection)
+    if "backend.main" in sys.modules:
+        importlib.reload(sys.modules["backend.main"])
+    else:
+        importlib.import_module("backend.main")
+    app = sys.modules["backend.main"].app
+    monkeypatch.setattr("backend.routers.search.get_connection", fake_get_connection)
+    return TestClient(app)
+
+
+def test_departures_lang(client):
+    resp = client.post("/search/departures", json={"lang": "en", "seats": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["stop_name"] == "Stop1_en"
+
+
+def test_arrivals_lang(client):
+    resp = client.post(
+        "/search/arrivals",
+        json={"lang": "en", "departure_stop_id": 1, "seats": 1},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["stop_name"] == "Stop1_en"


### PR DESCRIPTION
## Summary
- accept language in `/search/departures` and `/search/arrivals` POST endpoints
- send language parameter from frontend search page
- add tests for search endpoint localization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a5b619687c83279e47a413070724f9