### PR TITLE
Add link session support for ticket deep links

### DIFF
--- a/backend/services/link_sessions.py
+++ b/backend/services/link_sessions.py
@@ -1,0 +1,208 @@
+"""Utilities for managing short-lived ticket link sessions."""
+
+from __future__ import annotations
+import secrets
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Iterable, Tuple
+
+import jwt
+
+from ..database import get_connection
+from . import ticket_links
+
+
+_SCHEMA_READY = False
+_SCHEMA_LOCK = threading.Lock()
+
+
+def _ensure_schema(connection) -> None:
+    """Create the ``link_sessions`` table on demand."""
+
+    global _SCHEMA_READY
+    if _SCHEMA_READY:
+        return
+
+    with _SCHEMA_LOCK:
+        if _SCHEMA_READY:
+            return
+
+        with connection.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS link_sessions (
+                    id SERIAL PRIMARY KEY,
+                    ticket_id INTEGER NOT NULL,
+                    scope VARCHAR(32) NOT NULL,
+                    opaque VARCHAR(128) NOT NULL UNIQUE,
+                    token TEXT NOT NULL,
+                    jti UUID NOT NULL,
+                    expires_at TIMESTAMPTZ NOT NULL,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    revoked_at TIMESTAMPTZ
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_link_sessions_ticket_scope
+                    ON link_sessions (ticket_id, scope)
+                    WHERE revoked_at IS NULL
+                """
+            )
+            cur.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_link_sessions_jti
+                    ON link_sessions (jti)
+                """
+            )
+
+        _SCHEMA_READY = True
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_departure(dt: datetime | None) -> datetime:
+    if dt is None:
+        return _utcnow()
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _decode_payload(token: str) -> tuple[str, datetime | None]:
+    try:
+        payload = jwt.decode(token, options={"verify_signature": False})
+    except jwt.PyJWTError:
+        return "", None
+
+    jti = str(payload.get("jti") or "")
+    exp_value = payload.get("exp")
+    expires_at: datetime | None = None
+    if isinstance(exp_value, (int, float)):
+        expires_at = datetime.fromtimestamp(int(exp_value), tz=timezone.utc)
+
+    return jti, expires_at
+
+
+def _opaque_from_jti(jti: str) -> str:
+    cleaned = "".join(ch for ch in jti if ch.isalnum())
+    if cleaned:
+        return cleaned.lower()
+    return secrets.token_urlsafe(18)
+
+
+def _insert_session(
+    connection,
+    *,
+    ticket_id: int,
+    scope: str,
+    token: str,
+    jti: str,
+    expires_at: datetime,
+) -> Tuple[str, datetime]:
+    opaque = _opaque_from_jti(jti)
+    with connection.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO link_sessions (ticket_id, scope, opaque, token, jti, expires_at)
+            VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING opaque, expires_at
+            """,
+            (ticket_id, scope, opaque, token, jti, expires_at),
+        )
+        row = cur.fetchone()
+    if not row:
+        raise RuntimeError("Failed to create link session")
+    return row[0], row[1]
+
+
+def _select_active_session(connection, *, ticket_id: int, scope: str) -> tuple[str, datetime] | None:
+    with connection.cursor() as cur:
+        cur.execute(
+            """
+            SELECT opaque, expires_at
+              FROM link_sessions
+             WHERE ticket_id = %s
+               AND scope = %s
+               AND revoked_at IS NULL
+               AND expires_at > NOW()
+             ORDER BY expires_at DESC
+             LIMIT 1
+            """,
+            (ticket_id, scope),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    return row[0], row[1]
+
+
+def get_or_create_view_session(
+    ticket_id: int,
+    *,
+    purchase_id: int | None,
+    lang: str,
+    departure_dt: datetime | None,
+    scopes: Iterable[str] | None = None,
+    conn=None,
+) -> tuple[str, datetime]:
+    """Return an opaque identifier for the ticket view session."""
+
+    if ticket_id <= 0:
+        raise ValueError("ticket_id must be positive")
+
+    lang_value = (lang or "bg").lower()
+    actual_scopes = tuple(scopes or ("view",))
+    departure_value = _normalize_departure(departure_dt)
+
+    owns_connection = conn is None
+    connection = conn or get_connection()
+
+    try:
+        _ensure_schema(connection)
+
+        existing = _select_active_session(connection, ticket_id=ticket_id, scope="view")
+        if existing:
+            return existing
+
+        token = ticket_links.issue(
+            ticket_id=ticket_id,
+            purchase_id=purchase_id,
+            scopes=actual_scopes,
+            lang=lang_value,
+            departure_dt=departure_value,
+            conn=connection,
+        )
+
+        jti, token_exp = _decode_payload(token)
+        if not jti:
+            jti = str(uuid.uuid4())
+
+        expires_at = token_exp or departure_value
+
+        opaque, expires = _insert_session(
+            connection,
+            ticket_id=ticket_id,
+            scope="view",
+            token=token,
+            jti=jti,
+            expires_at=expires_at,
+        )
+
+        if owns_connection:
+            connection.commit()
+        return opaque, expires
+    finally:
+        if owns_connection:
+            try:
+                connection.close()
+            except Exception:
+                pass
+
+
+__all__ = ["get_or_create_view_session"]
+

--- a/db/migrations/007_create_link_sessions.sql
+++ b/db/migrations/007_create_link_sessions.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS link_sessions (
+    id SERIAL PRIMARY KEY,
+    ticket_id INTEGER NOT NULL,
+    scope VARCHAR(32) NOT NULL,
+    opaque VARCHAR(128) NOT NULL UNIQUE,
+    token TEXT NOT NULL,
+    jti UUID NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_link_sessions_ticket_scope
+    ON link_sessions (ticket_id, scope)
+    WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_link_sessions_jti
+    ON link_sessions (jti);

--- a/tests/test_email_notifications.py
+++ b/tests/test_email_notifications.py
@@ -233,8 +233,8 @@ def email_test_env(monkeypatch):
         results = []
         for spec in specs:
             state["issue_counter"] += 1
-            token = f"token-{state['issue_counter']}"
-            deep_link = f"https://example.test/ticket/{spec['ticket_id']}?token={token}"
+            opaque = f"opaque-{state['issue_counter']}"
+            deep_link = f"https://example.test/q/{opaque}"
             results.append({"ticket_id": spec["ticket_id"], "deep_link": deep_link})
         return results
 
@@ -347,7 +347,7 @@ def test_render_ticket_email_localization(lang, expected_subject, marker):
             "flags": {"status": "reserved", "is_paid": False},
         },
     }
-    deep_link = "https://example.test/ticket/42?token=abc"
+    deep_link = "https://example.test/q/opaque-42"
 
     subject, html = render_ticket_email(dto, deep_link, lang)
 
@@ -388,7 +388,7 @@ def test_create_purchase_sends_email(email_test_env):
     email = emails[0]
     assert email["to"] == "alice@example.com"
     assert email["pdf"] == b"%PDF-FAKE%"
-    assert "https://example.test/ticket/1?token=token-1" in email["html"]
+    assert "https://example.test/q/opaque-1" in email["html"]
     assert "Your ticket" in email["subject"]
 
 
@@ -439,5 +439,5 @@ def test_pay_booking_sends_payment_confirmation(email_test_env):
         "(оплату підтверджено)",
     ]
     assert any(marker in email["html"] for marker in confirmation_markers)
-    assert "token-2" in email["html"]
+    assert "https://example.test/q/opaque-2" in email["html"]
     assert email["pdf"] == b"%PDF-FAKE%"

--- a/tests/test_multi_purchase.py
+++ b/tests/test_multi_purchase.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import importlib
+from datetime import datetime, timezone
 from fastapi.testclient import TestClient
 import pytest
 
@@ -67,6 +68,7 @@ def client(monkeypatch):
         conn = DummyConn(cursor)
         store['cursor'] = cursor
         return conn
+    token_counter = {"value": 0}
     payloads = {
         "token-pay": {
             "ticket_id": 1,
@@ -90,9 +92,38 @@ def client(monkeypatch):
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
     import backend.database
     monkeypatch.setattr('backend.database.get_connection', fake_get_connection)
+    monkeypatch.setenv("TICKET_LINK_BASE_URL", "https://example.test")
+    def fake_issue(ticket_id, purchase_id, scopes, lang, departure_dt, conn=None):
+        token_counter["value"] += 1
+        return f"token-{token_counter['value']}"
+
     monkeypatch.setattr('backend.ticket_utils.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.services.ticket_links.verify', fake_verify)
+    monkeypatch.setattr('backend.services.ticket_links.issue', fake_issue)
+    session_counter = {"value": 0}
+
+    def fake_get_or_create_view_session(
+        ticket_id: int,
+        *,
+        purchase_id: int | None,
+        lang: str,
+        departure_dt,
+        scopes,
+        conn=None,
+    ) -> tuple[str, datetime]:
+        ticket_links.issue(
+            ticket_id,
+            purchase_id,
+            scopes,
+            lang,
+            departure_dt,
+            conn=conn,
+        )
+        session_counter["value"] += 1
+        return f"opaque-{session_counter['value']}", datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+    monkeypatch.setattr('backend.routers._ticket_link_helpers.get_or_create_view_session', fake_get_or_create_view_session)
     monkeypatch.setattr('backend.routers.purchase.render_ticket_pdf', lambda *a, **k: b'%PDF-FAKE%')
     monkeypatch.setattr(
         'backend.routers.purchase.render_ticket_email',

--- a/tests/test_roundtrip_purchase.py
+++ b/tests/test_roundtrip_purchase.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+from datetime import datetime, timezone
 from fastapi.testclient import TestClient
 import pytest
 
@@ -59,6 +60,7 @@ class UniqueSalesConn:
 def client(monkeypatch):
     def fake_get_connection():
         return UniqueSalesConn()
+    token_counter = {"value": 0}
     payloads = {
         "token-pay": {
             "ticket_id": 1,
@@ -81,9 +83,38 @@ def client(monkeypatch):
     sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
     import backend.database
     monkeypatch.setattr('backend.database.get_connection', fake_get_connection)
+    monkeypatch.setenv("TICKET_LINK_BASE_URL", "https://example.test")
+    def fake_issue(ticket_id, purchase_id, scopes, lang, departure_dt, conn=None):
+        token_counter["value"] += 1
+        return f"token-{token_counter['value']}"
+
     monkeypatch.setattr('backend.ticket_utils.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.routers.purchase.free_ticket', lambda *a, **k: None)
     monkeypatch.setattr('backend.services.ticket_links.verify', fake_verify)
+    monkeypatch.setattr('backend.services.ticket_links.issue', fake_issue)
+    session_counter = {"value": 0}
+
+    def fake_get_or_create_view_session(
+        ticket_id: int,
+        *,
+        purchase_id: int | None,
+        lang: str,
+        departure_dt,
+        scopes,
+        conn=None,
+    ) -> tuple[str, datetime]:
+        ticket_links.issue(
+            ticket_id,
+            purchase_id,
+            scopes,
+            lang,
+            departure_dt,
+            conn=conn,
+        )
+        session_counter["value"] += 1
+        return f"opaque-{session_counter['value']}", datetime(2030, 1, 1, tzinfo=timezone.utc)
+
+    monkeypatch.setattr('backend.routers._ticket_link_helpers.get_or_create_view_session', fake_get_or_create_view_session)
     monkeypatch.setattr('backend.routers.purchase.render_ticket_pdf', lambda *a, **k: b'%PDF-FAKE%')
     monkeypatch.setattr(
         'backend.routers.purchase.render_ticket_email',

--- a/tests/test_ticket_pdf.py
+++ b/tests/test_ticket_pdf.py
@@ -73,7 +73,7 @@ def test_render_ticket_pdf_produces_bytes():
         "payment_status": {"status": "paid", "is_paid": True},
     }
 
-    deep_link = "https://app.example.com/ticket/2732866?token=abc"
+    deep_link = "https://app.example.com/q/opaque-abc"
 
     pdf_bytes = render_ticket_pdf(dto, deep_link)
 


### PR DESCRIPTION
## Summary
- add a link session service and migration to persist opaque ticket link identifiers
- switch deep link generation and the ticket PDF endpoint to reuse link sessions and emit `/q/{opaque}` URLs
- update the test suite to exercise the new opaque links across ticket flows

## Testing
- pytest tests/test_ticket_pdf.py tests/test_ticket_pdf_endpoint.py tests/test_purchase.py
- pytest tests/test_booking_flow.py tests/test_multi_purchase.py tests/test_roundtrip_purchase.py tests/test_book_then_purchase.py tests/test_email_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68da788c7be08327ac2bb59af3779f44