### PR TITLE
fix: handle wildcard CORS preflight requests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -45,13 +45,16 @@ cors_origins = os.getenv(
     "CORS_ORIGINS", "http://localhost:3000,http://localhost:3001,http://localhost:4000"
 )
 if cors_origins.strip() == "*":
-    origins = ["*"]
+    origins: list[str] = []
+    origin_regex = ".*"
 else:
     origins = [origin.strip() for origin in cors_origins.split(",") if origin.strip()]
+    origin_regex = None
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
+    allow_origin_regex=origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/tests/test_bundle_public.py
+++ b/tests/test_bundle_public.py
@@ -119,6 +119,14 @@ def test_pricelist_bundle_missing_column(client):
 
 
 def test_selected_route_options(client):
-    resp = client.options("/selected_route")
+    resp = client.options(
+        "/selected_route",
+        headers={
+            "Origin": "http://localhost:4000",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
     assert resp.status_code == 200
+    # The CORS middleware should echo back the requesting origin.
+    assert resp.headers.get("access-control-allow-origin") == "http://localhost:4000"
 

--- a/tests/test_search_public.py
+++ b/tests/test_search_public.py
@@ -84,10 +84,24 @@ def test_arrivals_lang(client):
 
 
 def test_departures_options(client):
-    resp = client.options("/search/departures")
+    resp = client.options(
+        "/search/departures",
+        headers={
+            "Origin": "http://localhost:4000",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
     assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "http://localhost:4000"
 
 
 def test_arrivals_options(client):
-    resp = client.options("/search/arrivals")
+    resp = client.options(
+        "/search/arrivals",
+        headers={
+            "Origin": "http://localhost:4000",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
     assert resp.status_code == 200
+    assert resp.headers.get("access-control-allow-origin") == "http://localhost:4000"


### PR DESCRIPTION
## Summary
- allow wildcard CORS origins using regex so browsers get proper CORS headers
- assert CORS headers for public options endpoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac8ed17c24832791ac766ff0428cc8