### PR TITLE
Add ticket email notifications and templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,5 +38,5 @@ SMTP_HOST=smtp.example.com
 SMTP_PORT=587
 SMTP_USERNAME=example
 SMTP_PASSWORD=changeme
-SMTP_USE_TLS=true
-SMTP_FROM_EMAIL=noreply@example.com
+SMTP_FROM=noreply@example.com
+SMTP_FROM_NAME=Bus Tickets

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -1,0 +1,223 @@
+"""Email utilities for sending ticket notifications."""
+
+from __future__ import annotations
+
+import os
+import smtplib
+import ssl
+from datetime import datetime
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Any, Mapping, Tuple
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+DEFAULT_EMAIL_LANG = "bg"
+
+_TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates" / "emails"
+
+_ENV = Environment(
+    loader=FileSystemLoader(str(_TEMPLATES_DIR)),
+    autoescape=select_autoescape(["html", "xml"]),
+)
+
+_SUBJECT_TEMPLATES = {
+    "bg": "Вашият билет №{ticket}",
+    "en": "Your ticket #{ticket}",
+    "ua": "Ваш квиток №{ticket}",
+}
+
+_STATUS_LABELS = {
+    "bg": {
+        "paid": "потвърден",
+        "reserved": "резервиран",
+        "refunded": "възстановен",
+        "cancelled": "отменен",
+        "canceled": "отменен",
+        "default": "активен",
+    },
+    "en": {
+        "paid": "confirmed",
+        "reserved": "reserved",
+        "refunded": "refunded",
+        "cancelled": "cancelled",
+        "canceled": "cancelled",
+        "default": "active",
+    },
+    "ua": {
+        "paid": "підтверджений",
+        "reserved": "зарезервований",
+        "refunded": "повернений",
+        "cancelled": "скасований",
+        "canceled": "скасований",
+        "default": "активний",
+    },
+}
+
+
+class EmailConfigurationError(RuntimeError):
+    """Raised when SMTP configuration is invalid or missing."""
+
+
+def _get_env(name: str, required: bool = True) -> str | None:
+    value = os.getenv(name)
+    if required and not value:
+        raise EmailConfigurationError(f"Environment variable {name} is not configured")
+    return value
+
+
+def _resolve_lang(lang: str | None) -> str:
+    if not lang:
+        return DEFAULT_EMAIL_LANG
+    return lang.lower()
+
+
+def _resolve_subject(lang: str, ticket_number: Any, purchase_id: Any) -> str:
+    template = _SUBJECT_TEMPLATES.get(lang) or _SUBJECT_TEMPLATES[DEFAULT_EMAIL_LANG]
+    ticket_value = ticket_number or purchase_id or ""
+    purchase_value = purchase_id or ticket_value
+    return template.format(ticket=ticket_value, purchase=purchase_value)
+
+
+def _format_date(value: Any) -> str | None:
+    if not value:
+        return None
+    if isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value)
+        except ValueError:
+            return value
+        return dt.strftime("%d.%m.%Y")
+    if isinstance(value, datetime):
+        return value.strftime("%d.%m.%Y")
+    return str(value)
+
+
+def _status_text(lang: str, status_value: str | None) -> str:
+    labels = _STATUS_LABELS.get(lang) or _STATUS_LABELS[DEFAULT_EMAIL_LANG]
+    key = (status_value or "").lower()
+    if key in labels:
+        return labels[key]
+    return labels["default"]
+
+
+def _load_template(lang: str):
+    template_name = f"ticket_{lang}.html"
+    if not (_TEMPLATES_DIR / template_name).exists():
+        template_name = f"ticket_{DEFAULT_EMAIL_LANG}.html"
+    return _ENV.get_template(template_name)
+
+
+def render_ticket_email(
+    dto: Mapping[str, Any],
+    deep_link: str,
+    lang: str | None,
+) -> Tuple[str, str]:
+    """Render ticket email subject and HTML body for the given DTO."""
+
+    lang_value = _resolve_lang(lang)
+    template = _load_template(lang_value)
+
+    ticket = dto.get("ticket") if isinstance(dto, Mapping) else None
+    purchase = dto.get("purchase") if isinstance(dto, Mapping) else None
+    passenger = dto.get("passenger") if isinstance(dto, Mapping) else None
+    route = dto.get("route") if isinstance(dto, Mapping) else None
+    segment = dto.get("segment") if isinstance(dto, Mapping) else None
+    tour = dto.get("tour") if isinstance(dto, Mapping) else None
+
+    ticket_number = (ticket or {}).get("id")
+    seat_number = (ticket or {}).get("seat_number")
+
+    purchase_id = (purchase or {}).get("id")
+    purchase_status = (purchase or {}).get("status")
+    flags = (purchase or {}).get("flags") or dto.get("payment_status") or {}
+    status_value = flags.get("status") or purchase_status
+    status_text = _status_text(lang_value, status_value)
+
+    departure = (segment or {}).get("departure") or {}
+    arrival = (segment or {}).get("arrival") or {}
+
+    context = {
+        "lang": lang_value,
+        "customer_name": ((purchase or {}).get("customer") or {}).get("name")
+        or (passenger or {}).get("name"),
+        "ticket_number": ticket_number,
+        "purchase_id": purchase_id,
+        "seat_number": seat_number,
+        "route_name": (route or {}).get("name"),
+        "tour_date": _format_date((tour or {}).get("date")),
+        "departure_name": departure.get("name"),
+        "departure_time": departure.get("time"),
+        "arrival_name": arrival.get("name"),
+        "arrival_time": arrival.get("time"),
+        "status_text": status_text,
+        "is_paid": bool(flags.get("is_paid")),
+        "deep_link": deep_link,
+    }
+
+    html = template.render(**context)
+    subject = _resolve_subject(lang_value, ticket_number, purchase_id)
+    return subject, html
+
+
+def send_ticket_email(
+    to: str,
+    subject: str,
+    html_body: str,
+    pdf_bytes: bytes | None,
+) -> None:
+    """Send a ticket email with the provided HTML body and PDF attachment."""
+
+    host = _get_env("SMTP_HOST")
+    port_raw = _get_env("SMTP_PORT")
+    username = _get_env("SMTP_USERNAME", required=False)
+    password = _get_env("SMTP_PASSWORD", required=False)
+    from_email = _get_env("SMTP_FROM")
+    from_name = _get_env("SMTP_FROM_NAME", required=False)
+
+    port = int(port_raw) if port_raw else 587
+
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = f"{from_name} <{from_email}>" if from_name else from_email
+    message["To"] = to
+    message.set_content(
+        "This email requires an HTML-compatible client to display the ticket."
+    )
+    message.add_alternative(html_body, subtype="html")
+
+    if pdf_bytes:
+        filename = "ticket.pdf"
+        if subject:
+            safe_subject = subject.replace(" ", "-")
+            filename = f"{safe_subject}.pdf"
+        message.add_attachment(
+            pdf_bytes,
+            maintype="application",
+            subtype="pdf",
+            filename=filename,
+        )
+
+    context = ssl.create_default_context()
+    use_ssl = port == 465
+
+    if use_ssl:
+        smtp_cls = smtplib.SMTP_SSL
+        smtp_kwargs = {"context": context}
+    else:
+        smtp_cls = smtplib.SMTP
+        smtp_kwargs = {}
+
+    with smtp_cls(host, port, timeout=30, **smtp_kwargs) as server:
+        if not use_ssl:
+            server.starttls(context=context)
+        if username and password:
+            server.login(username, password)
+        server.send_message(message)
+
+
+__all__ = [
+    "EmailConfigurationError",
+    "render_ticket_email",
+    "send_ticket_email",
+]

--- a/backend/templates/emails/ticket_bg.html
+++ b/backend/templates/emails/ticket_bg.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="bg">
+  <body>
+    <p>Здравейте {{ customer_name or "пътник" }},</p>
+    <p>
+      Вашият билет <strong>№{{ ticket_number }}</strong>
+      {% if route_name %}за {{ route_name }}{% endif %}
+      в момента е <strong>{{ status_text }}</strong>.
+    </p>
+    <ul>
+      {% if tour_date %}<li><strong>Дата:</strong> {{ tour_date }}</li>{% endif %}
+      {% if departure_name or departure_time %}
+        <li>
+          <strong>Отпътуване:</strong>
+          {{ departure_name or "" }}
+          {% if departure_time %}— {{ departure_time }}{% endif %}
+        </li>
+      {% endif %}
+      {% if arrival_name or arrival_time %}
+        <li>
+          <strong>Пристигане:</strong>
+          {{ arrival_name or "" }}
+          {% if arrival_time %}— {{ arrival_time }}{% endif %}
+        </li>
+      {% endif %}
+      {% if seat_number %}<li><strong>Място:</strong> {{ seat_number }}</li>{% endif %}
+    </ul>
+    <p>
+      <a href="{{ deep_link }}">Отворете билета онлайн</a>
+      {% if is_paid %}(плащането е потвърдено){% endif %}
+    </p>
+    <p>PDF версията на билета е приложена към това писмо.</p>
+  </body>
+</html>

--- a/backend/templates/emails/ticket_en.html
+++ b/backend/templates/emails/ticket_en.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <p>Hello {{ customer_name or "traveller" }},</p>
+    <p>
+      Your ticket <strong>#{{ ticket_number }}</strong>
+      {% if route_name %}for {{ route_name }}{% endif %}
+      is currently <strong>{{ status_text }}</strong>.
+    </p>
+    <ul>
+      {% if tour_date %}<li><strong>Date:</strong> {{ tour_date }}</li>{% endif %}
+      {% if departure_name or departure_time %}
+        <li>
+          <strong>Departure:</strong>
+          {{ departure_name or "" }}
+          {% if departure_time %}— {{ departure_time }}{% endif %}
+        </li>
+      {% endif %}
+      {% if arrival_name or arrival_time %}
+        <li>
+          <strong>Arrival:</strong>
+          {{ arrival_name or "" }}
+          {% if arrival_time %}— {{ arrival_time }}{% endif %}
+        </li>
+      {% endif %}
+      {% if seat_number %}<li><strong>Seat:</strong> {{ seat_number }}</li>{% endif %}
+    </ul>
+    <p>
+      <a href="{{ deep_link }}">Open your ticket online</a>
+      {% if is_paid %}(payment confirmed){% endif %}
+    </p>
+    <p>The PDF version of your ticket is attached to this email.</p>
+  </body>
+</html>

--- a/backend/templates/emails/ticket_ua.html
+++ b/backend/templates/emails/ticket_ua.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="uk">
+  <body>
+    <p>Вітаємо {{ customer_name or "пасажир" }},</p>
+    <p>
+      Ваш квиток <strong>№{{ ticket_number }}</strong>
+      {% if route_name %}на рейс {{ route_name }}{% endif %}
+      зараз має статус <strong>{{ status_text }}</strong>.
+    </p>
+    <ul>
+      {% if tour_date %}<li><strong>Дата:</strong> {{ tour_date }}</li>{% endif %}
+      {% if departure_name or departure_time %}
+        <li>
+          <strong>Відправлення:</strong>
+          {{ departure_name or "" }}
+          {% if departure_time %}— {{ departure_time }}{% endif %}
+        </li>
+      {% endif %}
+      {% if arrival_name or arrival_time %}
+        <li>
+          <strong>Прибуття:</strong>
+          {{ arrival_name or "" }}
+          {% if arrival_time %}— {{ arrival_time }}{% endif %}
+        </li>
+      {% endif %}
+      {% if seat_number %}<li><strong>Місце:</strong> {{ seat_number }}</li>{% endif %}
+    </ul>
+    <p>
+      <a href="{{ deep_link }}">Відкрити квиток онлайн</a>
+      {% if is_paid %}(оплату підтверджено){% endif %}
+    </p>
+    <p>PDF-версію квитка додано до цього листа.</p>
+  </body>
+</html>

--- a/tests/test_book_then_purchase.py
+++ b/tests/test_book_then_purchase.py
@@ -34,6 +34,8 @@ class DummyCursor:
         q = self.query.lower()
         if 'select amount_due, status from purchase' in q:
             return [self.purchase_amount, self.purchase_status]
+        if 'select amount_due, customer_email from purchase' in q:
+            return [self.purchase_amount, 'a@b.com']
         if 'select route_id, pricelist_id from tour' in q:
             return [1, 1]
         if 'select id, available from seat' in q:
@@ -109,6 +111,12 @@ def client(monkeypatch):
     monkeypatch.setattr('backend.ticket_utils.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.services.ticket_links.verify', fake_verify)
+    monkeypatch.setattr('backend.routers.purchase.render_ticket_pdf', lambda *a, **k: b'%PDF-FAKE%')
+    monkeypatch.setattr(
+        'backend.routers.purchase.render_ticket_email',
+        lambda dto, deep_link, lang: ("subject", "<p>body</p>"),
+    )
+    monkeypatch.setattr('backend.routers.purchase.send_ticket_email', lambda *a, **k: None)
     if 'backend.main' in sys.modules:
         importlib.reload(sys.modules['backend.main'])
     else:

--- a/tests/test_booking_flow.py
+++ b/tests/test_booking_flow.py
@@ -24,6 +24,8 @@ class DummyCursor:
             return [1, 1, date(2024, 1, 1)]
         if "select route_id, date from tour" in q:
             return [1, date(2024, 1, 1)]
+        if "select amount_due, customer_email from purchase" in q:
+            return [10, "a@b.com"]
         if "select id, available from seat" in q:
             return [1, "1234"]
         if "select price from prices" in q:
@@ -129,6 +131,12 @@ def client(monkeypatch):
     monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.services.ticket_links.issue', fake_issue)
     monkeypatch.setattr('backend.services.ticket_links.verify', fake_verify)
+    monkeypatch.setattr('backend.routers.purchase.render_ticket_pdf', lambda *a, **k: b'%PDF-FAKE%')
+    monkeypatch.setattr(
+        'backend.routers.purchase.render_ticket_email',
+        lambda dto, deep_link, lang: ("subject", "<p>body</p>"),
+    )
+    monkeypatch.setattr('backend.routers.purchase.send_ticket_email', lambda *a, **k: None)
     if 'backend.main' in sys.modules:
         importlib.reload(sys.modules['backend.main'])
     else:

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -1,0 +1,443 @@
+import sys
+from datetime import date, time
+from types import SimpleNamespace
+
+import pytest
+from fastapi import BackgroundTasks
+from starlette.requests import Request
+
+sys.path.append('.')
+
+from backend.services.email import render_ticket_email
+
+
+@pytest.fixture
+def email_test_env(monkeypatch):
+    class DummyCursor:
+        def execute(self, *args, **kwargs):
+            return None
+
+        def fetchone(self):
+            return None
+
+        def close(self):
+            pass
+
+    class DummyPsycopgConn:
+        def __init__(self):
+            self.autocommit = False
+
+        def cursor(self):
+            return DummyCursor()
+
+        def commit(self):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr('psycopg2.connect', lambda *a, **k: DummyPsycopgConn())
+
+    state = {
+        "tour_date": date(2024, 1, 1),
+        "stop_times": {
+            1: time(8, 0),
+            2: time(9, 0),
+            3: time(10, 0),
+            4: time(11, 0),
+        },
+        "stops": {
+            1: "Sofia",
+            2: "Plovdiv",
+            3: "Varna",
+            4: "Burgas",
+        },
+        "tickets": [],
+        "purchases": {},
+        "next_ticket_id": 1,
+        "next_passenger_id": 1,
+        "next_purchase_id": 1,
+        "issue_counter": 0,
+        "emails": [],
+        "dto_status": "reserved",
+    }
+
+    class FakeCursor:
+        def __init__(self, state):
+            self.state = state
+            self.last_result = None
+            self.last_fetch_mode = "one"
+            self.query = ""
+
+        def execute(self, query, params=None):
+            self.query = query
+            q = query.lower()
+            if "select route_id, pricelist_id, date from tour" in q:
+                self.last_result = [1, 1, state["tour_date"]]
+                self.last_fetch_mode = "one"
+            elif "select route_id, date from tour" in q:
+                self.last_result = [1, state["tour_date"]]
+                self.last_fetch_mode = "one"
+            elif "select stop_id, departure_time from routestop" in q:
+                self.last_result = [
+                    (1, state["stop_times"][1]),
+                    (2, state["stop_times"][2]),
+                    (3, state["stop_times"][3]),
+                    (4, state["stop_times"][4]),
+                ]
+                self.last_fetch_mode = "all"
+            elif "select id, available from seat" in q:
+                if params:
+                    state["current_seat_num"] = params[1]
+                self.last_result = [1, "1234"]
+                self.last_fetch_mode = "one"
+            elif "select price from prices" in q:
+                self.last_result = [10]
+                self.last_fetch_mode = "one"
+            elif "select amount_due, status from purchase" in q:
+                purchase = state["purchases"].get(params[0])
+                if not purchase:
+                    self.last_result = None
+                else:
+                    self.last_result = [purchase["amount_due"], purchase["status"]]
+                self.last_fetch_mode = "one"
+            elif "select amount_due, customer_email from purchase" in q:
+                purchase = state["purchases"].get(params[0])
+                if not purchase:
+                    self.last_result = None
+                else:
+                    self.last_result = [purchase["amount_due"], purchase["customer_email"]]
+                self.last_fetch_mode = "one"
+            elif "select id from ticket where purchase_id" in q:
+                purchase_id = params[0]
+                self.last_result = [
+                    (ticket["id"],)
+                    for ticket in state["tickets"]
+                    if ticket["purchase_id"] == purchase_id
+                ]
+                self.last_fetch_mode = "all"
+            elif "select t.id" in q and "from ticket" in q and "join tour" in q:
+                purchase_id = params[0]
+                rows = []
+                for ticket in state["tickets"]:
+                    if ticket["purchase_id"] == purchase_id:
+                        rows.append(
+                            (
+                                ticket["id"],
+                                ticket["purchase_id"],
+                                state["tour_date"],
+                                state["stop_times"][ticket["departure_stop_id"]],
+                            )
+                        )
+                self.last_result = rows
+                self.last_fetch_mode = "all"
+            elif "insert into passenger" in q:
+                passenger_id = state["next_passenger_id"]
+                state["next_passenger_id"] += 1
+                self.last_result = [passenger_id]
+                self.last_fetch_mode = "one"
+            elif "insert into purchase" in q:
+                purchase_id = state["next_purchase_id"]
+                state["next_purchase_id"] += 1
+                purchase = {
+                    "id": purchase_id,
+                    "customer_name": params[0],
+                    "customer_email": params[1],
+                    "customer_phone": params[2],
+                    "amount_due": params[3],
+                    "status": "paid" if "'paid'" in q else "reserved",
+                }
+                state["purchases"][purchase_id] = purchase
+                self.last_result = [purchase_id]
+                self.last_fetch_mode = "one"
+            elif "insert into ticket" in q:
+                ticket_id = state["next_ticket_id"]
+                state["next_ticket_id"] += 1
+                (
+                    tour_id,
+                    seat_id,
+                    passenger_id,
+                    departure_stop_id,
+                    arrival_stop_id,
+                    purchase_id,
+                    extra_baggage,
+                ) = params
+                seat_number = state.get("current_seat_num", seat_id)
+                state["tickets"].append(
+                    {
+                        "id": ticket_id,
+                        "purchase_id": purchase_id,
+                        "tour_id": tour_id,
+                        "seat_id": seat_id,
+                        "seat_number": seat_number,
+                        "departure_stop_id": departure_stop_id,
+                        "arrival_stop_id": arrival_stop_id,
+                    }
+                )
+                self.last_result = [ticket_id]
+                self.last_fetch_mode = "one"
+            elif "update purchase set amount_due" in q and params:
+                purchase_id = params[-1]
+                purchase = state["purchases"].get(purchase_id)
+                if purchase:
+                    purchase["amount_due"] = params[0]
+                    if "status=%s" in q:
+                        purchase["status"] = params[1]
+            elif "update purchase set status='paid'" in q:
+                purchase_id = params[0]
+                purchase = state["purchases"].get(purchase_id)
+                if purchase:
+                    purchase["status"] = "paid"
+            else:
+                self.last_result = None
+                self.last_fetch_mode = "one"
+
+        def fetchone(self):
+            if self.last_fetch_mode == "all":
+                if not self.last_result:
+                    return None
+                return self.last_result[0]
+            return self.last_result
+
+        def fetchall(self):
+            if self.last_fetch_mode == "all":
+                return list(self.last_result)
+            if self.last_result is None:
+                return []
+            return [self.last_result]
+
+        def close(self):
+            pass
+
+    class FakeConn:
+        def __init__(self, state):
+            self.state = state
+            self.closed = False
+
+        def cursor(self):
+            return FakeCursor(self.state)
+
+        def commit(self):
+            pass
+
+        def rollback(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    def fake_get_connection():
+        return FakeConn(state)
+
+    def fake_issue_ticket_links(specs, lang):
+        results = []
+        for spec in specs:
+            state["issue_counter"] += 1
+            token = f"token-{state['issue_counter']}"
+            deep_link = f"https://example.test/ticket/{spec['ticket_id']}?token={token}"
+            results.append({"ticket_id": spec["ticket_id"], "deep_link": deep_link})
+        return results
+
+    def fake_send(to, subject, html_body, pdf_bytes):
+        state["emails"].append(
+            {
+                "to": to,
+                "subject": subject,
+                "html": html_body,
+                "pdf": pdf_bytes,
+            }
+        )
+
+    def fake_get_ticket_dto(ticket_id, lang, conn):
+        ticket = next((t for t in state["tickets"] if t["id"] == ticket_id), None)
+        if ticket is None:
+            raise ValueError("ticket not found")
+        purchase = state["purchases"].get(ticket["purchase_id"])
+        status = state.get("dto_status", purchase.get("status"))
+        is_paid = status == "paid"
+        departure_name = state["stops"].get(ticket["departure_stop_id"], "Departure")
+        arrival_name = state["stops"].get(ticket["arrival_stop_id"], "Arrival")
+        return {
+            "ticket": {
+                "id": ticket_id,
+                "seat_number": ticket.get("seat_number"),
+            },
+            "passenger": {"name": purchase.get("customer_name")},
+            "route": {"name": "Sofia — Varna"},
+            "tour": {"date": state["tour_date"].isoformat()},
+            "segment": {
+                "departure": {"name": departure_name, "time": "08:00"},
+                "arrival": {"name": arrival_name, "time": "11:00"},
+            },
+            "purchase": {
+                "id": purchase["id"],
+                "customer": {
+                    "name": purchase.get("customer_name"),
+                    "email": purchase.get("customer_email"),
+                },
+                "amount_due": purchase.get("amount_due"),
+                "status": status,
+                "flags": {"status": status, "is_paid": is_paid},
+                "payment_method": "online",
+            },
+            "payment_status": {"status": status, "is_paid": is_paid},
+        }
+
+    class DummyQR:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def add_data(self, *args, **kwargs):
+            pass
+
+        def make(self, *args, **kwargs):
+            pass
+
+        def make_image(self, *args, **kwargs):
+            class DummyImage:
+                def save(self, buffer, format="PNG"):
+                    buffer.write(b"")
+
+            return DummyImage()
+
+    class DummyHTML:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def write_pdf(self):
+            return b"%PDF%"
+
+    monkeypatch.setitem(sys.modules, 'qrcode', SimpleNamespace(QRCode=DummyQR))
+    monkeypatch.setitem(sys.modules, 'weasyprint', SimpleNamespace(HTML=DummyHTML))
+
+    from backend.routers import purchase as purchase_router
+
+    monkeypatch.setattr(purchase_router, 'get_connection', fake_get_connection)
+    monkeypatch.setattr(purchase_router, 'issue_ticket_links', fake_issue_ticket_links)
+    monkeypatch.setattr(purchase_router, 'render_ticket_pdf', lambda dto, deep_link: b'%PDF-FAKE%')
+    monkeypatch.setattr(purchase_router, 'send_ticket_email', fake_send)
+    monkeypatch.setattr(purchase_router, 'get_ticket_dto', fake_get_ticket_dto)
+
+    return state, purchase_router
+
+
+@pytest.mark.parametrize(
+    "lang, expected_subject, marker",
+    [
+        ("en", "Your ticket #42", "Open your ticket online"),
+        ("bg", "Вашият билет №42", "Отворете билета онлайн"),
+        ("ua", "Ваш квиток №42", "Відкрити квиток онлайн"),
+    ],
+)
+def test_render_ticket_email_localization(lang, expected_subject, marker):
+    dto = {
+        "ticket": {"id": 42, "seat_number": 7},
+        "passenger": {"name": "Ivan"},
+        "route": {"name": "Sofia — Varna"},
+        "tour": {"date": "2024-01-01"},
+        "segment": {
+            "departure": {"name": "Sofia", "time": "08:00"},
+            "arrival": {"name": "Varna", "time": "11:00"},
+        },
+        "purchase": {
+            "id": 99,
+            "customer": {"name": "Ivan", "email": "ivan@example.com"},
+            "amount_due": 15.5,
+            "status": "reserved",
+            "flags": {"status": "reserved", "is_paid": False},
+        },
+    }
+    deep_link = "https://example.test/ticket/42?token=abc"
+
+    subject, html = render_ticket_email(dto, deep_link, lang)
+
+    assert expected_subject in subject
+    assert deep_link in html
+    assert marker in html
+
+
+def _run_background_tasks(tasks: BackgroundTasks) -> None:
+    for task in tasks.tasks:
+        task.func(*task.args, **task.kwargs)
+
+
+def test_create_purchase_sends_email(email_test_env):
+    state, purchase_router = email_test_env
+
+    data = purchase_router.PurchaseCreate(
+        tour_id=1,
+        seat_nums=[1],
+        passenger_names=["Alice"],
+        passenger_phone="123",
+        passenger_email="alice@example.com",
+        departure_stop_id=1,
+        arrival_stop_id=3,
+        adult_count=1,
+        discount_count=0,
+        lang="en",
+    )
+    tasks = BackgroundTasks()
+
+    purchase_router.create_purchase(data, background_tasks=tasks)
+    assert tasks.tasks, "Expected background email task to be scheduled"
+
+    _run_background_tasks(tasks)
+
+    emails = state["emails"]
+    assert len(emails) == 1
+    email = emails[0]
+    assert email["to"] == "alice@example.com"
+    assert email["pdf"] == b"%PDF-FAKE%"
+    assert "https://example.test/ticket/1?token=token-1" in email["html"]
+    assert "Your ticket" in email["subject"]
+
+
+def test_pay_booking_sends_payment_confirmation(email_test_env):
+    state, purchase_router = email_test_env
+
+    data = purchase_router.PurchaseCreate(
+        tour_id=1,
+        seat_nums=[1],
+        passenger_names=["Alice"],
+        passenger_phone="123",
+        passenger_email="alice@example.com",
+        departure_stop_id=1,
+        arrival_stop_id=3,
+        adult_count=1,
+        discount_count=0,
+        lang="en",
+    )
+    initial_tasks = BackgroundTasks()
+    purchase_router.create_purchase(data, background_tasks=initial_tasks)
+    _run_background_tasks(initial_tasks)
+
+    state["emails"].clear()
+    state["dto_status"] = "paid"
+
+    pay_tasks = BackgroundTasks()
+    scope = {"type": "http", "headers": [], "query_string": b""}
+    request = Request(scope)
+    request.state.is_admin = True
+
+    pay_in = purchase_router.PayIn(purchase_id=1)
+    purchase_router.pay_booking(
+        pay_in,
+        request,
+        background_tasks=pay_tasks,
+        context=SimpleNamespace(),
+    )
+
+    assert pay_tasks.tasks, "Expected payment email task"
+    _run_background_tasks(pay_tasks)
+
+    emails = state["emails"]
+    assert len(emails) == 1
+    email = emails[0]
+    confirmation_markers = [
+        "(payment confirmed)",
+        "(плащането е потвърдено)",
+        "(оплату підтверджено)",
+    ]
+    assert any(marker in email["html"] for marker in confirmation_markers)
+    assert "token-2" in email["html"]
+    assert email["pdf"] == b"%PDF-FAKE%"

--- a/tests/test_multi_purchase.py
+++ b/tests/test_multi_purchase.py
@@ -26,6 +26,8 @@ class DummyCursor:
         q = self.query.lower()
         if 'select amount_due, status from purchase' in q:
             return [self.purchase_amount, self.purchase_status]
+        if 'select amount_due, customer_email from purchase' in q:
+            return [self.purchase_amount, 'a@b.com']
         if 'select route_id, pricelist_id from tour' in q:
             return [1, 1]
         if 'select id, available from seat' in q:
@@ -91,6 +93,12 @@ def client(monkeypatch):
     monkeypatch.setattr('backend.ticket_utils.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.services.ticket_links.verify', fake_verify)
+    monkeypatch.setattr('backend.routers.purchase.render_ticket_pdf', lambda *a, **k: b'%PDF-FAKE%')
+    monkeypatch.setattr(
+        'backend.routers.purchase.render_ticket_email',
+        lambda dto, deep_link, lang: ("subject", "<p>body</p>"),
+    )
+    monkeypatch.setattr('backend.routers.purchase.send_ticket_email', lambda *a, **k: None)
     if 'backend.main' in sys.modules:
         importlib.reload(sys.modules['backend.main'])
     else:

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -21,6 +21,8 @@ class DummyCursor:
             return [1, 1]
         if "select status from purchase" in q:
             return [self.status_resp]
+        if "select amount_due, customer_email from purchase" in q:
+            return [10, "a@b.com"]
         if "select route_id, pricelist_id, date from tour" in q:
             return [1, 1, date(2024, 1, 1)]
         if "select route_id, date from tour" in q:
@@ -125,6 +127,12 @@ def client(monkeypatch):
     monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.services.ticket_links.issue', fake_issue)
     monkeypatch.setattr('backend.services.ticket_links.verify', fake_verify)
+    monkeypatch.setattr('backend.routers.purchase.render_ticket_pdf', lambda *a, **k: b'%PDF-FAKE%')
+    monkeypatch.setattr(
+        'backend.routers.purchase.render_ticket_email',
+        lambda dto, deep_link, lang: ("subject", "<p>body</p>"),
+    )
+    monkeypatch.setattr('backend.routers.purchase.send_ticket_email', lambda *a, **k: None)
     if 'backend.main' in sys.modules:
         importlib.reload(sys.modules['backend.main'])
     else:

--- a/tests/test_roundtrip_purchase.py
+++ b/tests/test_roundtrip_purchase.py
@@ -31,6 +31,8 @@ class UniqueSalesCursor:
             return [1, "1234"]
         if "select amount_due, status from purchase" in q:
             return [10, 'paid']
+        if "select amount_due, customer_email from purchase" in q:
+            return [10, 'a@b.com']
         if "select amount_due from purchase" in q:
             return [10]
         return [1]
@@ -82,6 +84,12 @@ def client(monkeypatch):
     monkeypatch.setattr('backend.ticket_utils.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.services.ticket_links.verify', fake_verify)
+    monkeypatch.setattr('backend.routers.purchase.render_ticket_pdf', lambda *a, **k: b'%PDF-FAKE%')
+    monkeypatch.setattr(
+        'backend.routers.purchase.render_ticket_email',
+        lambda dto, deep_link, lang: ("subject", "<p>body</p>"),
+    )
+    monkeypatch.setattr('backend.routers.purchase.send_ticket_email', lambda *a, **k: None)
     if 'backend.main' in sys.modules:
         importlib.reload(sys.modules['backend.main'])
     else:


### PR DESCRIPTION
## Summary
- document the SMTP sender configuration in `.env.example`
- add `backend/services/email.py` plus localized templates to render ticket notification emails
- queue background email tasks in the purchase routes and add tests that mock SMTP delivery

## Testing
- pytest tests/test_email_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68d6986fdc6c8327967bee4f5236707f