### PR TITLE
Pin bcrypt dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,6 @@ PyJWT>=2.0.0
 Jinja2==3.1.5
 qrcode[pil]==7.4.2
 WeasyPrint==63.0
-passlib[bcrypt]
+passlib[bcrypt]==1.7.4
+bcrypt==4.0.1
 httpx==0.27.2


### PR DESCRIPTION
## Summary
- pin passlib and bcrypt versions to avoid incompatibilities during authentication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d975e961d883279357d0a41e4e1dee