### PR TITLE
Add ticket deep links to purchase and ticket APIs

### DIFF
--- a/backend/routers/_ticket_link_helpers.py
+++ b/backend/routers/_ticket_link_helpers.py
@@ -1,0 +1,153 @@
+"""Shared utilities for issuing ticket deep links."""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import date as date_cls, datetime as dt_cls, time as time_cls, timezone
+from typing import Any, List, Sequence, TypedDict, cast
+
+from fastapi import HTTPException
+
+from ..services import ticket_links
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TICKET_LANG = "bg"
+DEFAULT_TICKET_SCOPES = ("view", "download")
+
+
+class TicketIssueSpec(TypedDict):
+    """Parameters required to issue a ticket link."""
+
+    ticket_id: int
+    purchase_id: int | None
+    departure_dt: dt_cls
+
+
+class TicketLinkResult(TypedDict):
+    """Structure returned for issued ticket links."""
+
+    ticket_id: int
+    deep_link: str
+
+
+def _mask_token(token: str) -> str:
+    """Mask a JWT token for safe logging."""
+
+    if len(token) <= 10:
+        return "***"
+    return f"{token[:6]}...{token[-4:]}"
+
+
+def _normalize_date(value: Any) -> date_cls:
+    if isinstance(value, date_cls):
+        return value
+    if isinstance(value, dt_cls):
+        return value.date()
+    if isinstance(value, str):
+        try:
+            return dt_cls.fromisoformat(value).date()
+        except ValueError:
+            try:
+                return dt_cls.strptime(value, "%Y-%m-%d").date()
+            except ValueError as exc:  # pragma: no cover - defensive
+                raise ValueError("Invalid date value") from exc
+    raise ValueError("Unsupported date value")
+
+
+def _normalize_time(value: Any) -> time_cls:
+    if value is None:
+        return time_cls(0, 0)
+    if isinstance(value, time_cls):
+        return value
+    if isinstance(value, dt_cls):
+        return value.time()
+    if isinstance(value, str):
+        for fmt in ("%H:%M:%S", "%H:%M"):
+            try:
+                return dt_cls.strptime(value, fmt).time()
+            except ValueError:
+                continue
+    return time_cls(0, 0)
+
+
+def combine_departure_datetime(tour_date: Any, departure_time: Any) -> dt_cls:
+    """Combine tour date and stop departure time into an aware datetime."""
+
+    date_value = _normalize_date(tour_date)
+    time_value = _normalize_time(departure_time)
+    combined = dt_cls.combine(date_value, time_value)
+    if combined.tzinfo is None:
+        return combined.replace(tzinfo=timezone.utc)
+    return combined.astimezone(timezone.utc)
+
+
+def build_deep_link(ticket_id: int, token: str) -> str:
+    """Construct a deep link URL for a ticket."""
+
+    base_url = os.getenv("APP_PUBLIC_URL", "http://localhost:4000").rstrip("/")
+    return f"{base_url}/ticket/{ticket_id}?token={token}"
+
+
+def issue_ticket_links(
+    specs: Sequence[TicketIssueSpec],
+    lang: str | None,
+) -> List[TicketLinkResult]:
+    """Issue ticket links for provided specs and return deep-link payloads."""
+
+    if not specs:
+        return []
+
+    lang_value = (lang or DEFAULT_TICKET_LANG).lower()
+    results: List[TicketLinkResult] = []
+
+    for spec in specs:
+        try:
+            token = ticket_links.issue(
+                ticket_id=spec["ticket_id"],
+                purchase_id=spec["purchase_id"],
+                scopes=DEFAULT_TICKET_SCOPES,
+                lang=lang_value,
+                departure_dt=spec["departure_dt"],
+            )
+        except ticket_links.TicketLinkError as exc:
+            logger.exception(
+                "Failed to issue ticket link for ticket %s", spec["ticket_id"]
+            )
+            raise HTTPException(500, "Failed to issue ticket link") from exc
+        except Exception as exc:  # pragma: no cover - unexpected failure
+            logger.exception(
+                "Unexpected error while issuing ticket link for ticket %s",
+                spec["ticket_id"],
+            )
+            raise HTTPException(500, "Failed to issue ticket link") from exc
+
+        deep_link = build_deep_link(spec["ticket_id"], token)
+        logger.info(
+            "Issued ticket link for ticket %s (purchase %s): %s",
+            spec["ticket_id"],
+            spec["purchase_id"],
+            _mask_token(token),
+        )
+
+        results.append(
+            cast(
+                TicketLinkResult,
+                {
+                    "ticket_id": spec["ticket_id"],
+                    "deep_link": deep_link,
+                },
+            )
+        )
+
+    return results
+
+
+__all__ = [
+    "TicketIssueSpec",
+    "TicketLinkResult",
+    "combine_departure_datetime",
+    "build_deep_link",
+    "issue_ticket_links",
+]

--- a/tests/test_booking_flow.py
+++ b/tests/test_booking_flow.py
@@ -1,6 +1,8 @@
 import importlib
 import os
 import sys
+from datetime import date, time
+
 from fastapi.testclient import TestClient
 import pytest
 
@@ -18,8 +20,10 @@ class DummyCursor:
         q = self.query.lower()
         if "select id, seat_id from ticket" in q:
             return [1, 1]
-        if "select route_id, pricelist_id from tour" in q:
-            return [1, 1]
+        if "select route_id, pricelist_id, date from tour" in q:
+            return [1, 1, date(2024, 1, 1)]
+        if "select route_id, date from tour" in q:
+            return [1, date(2024, 1, 1)]
         if "select id, available from seat" in q:
             return [1, "1234"]
         if "select price from prices" in q:
@@ -28,8 +32,13 @@ class DummyCursor:
 
     def fetchall(self):
         q = self.query.lower()
-        if "select stop_id from routestop" in q:
-            return [(1,), (2,), (3,), (4,)]
+        if "select stop_id, departure_time from routestop" in q:
+            return [
+                (1, time(8, 0)),
+                (2, time(9, 0)),
+                (3, time(10, 0)),
+                (4, time(11, 0)),
+            ]
         if "select id from ticket where purchase_id" in q:
             return [(1,)]
         return []
@@ -56,11 +65,18 @@ class DummyConn:
 @pytest.fixture
 def client(monkeypatch):
     store = {}
+    monkeypatch.setenv("APP_PUBLIC_URL", "https://example.test")
 
     def fake_get_connection():
         conn = DummyConn()
         store['cursor'] = conn.cursor_obj
         return conn
+
+    token_counter = {"value": 0}
+
+    def fake_issue(ticket_id, purchase_id, scopes, lang, departure_dt):
+        token_counter["value"] += 1
+        return f"token-{token_counter['value']}"
 
     monkeypatch.setattr('psycopg2.connect', lambda *a, **kw: DummyConn())
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -68,6 +84,7 @@ def client(monkeypatch):
     monkeypatch.setattr('backend.database.get_connection', fake_get_connection)
     monkeypatch.setattr('backend.ticket_utils.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
+    monkeypatch.setattr('backend.services.ticket_links.issue', fake_issue)
     if 'backend.main' in sys.modules:
         importlib.reload(sys.modules['backend.main'])
     else:
@@ -94,6 +111,7 @@ def test_booking_flow(client):
     assert any('reserved' in q[0].lower() for q in store['cursor'].queries)
     assert any('insert into sales' in q[0].lower() for q in store['cursor'].queries)
     assert 'amount_due' in resp.json()
+    assert resp.json()['tickets'][0]['deep_link'] == 'https://example.test/ticket/1?token=token-1'
 
     store['cursor'].queries.clear()
 
@@ -119,6 +137,7 @@ def test_booking_flow(client):
     assert any('paid' in q[0].lower() for q in store['cursor'].queries)
     assert any('insert into sales' in q[0].lower() for q in store['cursor'].queries)
     assert 'amount_due' in resp.json()
+    assert resp.json()['tickets'][0]['deep_link'] == 'https://example.test/ticket/1?token=token-2'
 
     store['cursor'].queries.clear()
 


### PR DESCRIPTION
## Summary
- add shared helper utilities for issuing ticket link JWTs, building deep links, and logging masked tokens
- update ticket and purchase creation flows to capture departure times, issue ticket links, and return deep links in API responses
- extend booking and purchase tests to mock ticket link issuance and assert deep link values in responses

## Testing
- pytest tests/test_booking_flow.py tests/test_purchase.py tests/test_ticket_link_tokens.py *(fails: missing httpx dependency required by fastapi.testclient)*

------
https://chatgpt.com/codex/tasks/task_e_68d67dde3ad483279520eba36c20a067