### PR TITLE
Add ticket management APIs for public ticket links

### DIFF
--- a/backend/routers/_ticket_link_helpers.py
+++ b/backend/routers/_ticket_link_helpers.py
@@ -14,7 +14,15 @@ from ..services import ticket_links
 logger = logging.getLogger(__name__)
 
 DEFAULT_TICKET_LANG = "bg"
-DEFAULT_TICKET_SCOPES = ("view", "download")
+DEFAULT_TICKET_SCOPES = (
+    "view",
+    "download",
+    "pay",
+    "cancel",
+    "edit",
+    "seat",
+    "reschedule",
+)
 
 
 class TicketIssueSpec(TypedDict):


### PR DESCRIPTION
## Summary
- extend issued ticket link scopes to cover management actions
- add REST endpoints to read ticket details, update passenger info, change seats, and reschedule
- expose a ticket-specific seat map endpoint for client selection

## Testing
- pytest *(fails: missing optional dependencies such as httpx, jinja2, qrcode)*

------
https://chatgpt.com/codex/tasks/task_e_68d69ae4c7948327b57c49ca8a21b3a9