### PR TITLE
Add ticket link revocation and public access guard

### DIFF
--- a/backend/routers/ticket.py
+++ b/backend/routers/ticket.py
@@ -17,6 +17,7 @@ from ._ticket_link_helpers import (
 from ..services.ticket_dto import get_ticket_dto
 from ..services.ticket_pdf import render_ticket_pdf
 from ..services import ticket_links
+from ..services.access_guard import guard_public_request
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,13 @@ def get_ticket_pdf(
     lang: str | None = None,
     context=Depends(require_scope("view")),
 ):
+    guard_public_request(
+        request,
+        "view",
+        ticket_id=ticket_id,
+        context=context,
+    )
+
     conn = get_connection()
     try:
         resolved_lang = lang or getattr(context, "lang", None) or "bg"

--- a/backend/services/access_guard.py
+++ b/backend/services/access_guard.py
@@ -1,0 +1,109 @@
+"""Helpers for logging and throttling public ticket link requests."""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from threading import Lock
+from typing import Optional
+
+from fastapi import HTTPException, Request
+
+from ..auth import RequestContext
+
+logger = logging.getLogger("backend.public_access")
+
+
+# Rate limiting parameters (can be monkeypatched in tests)
+RATE_LIMIT_MAX_REQUESTS = 10
+RATE_LIMIT_WINDOW_SECONDS = 10
+RATE_LIMIT_BURST = 3
+RATE_LIMIT_DELAY_SECONDS = 0.25
+
+
+@dataclass
+class _RateLimitEntry:
+    count: int
+    window_start: float
+
+
+_rate_limit_store: dict[str, _RateLimitEntry] = {}
+_rate_limit_lock = Lock()
+_time_fn = time.monotonic
+_sleep_fn = time.sleep
+
+
+def reset_rate_limit_state() -> None:
+    """Clear rate limit counters (useful for tests)."""
+
+    with _rate_limit_lock:
+        _rate_limit_store.clear()
+
+
+def _enforce_rate_limit(key: str) -> None:
+    """Check rate limit counters for the provided key."""
+
+    now = _time_fn()
+    with _rate_limit_lock:
+        entry = _rate_limit_store.get(key)
+        if entry and now - entry.window_start <= RATE_LIMIT_WINDOW_SECONDS:
+            entry.count += 1
+        else:
+            entry = _RateLimitEntry(count=1, window_start=now)
+        _rate_limit_store[key] = entry
+        count = entry.count
+
+    if count > RATE_LIMIT_MAX_REQUESTS:
+        delay = RATE_LIMIT_DELAY_SECONDS * min(count - RATE_LIMIT_MAX_REQUESTS, RATE_LIMIT_BURST)
+        if delay > 0:
+            _sleep_fn(delay)
+        if count > RATE_LIMIT_MAX_REQUESTS + RATE_LIMIT_BURST:
+            raise HTTPException(status_code=429, detail="Too many requests")
+
+
+def _extract_ip(request: Request) -> str:
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    if request.client:
+        return request.client.host
+    return "unknown"
+
+
+def guard_public_request(
+    request: Request,
+    scope: str,
+    *,
+    ticket_id: Optional[int] = None,
+    purchase_id: Optional[int] = None,
+    context: Optional[RequestContext] = None,
+) -> None:
+    """Log public access details and apply a lightweight rate limit."""
+
+    ip = _extract_ip(request)
+    token_id: Optional[str] = None
+    if context and not context.is_admin:
+        token_id = context.jti
+    elif context and context.is_admin:
+        token_id = "admin"
+    else:
+        token_id = request.headers.get("X-Ticket-Token") or None
+
+    rate_key = token_id or ip or "unknown"
+    _enforce_rate_limit(f"{scope}:{rate_key}")
+
+    logger.info(
+        "Public access scope=%s ip=%s token=%s ticket_id=%s purchase_id=%s",
+        scope,
+        ip,
+        token_id or "-",
+        ticket_id,
+        purchase_id,
+    )
+
+
+__all__ = [
+    "guard_public_request",
+    "reset_rate_limit_state",
+]

--- a/tests/test_access_guard.py
+++ b/tests/test_access_guard.py
@@ -1,0 +1,69 @@
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi import HTTPException
+
+from backend.auth import RequestContext
+from backend.services import access_guard
+
+
+class DummyRequest:
+    def __init__(self, ip: str = "127.0.0.1", token: str | None = None):
+        self.headers: dict[str, str] = {}
+        if token:
+            self.headers["X-Ticket-Token"] = token
+        self.client = SimpleNamespace(host=ip)
+
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    access_guard.reset_rate_limit_state()
+    yield
+    access_guard.reset_rate_limit_state()
+
+
+def test_guard_public_request_enforces_rate_limit(monkeypatch):
+    monkeypatch.setattr(access_guard, "RATE_LIMIT_MAX_REQUESTS", 2)
+    monkeypatch.setattr(access_guard, "RATE_LIMIT_BURST", 1)
+    monkeypatch.setattr(access_guard, "RATE_LIMIT_DELAY_SECONDS", 0.1)
+
+    current = {"value": 0.0}
+
+    def fake_time():
+        return current["value"]
+
+    sleeps: list[float] = []
+
+    def fake_sleep(duration: float) -> None:
+        sleeps.append(duration)
+
+    monkeypatch.setattr(access_guard, "_time_fn", fake_time)
+    monkeypatch.setattr(access_guard, "_sleep_fn", fake_sleep)
+
+    context = RequestContext(
+        is_admin=False,
+        link=None,
+        scopes=["view"],
+        ticket_id=55,
+        purchase_id=None,
+        lang="bg",
+        jti="rate-jti",
+    )
+    request = DummyRequest(ip="10.0.0.1")
+
+    access_guard.guard_public_request(request, "view", ticket_id=55, context=context)
+    access_guard.guard_public_request(request, "view", ticket_id=55, context=context)
+
+    with pytest.raises(HTTPException) as exc:
+        access_guard.guard_public_request(request, "view", ticket_id=55, context=context)
+
+    assert exc.value.status_code == 429
+    assert sleeps and sleeps[-1] == pytest.approx(0.1)
+
+    current["value"] = 100.0
+    access_guard.guard_public_request(request, "view", ticket_id=55, context=context)

--- a/tests/test_free_ticket.py
+++ b/tests/test_free_ticket.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, List, Tuple
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.ticket_utils import free_ticket
+from backend.services import ticket_links
+
+
+class StubCursor:
+    def __init__(self):
+        self._result: Any = None
+        self.available = "12"
+        self.jtis = ["jti-1", "jti-2"]
+        self.queries: List[Tuple[str, Tuple[Any, ...]]] = []
+
+    def execute(self, query, params=None):
+        normalized = " ".join(query.split()).lower()
+        self.queries.append((normalized, params or tuple()))
+        if normalized.startswith("select tour_id"):
+            self._result = (5, 7, 1, 3)
+        elif "select jti from ticket_link_tokens" in normalized:
+            self._result = [(jti,) for jti in self.jtis]
+        elif normalized.startswith("select route_id"):
+            self._result = (11,)
+        elif "select stop_id from routestop" in normalized:
+            self._result = [(1,), (2,), (3,)]
+        elif normalized.startswith("select available from seat"):
+            self._result = (self.available,)
+        elif normalized.startswith("update seat set available"):
+            self.available = params[0]
+            self._result = None
+        elif normalized.startswith("update available"):
+            self._result = None
+        elif normalized.startswith("delete from ticket"):
+            self._result = None
+        else:
+            raise AssertionError(f"Unexpected query: {query}")
+
+    def fetchone(self):
+        if isinstance(self._result, list):
+            if self._result:
+                return self._result.pop(0)
+            return None
+        result = self._result
+        self._result = None
+        return result
+
+    def fetchall(self):
+        if isinstance(self._result, list):
+            result = self._result
+            self._result = None
+            return result
+        if self._result is None:
+            return []
+        result = [self._result]
+        self._result = None
+        return result
+
+
+def test_free_ticket_revokes_tokens(monkeypatch):
+    revoked: List[str] = []
+
+    def fake_revoke(jti: str) -> bool:
+        revoked.append(jti)
+        return True
+
+    monkeypatch.setattr(ticket_links, "revoke", fake_revoke)
+
+    cursor = StubCursor()
+    free_ticket(cursor, ticket_id=42)
+
+    assert revoked == ["jti-1", "jti-2"]


### PR DESCRIPTION
## Summary
- add an in-memory access guard to log public ticket actions and throttle abusive requests
- revoke existing ticket link records when reissuing or cancelling/refunding tickets and expose a ticket link revoke helper
- cover the new behaviour with unit tests for token revocation, rate limiting, and the free_ticket helper

## Testing
- `pytest` *(fails: missing optional dependencies httpx and qrcode in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69b3ac7648327a3220c143dba8f94