### PR TITLE
Ensure occupied seats stay active when saving tour edits

### DIFF
--- a/frontend/src/pages/ToursPage.js
+++ b/frontend/src/pages/ToursPage.js
@@ -184,12 +184,14 @@ export default function ToursPage() {
   const saveEdit = async () => {
     try {
       const finalActive = initialSeats
-        .filter(s=>s.status!=="occupied")
         .filter(s=>{
-          if(seatEdits.hasOwnProperty(s.seat_num)){
-            return !seatEdits[s.seat_num];
+          if(s.status==="occupied"){
+            return true;
           }
-          return s.status!=="blocked";
+          const isBlocked = seatEdits.hasOwnProperty(s.seat_num)
+            ? seatEdits[s.seat_num]
+            : s.status==="blocked";
+          return !isBlocked;
         })
         .map(s=>s.seat_num);
 


### PR DESCRIPTION
## Summary
- keep occupied seats in the active seat list when saving tour changes
- prevent 400 errors when saving after toggling seat availability

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da403b10708327aa1e6c11ecb3d822