### PR TITLE
Add ticket DTO aggregator and tests

### DIFF
--- a/backend/services/ticket_dto.py
+++ b/backend/services/ticket_dto.py
@@ -1,0 +1,397 @@
+"""Ticket DTO aggregator.
+
+The application renders ticket details in several places (PDF tickets,
+customer e-mails, admin tools).  Each of those entry points previously had
+to issue its own SQL queries which was both error prone and hard to extend.
+This module centralises the data gathering logic in a single helper function
+so the callers can simply request a ready-to-use dictionary.
+
+The :func:`get_ticket_dto` helper pulls together information about the ticket
+itself, the passenger, purchase/payment metadata, the tour (including the
+route and localisation-aware stop titles) and pricing details.  Additionally
+it calculates convenience fields such as the segment duration and a
+structured description of the journey portion covered by the ticket.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, time
+from decimal import Decimal
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from ..models import BookingTermsEnum
+
+
+# Mapping between supported languages and the column that stores a translated
+# stop name.  Unknown languages fall back to ``stop_name`` automatically.
+_LANG_TO_STOP_COLUMN: Dict[str, str] = {
+    "bg": "stop_bg",
+    "en": "stop_en",
+    "ua": "stop_ua",
+}
+
+
+_STOP_COLUMN_INDEX = {
+    "stop_name": 4,
+    "stop_en": 5,
+    "stop_bg": 6,
+    "stop_ua": 7,
+}
+
+
+def _format_time(value: Optional[time]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.strftime("%H:%M")
+
+
+def _format_datetime(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.isoformat()
+
+
+def _decimal_to_float(value: Optional[Decimal]) -> Optional[float]:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _choose_stop_name(row: Sequence, lang: str) -> str:
+    lang_key = (lang or "").lower()
+    column = _LANG_TO_STOP_COLUMN.get(lang_key)
+    if column:
+        idx = _STOP_COLUMN_INDEX[column]
+        localized = row[idx]
+        if localized:
+            return localized
+    # fall back to the default column
+    return row[_STOP_COLUMN_INDEX["stop_name"]]
+
+
+def _humanize_duration(minutes: Optional[int]) -> Optional[str]:
+    if minutes is None:
+        return None
+    hours, mins = divmod(minutes, 60)
+    parts: List[str] = []
+    if hours:
+        parts.append(f"{hours}h")
+    if mins or not parts:
+        parts.append(f"{mins}m")
+    return " ".join(parts)
+
+
+def _booking_rules(terms: BookingTermsEnum) -> Dict[str, Optional[object]]:
+    """Return a structured description for the booking terms."""
+
+    if terms == BookingTermsEnum.EXPIRE_AFTER_48H:
+        return {
+            "code": terms.name,
+            "kind": "expires_after_booking",
+            "expires_in_hours": 48,
+            "description": "Reservation expires 48 hours after booking if not paid.",
+        }
+    if terms == BookingTermsEnum.EXPIRE_BEFORE_48H:
+        return {
+            "code": terms.name,
+            "kind": "expires_before_departure",
+            "expires_in_hours": 48,
+            "description": "Reservation must be paid at least 48 hours before departure.",
+        }
+    if terms == BookingTermsEnum.NO_EXPIRY:
+        return {
+            "code": terms.name,
+            "kind": "pay_on_board",
+            "expires_in_hours": None,
+            "description": "Reservation remains valid until departure; payment on board.",
+        }
+    if terms == BookingTermsEnum.NO_BOOKING:
+        return {
+            "code": terms.name,
+            "kind": "purchase_only",
+            "expires_in_hours": None,
+            "description": "Booking is not available; tickets must be purchased immediately.",
+        }
+    # Fallback, should not normally happen but keeps the function future-proof.
+    return {
+        "code": terms.name,
+        "kind": "unknown",
+        "expires_in_hours": None,
+        "description": None,
+    }
+
+
+def _payment_flags(status: Optional[str]) -> Dict[str, object]:
+    status_value = status or ""
+    return {
+        "status": status_value,
+        "is_reserved": status_value == "reserved",
+        "is_paid": status_value in {"paid", "refunded"},
+        "is_cancelled": status_value == "cancelled",
+        "is_refunded": status_value == "refunded",
+        "is_active": status_value in {"reserved", "paid"},
+    }
+
+
+def _build_stop(row: Sequence, lang: str) -> Dict[str, object]:
+    stop_id, order, arrival_time, departure_time, *_rest = row
+    return {
+        "id": stop_id,
+        "order": order,
+        "name": _choose_stop_name(row, lang),
+        "arrival_time": _format_time(arrival_time),
+        "departure_time": _format_time(departure_time),
+        "description": row[8],
+        "location": row[9],
+    }
+
+
+def _segment_times(
+    tour_date: Optional[date],
+    departure: Optional[time],
+    arrival: Optional[time],
+) -> Tuple[Optional[int], Optional[str]]:
+    if tour_date is None or departure is None or arrival is None:
+        return None, None
+    dep_dt = datetime.combine(tour_date, departure)
+    arr_dt = datetime.combine(tour_date, arrival)
+    if arr_dt <= dep_dt:
+        arr_dt += timedelta(days=1)
+    delta = arr_dt - dep_dt
+    minutes = int(delta.total_seconds() // 60)
+    return minutes, _humanize_duration(minutes)
+
+
+def get_ticket_dto(ticket_id: int, lang: str, conn) -> Dict[str, object]:
+    """Aggregate a comprehensive DTO for the specified ticket.
+
+    Parameters
+    ----------
+    ticket_id:
+        Identifier of the ticket to load.
+    lang:
+        Language code used when choosing the stop title (``bg``, ``en``, ``ua``)
+        with graceful fallback to the default name.
+    conn:
+        Database connection (psycopg2 connection or a compatible object).
+    """
+
+    base_query = """
+        SELECT
+            t.id,
+            t.seat_id,
+            s.seat_num,
+            t.passenger_id,
+            pa.name,
+            t.departure_stop_id,
+            t.arrival_stop_id,
+            t.extra_baggage,
+            t.tour_id,
+            tr.date,
+            tr.route_id,
+            r.name,
+            tr.pricelist_id,
+            tr.layout_variant,
+            tr.booking_terms,
+            t.purchase_id,
+            pu.customer_name,
+            pu.customer_email,
+            pu.customer_phone,
+            pu.amount_due,
+            pu.deadline,
+            pu.status,
+            pu.payment_method,
+            pu.update_at,
+            pr.price
+        FROM ticket t
+        JOIN passenger pa ON pa.id = t.passenger_id
+        LEFT JOIN seat s ON s.id = t.seat_id
+        LEFT JOIN tour tr ON tr.id = t.tour_id
+        LEFT JOIN route r ON r.id = tr.route_id
+        LEFT JOIN purchase pu ON pu.id = t.purchase_id
+        LEFT JOIN prices pr
+            ON pr.pricelist_id = tr.pricelist_id
+           AND pr.departure_stop_id = t.departure_stop_id
+           AND pr.arrival_stop_id = t.arrival_stop_id
+        WHERE t.id = %s
+    """
+
+    stops_query = """
+        SELECT
+            rs.stop_id,
+            rs."order",
+            rs.arrival_time,
+            rs.departure_time,
+            st.stop_name,
+            st.stop_en,
+            st.stop_bg,
+            st.stop_ua,
+            st.description,
+            st.location
+        FROM routestop rs
+        JOIN stop st ON st.id = rs.stop_id
+        WHERE rs.route_id = %s
+        ORDER BY rs."order"
+    """
+
+    cur = conn.cursor()
+    try:
+        cur.execute(base_query, (ticket_id,))
+        row = cur.fetchone()
+        if not row:
+            raise ValueError(f"Ticket {ticket_id} not found")
+
+        (
+            _ticket_id,
+            seat_id,
+            seat_num,
+            passenger_id,
+            passenger_name,
+            departure_stop_id,
+            arrival_stop_id,
+            extra_baggage,
+            tour_id,
+            tour_date,
+            route_id,
+            route_name,
+            pricelist_id,
+            layout_variant,
+            booking_terms_value,
+            purchase_id,
+            customer_name,
+            customer_email,
+            customer_phone,
+            amount_due,
+            deadline,
+            purchase_status,
+            payment_method,
+            updated_at,
+            price,
+        ) = row
+
+        booking_terms_enum = BookingTermsEnum(booking_terms_value)
+
+        cur.execute(stops_query, (route_id,))
+        stops_rows = cur.fetchall()
+    finally:
+        cur.close()
+
+    stops: List[Dict[str, object]] = []
+    stop_times: Dict[int, Dict[str, Optional[time]]] = {}
+    for stop_row in stops_rows:
+        stop = _build_stop(stop_row, lang)
+        stops.append(stop)
+        stop_times[int(stop_row[0])] = {
+            "arrival": stop_row[2],
+            "departure": stop_row[3],
+        }
+
+    departure_stop = next((s for s in stops if s["id"] == departure_stop_id), None)
+    arrival_stop = next((s for s in stops if s["id"] == arrival_stop_id), None)
+
+    dep_time_obj = stop_times.get(departure_stop_id, {}).get("departure") or stop_times.get(
+        departure_stop_id, {}
+    ).get("arrival")
+    arr_time_obj = stop_times.get(arrival_stop_id, {}).get("arrival") or stop_times.get(
+        arrival_stop_id, {}
+    ).get("departure")
+
+    duration_minutes, duration_label = _segment_times(tour_date, dep_time_obj, arr_time_obj)
+
+    if departure_stop and arrival_stop:
+        start_order = departure_stop["order"]
+        end_order = arrival_stop["order"]
+        between = [
+            {
+                "id": stop["id"],
+                "name": stop["name"],
+                "order": stop["order"],
+                "arrival_time": stop["arrival_time"],
+                "departure_time": stop["departure_time"],
+            }
+            for stop in stops
+            if start_order < stop["order"] < end_order
+        ]
+    else:
+        between = []
+
+    segment = {
+        "departure": None if departure_stop is None else {
+            "id": departure_stop["id"],
+            "name": departure_stop["name"],
+            "order": departure_stop["order"],
+            "time": departure_stop["departure_time"] or departure_stop["arrival_time"],
+        },
+        "arrival": None if arrival_stop is None else {
+            "id": arrival_stop["id"],
+            "name": arrival_stop["name"],
+            "order": arrival_stop["order"],
+            "time": arrival_stop["arrival_time"] or arrival_stop["departure_time"],
+        },
+        "intermediate_stops": between,
+        "duration_minutes": duration_minutes,
+        "duration_human": duration_label,
+    }
+
+    purchase_info: Optional[Dict[str, object]]
+    payment_details: Optional[Dict[str, object]]
+    if purchase_id is not None:
+        flags = _payment_flags(purchase_status)
+        purchase_info = {
+            "id": purchase_id,
+            "customer": {
+                "name": customer_name,
+                "email": customer_email,
+                "phone": customer_phone,
+            },
+            "amount_due": _decimal_to_float(amount_due),
+            "deadline": _format_datetime(deadline),
+            "payment_method": payment_method,
+            "updated_at": _format_datetime(updated_at),
+            "status": purchase_status,
+            "flags": flags,
+        }
+        payment_details = flags
+    else:
+        purchase_info = None
+        payment_details = None
+
+    dto = {
+        "ticket": {
+            "id": ticket_id,
+            "seat_id": seat_id,
+            "seat_number": seat_num,
+            "departure_stop_id": departure_stop_id,
+            "arrival_stop_id": arrival_stop_id,
+            "extra_baggage": extra_baggage,
+        },
+        "passenger": {
+            "id": passenger_id,
+            "name": passenger_name,
+        },
+        "tour": {
+            "id": tour_id,
+            "date": tour_date.isoformat() if tour_date else None,
+            "layout_variant": layout_variant,
+            "pricelist_id": pricelist_id,
+            "booking_terms": {
+                "value": int(booking_terms_enum),
+                "code": booking_terms_enum.name,
+            },
+        },
+        "route": {
+            "id": route_id,
+            "name": route_name,
+            "stops": stops,
+        },
+        "segment": segment,
+        "pricing": {
+            "price": _decimal_to_float(price),
+        },
+        "purchase": purchase_info,
+        "payment_status": payment_details,
+        "booking_rules": _booking_rules(booking_terms_enum),
+    }
+
+    return dto
+

--- a/tests/test_ticket_dto.py
+++ b/tests/test_ticket_dto.py
@@ -1,0 +1,233 @@
+import os
+import sys
+from datetime import date, datetime, time
+from decimal import Decimal
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.services.ticket_dto import get_ticket_dto
+
+
+class ScriptedCursor:
+    """A minimal cursor that replays predetermined query results."""
+
+    def __init__(self, script):
+        self._script = list(script)
+        self._current = None
+        self.queries = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, query, params=None):
+        normalized = " ".join(query.split())
+        self.queries.append((normalized, params))
+        if not self._script:
+            raise AssertionError("No scripted response left for query")
+        self._current = self._script.pop(0)
+
+    def fetchone(self):
+        if isinstance(self._current, list):
+            result = self._current[0] if self._current else None
+        else:
+            result = self._current
+        self._current = None
+        return result
+
+    def fetchall(self):
+        if self._current is None:
+            return []
+        if isinstance(self._current, list):
+            result = self._current
+            self._current = None
+            return result
+        raise AssertionError("fetchall called for scalar result")
+
+    def close(self):
+        pass
+
+
+class ScriptedConnection:
+    def __init__(self, script):
+        self._script = script
+
+    def cursor(self):
+        return ScriptedCursor(self._script)
+
+
+def test_ticket_dto_localization_and_duration():
+    base_row = (
+        1,  # ticket id
+        3,  # seat id
+        12,  # seat number
+        5,  # passenger id
+        "Ivan Petrov",  # passenger name
+        10,  # departure stop id
+        30,  # arrival stop id
+        2,  # extra baggage
+        100,  # tour id
+        date(2024, 5, 1),  # tour date
+        7,  # route id
+        "Sofia - Varna",  # route name
+        9,  # pricelist id
+        2,  # layout variant
+        1,  # booking terms -> EXPIRE_BEFORE_48H
+        50,  # purchase id
+        "Alex Buyer",  # customer name
+        "alex@example.com",  # customer email
+        "+359111111",  # customer phone
+        Decimal("45.50"),  # amount due
+        datetime(2024, 4, 30, 12, 0),  # deadline
+        "reserved",  # status
+        "online",  # payment method
+        datetime(2024, 4, 25, 9, 30),  # update at
+        Decimal("49.90"),  # price
+    )
+
+    stops_rows = [
+        (
+            10,
+            1,
+            None,
+            time(8, 0),
+            "Sofia",
+            "Sofia EN",
+            "София",
+            "Софія",
+            "Central station",
+            "https://example.com/a",
+        ),
+        (
+            20,
+            2,
+            time(10, 30),
+            time(10, 45),
+            "Plovdiv",
+            "Plovdiv EN",
+            "Пловдив",
+            "Пловдив",
+            "Mid stop",
+            None,
+        ),
+        (
+            30,
+            3,
+            time(13, 30),
+            None,
+            "Varna",
+            "Varna EN",
+            "Варна",
+            "Варна",
+            "Sea station",
+            "https://example.com/c",
+        ),
+    ]
+
+    conn = ScriptedConnection([base_row, stops_rows])
+
+    dto = get_ticket_dto(1, "bg", conn)
+
+    assert dto["ticket"]["seat_number"] == 12
+    assert dto["passenger"]["name"] == "Ivan Petrov"
+    assert dto["pricing"]["price"] == pytest.approx(49.90)
+
+    # Localised names are taken from ``stop_bg`` when available.
+    assert dto["route"]["stops"][0]["name"] == "София"
+    assert dto["segment"]["departure"]["name"] == "София"
+    assert dto["segment"]["arrival"]["name"] == "Варна"
+    assert dto["segment"]["intermediate_stops"][0]["name"] == "Пловдив"
+
+    # Duration is computed from the timetable entries.
+    assert dto["segment"]["duration_minutes"] == 330
+    assert dto["segment"]["duration_human"] == "5h 30m"
+
+    # Booking rules and payment status are exposed for UI rendering.
+    assert dto["booking_rules"]["code"] == "EXPIRE_BEFORE_48H"
+    assert dto["purchase"]["flags"]["is_paid"] is False
+    assert dto["purchase"]["customer"]["email"] == "alex@example.com"
+
+
+def test_ticket_dto_without_purchase_and_language_fallback():
+    base_row = (
+        2,
+        6,
+        18,
+        11,
+        "Maria Ivanova",
+        101,
+        202,
+        0,
+        300,
+        date(2024, 7, 20),
+        14,
+        "Night Route",
+        22,
+        1,
+        2,  # booking terms -> NO_EXPIRY
+        None,  # purchase id
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Decimal("35.00"),
+    )
+
+    stops_rows = [
+        (
+            101,
+            1,
+            None,
+            time(22, 30),
+            "Origin",
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            202,
+            2,
+            time(2, 0),
+            None,
+            "Destination",
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+    ]
+
+    conn = ScriptedConnection([base_row, stops_rows])
+
+    dto = get_ticket_dto(2, "de", conn)
+
+    # Unsupported languages fall back to the default stop name column.
+    assert dto["route"]["stops"][0]["name"] == "Origin"
+    assert dto["segment"]["arrival"]["name"] == "Destination"
+
+    # Purchase section is omitted when the ticket is not linked to a purchase.
+    assert dto["purchase"] is None
+    assert dto["payment_status"] is None
+
+    # Duration handles overnight trips (arrival time before departure).
+    assert dto["segment"]["duration_minutes"] == 210
+    assert dto["segment"]["duration_human"] == "3h 30m"
+    assert dto["booking_rules"]["code"] == "NO_EXPIRY"
+
+
+def test_ticket_dto_missing_ticket():
+    conn = ScriptedConnection([None])
+    with pytest.raises(ValueError):
+        get_ticket_dto(999, "en", conn)
+


### PR DESCRIPTION
## Summary
- add a backend service helper that aggregates ticket, passenger, route and pricing details with localisation and booking rules
- cover the new aggregator with database-style scripted tests verifying localisation, duration and error handling

## Testing
- pytest tests/test_ticket_dto.py

------
https://chatgpt.com/codex/tasks/task_e_68d68ae14f0c8327b7bb1738fd9deebd