### PR TITLE
Ensure purchase logs use Sofia 24-hour time

### DIFF
--- a/frontend/src/pages/PurchasesPage.js
+++ b/frontend/src/pages/PurchasesPage.js
@@ -172,7 +172,7 @@ export default function PurchasesPage() {
                               info[p.id].logs.map((l) => (
                                 <tr key={l.id}>
                                   <td>{l.action}</td>
-                                  <td>{new Date(l.at).toLocaleString('ru-RU')}</td>
+                                  <td>{new Date(l.at).toLocaleString('ru-RU', { timeZone: 'Europe/Sofia', hour12: false })}</td>
                                   <td>{l.by || '—'}</td>
                                   <td>{l.method || '—'}</td>
                                   <td>{l.amount}</td>


### PR DESCRIPTION
## Summary
- format purchase log timestamps in Sofia timezone with 24-hour clock

## Testing
- `pytest`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ac64c064cc8327aa4ab1fa3551f2c7