### PR TITLE
Handle missing translation columns in selected_pricelist

### DIFF
--- a/backend/routers/bundle.py
+++ b/backend/routers/bundle.py
@@ -220,10 +220,13 @@ def selected_pricelist(data: LangRequest):
         query = query_tpl.format(col=col)
         try:
             cur.execute(query, (pricelist_id,))
-        except Exception as e:
+        except UndefinedColumn:
             # If the database does not contain the requested translation
             # column (e.g. ``stop_bg``), retry the query using the default
             # ``stop_name`` column instead of failing with a 500 error.
+            fallback_query = query_tpl.format(col="stop_name")
+            cur.execute(fallback_query, (pricelist_id,))
+        except Exception as e:
             if "column" in str(e).lower() and "does not exist" in str(e).lower():
                 fallback_query = query_tpl.format(col="stop_name")
                 cur.execute(fallback_query, (pricelist_id,))


### PR DESCRIPTION
## Summary
- prevent `/selected_pricelist` from failing when stop translation columns are absent
- gracefully fall back to `stop_name` for unknown languages or missing translation columns

## Testing
- `pytest tests/test_bundle_public.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad817288bc832792a054c73c77e842