### PR TITLE
feat: enhance report page styling

### DIFF
--- a/frontend/src/pages/ReportPage.js
+++ b/frontend/src/pages/ReportPage.js
@@ -20,6 +20,7 @@ function ReportPage() {
   // Результат отчёта
   const [reportData, setReportData] = useState(null);
   const [message, setMessage] = useState("");
+  const [isError, setIsError] = useState(false);
 
   // Загружаем маршруты
   useEffect(() => {
@@ -50,6 +51,7 @@ function ReportPage() {
   const handleSearch = (e) => {
     e.preventDefault();
     setMessage("Загрузка отчёта...");
+    setIsError(false);
 
     // На бэкенд отправляем ID остановок
     const departureStopId = departureStop || null;
@@ -70,6 +72,7 @@ function ReportPage() {
     .catch(err => {
       console.error("Ошибка получения отчёта:", err);
       setMessage("Ошибка получения отчёта");
+      setIsError(true);
     });
   };
 
@@ -156,7 +159,7 @@ function ReportPage() {
         <button type="submit">Найти отчёт</button>
       </form>
 
-      {message && <p className="report-message">{message}</p>}
+      {message && <p className={`report-message${isError ? " error" : ""}`}>{message}</p>}
 
       {reportData && (
         <div className="report-results">
@@ -166,36 +169,38 @@ function ReportPage() {
 
           <h3>Детали билетов</h3>
           {reportData.tickets.length > 0 ? (
-            <table className="report-table">
-              <thead>
-                <tr>
-                  <th>Билет</th>
-                  <th>Рейс</th>
-                  <th>Маршрут</th>
-                  <th>Место</th>
-                  <th>Цена</th>
-                  <th>Пассажир</th>
-                  <th>Дата рейса</th>
-                  <th>Отправная</th>
-                  <th>Конечная</th>
-                </tr>
-              </thead>
-              <tbody>
-                {reportData.tickets.map((tk) => (
-                  <tr key={tk.ticket_id}>
-                    <td>{tk.ticket_id}</td>
-                    <td>{tk.tour_id}</td>
-                    <td>{tk.route_name}</td>
-                    <td>{tk.seat_num}</td>
-                    <td>{tk.price}</td>
-                    <td>{tk.passenger_name}</td>
-                    <td>{tk.tour_date}</td>
-                    <td>{tk.departure_stop_name}</td>
-                    <td>{tk.arrival_stop_name}</td>
+            <div className="table-wrapper">
+              <table className="report-table">
+                <thead>
+                  <tr>
+                    <th>Билет</th>
+                    <th>Рейс</th>
+                    <th>Маршрут</th>
+                    <th>Место</th>
+                    <th>Цена</th>
+                    <th>Пассажир</th>
+                    <th>Дата рейса</th>
+                    <th>Отправная</th>
+                    <th>Конечная</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {reportData.tickets.map((tk) => (
+                    <tr key={tk.ticket_id}>
+                      <td>{tk.ticket_id}</td>
+                      <td>{tk.tour_id}</td>
+                      <td>{tk.route_name}</td>
+                      <td>{tk.seat_num}</td>
+                      <td>{tk.price}</td>
+                      <td>{tk.passenger_name}</td>
+                      <td>{tk.tour_date}</td>
+                      <td>{tk.departure_stop_name}</td>
+                      <td>{tk.arrival_stop_name}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           ) : (
             <p>Нет проданных билетов по заданным параметрам.</p>
           )}

--- a/frontend/src/styles/ReportPage.css
+++ b/frontend/src/styles/ReportPage.css
@@ -1,73 +1,95 @@
 .report-container {
     max-width: 900px;
     margin: 20px auto;
-    padding: 20px;
-    font-family: 'Roboto', sans-serif;
+    padding: 24px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    font: 14px/1.4 system-ui, Arial, sans-serif;
   }
-  
+
   .report-form {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 15px;
-    margin-bottom: 20px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+    background: #f9fafb;
+    border: 1px solid #e5e7eb;
+    padding: 20px;
+    border-radius: 8px;
   }
-  
-  .report-form div {
+
+  .report-form > div {
     display: flex;
     flex-direction: column;
   }
-  
+
   .report-form label {
     font-weight: bold;
     margin-bottom: 5px;
   }
-  
+
   .report-form input,
   .report-form select {
     padding: 8px;
     border: 1px solid #ccc;
     border-radius: 4px;
+    background: #fff;
   }
-  
+
   .report-form button {
+    grid-column: 1 / -1;
+    justify-self: start;
     padding: 10px 16px;
     background-color: #4d9ef9;
     color: white;
     border: none;
     border-radius: 4px;
     cursor: pointer;
-    align-self: flex-end;
-    margin-top: 22px;
+    transition: background-color 0.2s ease;
   }
-  
+
   .report-form button:hover {
     background-color: #327ad6;
   }
-  
+
   .report-message {
-    color: blue;
-    font-weight: bold;
+    font-weight: 500;
     margin-bottom: 20px;
+    color: #0d6efd;
   }
-  
+
+  .report-message.error {
+    color: #d9534f;
+  }
+
   .report-results {
     margin-top: 20px;
   }
-  
+
+  .table-wrapper {
+    overflow-x: auto;
+  }
+
   .report-table {
     width: 100%;
     border-collapse: collapse;
     margin-top: 10px;
+    min-width: 600px;
   }
-  
+
   .report-table th,
   .report-table td {
     padding: 8px 12px;
     border: 1px solid #ddd;
     text-align: left;
   }
-  
+
   .report-table th {
     background-color: #f0f2f7;
+  }
+
+  .report-table tr:nth-child(even) {
+    background-color: #f9fafb;
   }
   


### PR DESCRIPTION
## Summary
- improve report page layout with grid-based form and responsive table
- add error state to report message styling

## Testing
- `npm test -- --watchAll=false`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac592d57f883278e9d717e095dac31