### PR TITLE
Handle CORS preflight for search and bundle endpoints

### DIFF
--- a/backend/routers/bundle.py
+++ b/backend/routers/bundle.py
@@ -1,6 +1,6 @@
 from datetime import time as dt_time
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from ..auth import require_admin_token
 from ..database import get_connection
 from ..models import (
@@ -148,6 +148,12 @@ def _get_route(cur, route_id: int, col: str):
         for r in cur.fetchall()
     ]
     return {"id": route_id, "name": name, "stops": stops}
+
+
+@router.options("/selected_route")
+def selected_route_options() -> Response:
+    """Preflight request handler for selected route bundle."""
+    return Response(status_code=200)
 
 
 @router.post("/selected_route", response_model=RoutesBundleOut)

--- a/backend/routers/search.py
+++ b/backend/routers/search.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Response
 from ..database import get_connection
 from ..models import LangRequest
 
@@ -12,6 +12,12 @@ class DeparturesRequest(LangRequest):
 class ArrivalsRequest(LangRequest):
     departure_stop_id: int
     seats: int = 1
+
+
+@router.options("/departures")
+def departures_options() -> Response:
+    """Preflight request handler for departures search."""
+    return Response(status_code=200)
 
 
 @router.post("/departures")
@@ -43,6 +49,12 @@ def get_departures(data: DeparturesRequest):
     cur.close()
     conn.close()
     return stops_list
+
+
+@router.options("/arrivals")
+def arrivals_options() -> Response:
+    """Preflight request handler for arrivals search."""
+    return Response(status_code=200)
 
 
 @router.post("/arrivals")

--- a/tests/test_bundle_public.py
+++ b/tests/test_bundle_public.py
@@ -117,3 +117,8 @@ def test_pricelist_bundle_missing_column(client):
     data = resp.json()
     assert data["prices"][0]["departure_name"] == "A_en"
 
+
+def test_selected_route_options(client):
+    resp = client.options("/selected_route")
+    assert resp.status_code == 200
+

--- a/tests/test_search_public.py
+++ b/tests/test_search_public.py
@@ -37,6 +37,12 @@ class DummyConn:
     def cursor(self):
         return DummyCursor()
 
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
     def close(self):
         pass
 
@@ -75,3 +81,13 @@ def test_arrivals_lang(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data[0]["stop_name"] == "Stop1_en"
+
+
+def test_departures_options(client):
+    resp = client.options("/search/departures")
+    assert resp.status_code == 200
+
+
+def test_arrivals_options(client):
+    resp = client.options("/search/arrivals")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add explicit OPTIONS handlers for `/search/departures`, `/search/arrivals`, and `/selected_route`
- cover preflight behaviour with tests

## Testing
- `python -m pytest tests/test_search_public.py tests/test_bundle_public.py`

------
https://chatgpt.com/codex/tasks/task_e_68a83d1add408327b7d8eb588f526b30