### PR TITLE
Improve ticket PDF layout and QR formatting

### DIFF
--- a/backend/services/ticket_pdf.py
+++ b/backend/services/ticket_pdf.py
@@ -62,14 +62,15 @@ _DEFAULT_I18N: Dict[str, Any] = {
     "status_pending": "Ожидает оплаты",
     "status_unknown": "Статус неизвестен",
     "value_not_available": "—",
-    "footer_note": "Полис страхования ответственности перевозчика действует на протяжении всего рейса.",
-    "footer_brand": "Since 1992 · Максимов Турс",
+    "footer_line": "Полис действует на протяжении рейса · Since 1992 · Максимов Турс",
     "ticket_page_title": "Электронный билет №{number} — {brand}",
     "departure_label": "Отправление",
     "arrival_label": "Прибытие",
     "currency_code": "UAH",
-    "qr_hint": "Сканируйте QR-код, чтобы оплатить, отменить или перенести поездку.",
+    "qr_hint": "Сканируйте для управления поездкой.",
     "qr_unavailable": "QR-код недоступен",
+    "timezone_label": "UTC+2 / лок. время рейса",
+    "refund_rules_short": "Возврат: >72 ч — 90%, 72–24 ч — 70%, 24–12 ч — 50%, <12 ч — без возмещения",
 }
 
 _STATUS_TO_I18N_KEY = {
@@ -83,6 +84,8 @@ _STATUS_TO_I18N_KEY = {
 }
 
 _SUCCESS_STATUSES = {"paid", "refunded"}
+_WARNING_STATUSES = {"reserved", "pending", "awaiting"}
+_NEGATIVE_STATUSES = {"cancelled", "canceled"}
 
 
 def _merge_i18n(overrides: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
@@ -157,7 +160,7 @@ def _format_duration(minutes: Optional[int], fallback: Optional[str], i18n: Mapp
 def _generate_qr_data_uri(data: Optional[str]) -> Optional[str]:
     if not data:
         return None
-    qr = qrcode.QRCode(version=None, box_size=10, border=2)
+    qr = qrcode.QRCode(version=None, box_size=18, border=4)
     qr.add_data(data)
     qr.make(fit=True)
     img = qr.make_image(fill_color="black", back_color="white")
@@ -177,14 +180,28 @@ def _status_label(status: Optional[str], i18n: Mapping[str, Any]) -> str:
 
 
 def _status_css_class(status: Optional[str]) -> str:
-    if status and status.lower() in _SUCCESS_STATUSES:
+    if not status:
+        return ""
+    normalized = status.lower()
+    if normalized in _SUCCESS_STATUSES:
         return "ok"
+    if normalized in _WARNING_STATUSES:
+        return "warn"
+    if normalized in _NEGATIVE_STATUSES:
+        return "cancelled"
     return ""
 
 
 def _status_color(status: Optional[str]) -> Optional[str]:
-    if status and status.lower() in _SUCCESS_STATUSES:
+    if not status:
+        return None
+    normalized = status.lower()
+    if normalized in _SUCCESS_STATUSES:
         return "var(--success)"
+    if normalized in _WARNING_STATUSES:
+        return "var(--accent)"
+    if normalized in _NEGATIVE_STATUSES:
+        return "#4b5563"
     return None
 
 

--- a/backend/templates/ticket.html
+++ b/backend/templates/ticket.html
@@ -19,6 +19,8 @@
       --bg:#f5f7fb;
       --card:#ffffff;
       --success:#16a34a;
+      --warning:#ea580c;
+      --neutral:#cbd5f5;
       --r:14px; --pad:12px; --gap:12px;
       --fz:13px; --fz-sm:12px; --fz-lg:22px;
     }
@@ -46,25 +48,44 @@
       padding:14px 16px; border-bottom:1px solid var(--stroke);
       background:linear-gradient(180deg,#fff,#fbfdff);
     }
-    .brandline{display:flex;align-items:center;gap:12px;margin-bottom:6px}
+    .brandline{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:8px}
     .logo{
+      display:inline-block;
       width:34px;height:34px;border-radius:50%;
       background:radial-gradient(circle at 30% 30%, #fff 0 35%, var(--brand) 36% 100%);
     }
     .brandname{font-weight:900; color:var(--brand); letter-spacing:.3px}
-    .title{margin:0;font-size:16px}
-    .route{display:flex;gap:10px;align-items:baseline;flex-wrap:wrap}
+    .title{margin:0;font-size:16px;display:flex;align-items:center;gap:8px}
+    .stamp{
+      display:inline-flex;align-items:center;gap:6px;
+      padding:6px 12px;border-radius:999px;border:2px solid rgba(0,0,0,.08);
+      font-weight:800;font-size:12px;letter-spacing:.3px;text-transform:uppercase;
+      background:#f2fbf5;color:var(--success);
+      box-shadow:inset 0 0 0 1px rgba(255,255,255,.6);
+    }
+    .stamp svg{width:14px;height:14px;stroke:currentColor;stroke-width:2;fill:none}
+    .stamp.ok{background:#f2fbf5;color:var(--success);border-color:rgba(22,163,74,.25)}
+    .stamp.warn{background:#fff6ec;color:var(--warning);border-color:rgba(234,88,12,.35)}
+    .stamp.cancelled{background:#f3f4f6;color:#4b5563;border-color:rgba(148,163,184,.4)}
+
+    .route-row{display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+    .route-names{display:flex;gap:10px;align-items:baseline;flex-wrap:wrap}
     .city{font-weight:900;font-size:var(--fz-lg); letter-spacing:.2px}
-    .meta{color:var(--muted);font-size:var(--fz-sm);margin-top:2px}
+    .meta{color:var(--muted);font-size:var(--fz-sm);margin-top:6px;display:flex;flex-wrap:wrap;gap:6px 10px}
+    .meta span{display:flex;align-items:center;gap:4px}
+    .meta span:not(:first-child)::before{content:"·";margin-right:4px;color:var(--muted);font-weight:700}
 
     .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:6px}
     .chip{
-      padding:4px 10px;border:1px solid var(--stroke);border-radius:999px;
-      background:#fff;font-weight:700;font-size:12px
+      display:inline-flex;align-items:center;gap:6px;
+      padding:4px 12px;border-radius:999px;
+      border:1px solid var(--stroke);
+      background:#fff;font-weight:700;font-size:12px;line-height:1;
     }
-    .chip.ok{ border-color:#c7f3cf; background:#eefcf0; color:#166534 }
+    .chip svg{width:14px;height:14px;stroke:currentColor;stroke-width:1.8;fill:none}
     .chip.place{ border-color:#dbe2f3; background:#f3f6ff; color:#1e388a }
     .chip.bag{ border-color:#ffe0bf; background:#fff4e8; color:#a65300 }
+    .chip.duration{ border-color:#c7f3cf; background:#f2fbf5; color:#166534 }
 
     /* Правая сводка + QR + кнопка */
     .side{
@@ -74,15 +95,14 @@
     .kv{display:grid;grid-template-columns:auto 1fr;gap:4px 10px;font-size:var(--fz-sm);color:var(--muted)}
     .kv b{color:var(--ink);font-size:var(--fz)}
     .cta{display:flex;flex-direction:column;gap:6px}
-    .cta .hint{color:var(--muted);font-size:var(--fz-sm);line-height:1.4}
     .qr{display:flex;flex-direction:column;align-items:center;gap:8px}
     .qr-box{
-      width:128px;height:128px;border:1px solid var(--stroke);border-radius:12px;
-      display:flex;align-items:center;justify-content:center;background:#fff;padding:4px
+      width:4.2cm;height:4.2cm;border:1px solid var(--stroke);border-radius:14px;
+      display:flex;align-items:center;justify-content:center;background:#fff;padding:6px
     }
     .qr-box img{max-width:100%;max-height:100%}
     .qr-placeholder{color:var(--muted);font-size:var(--fz-sm);text-align:center;line-height:1.35;padding:8px}
-    .qr-hint{color:var(--muted);font-size:var(--fz-sm);text-align:center;line-height:1.35;max-width:140px}
+    .qr-hint{color:var(--muted);font-size:var(--fz-sm);text-align:center;line-height:1.35;max-width:160px}
     .btn{
       display:inline-block;margin-top:8px;padding:8px 10px;border-radius:10px;
       border:1px solid var(--brand); background:var(--brand); color:#fff; font-weight:800;
@@ -93,40 +113,49 @@
 
     /* Контент: 2 колонки */
     .content{display:grid;grid-template-columns:1.12fr 0.88fr; gap:var(--gap); padding:var(--pad)}
-    .card{border:1px solid var(--stroke);border-radius:12px;padding:10px 12px;background:#fff}
+    .card{border:1px solid var(--stroke);border-radius:12px;padding:12px 14px;background:#fff;display:flex;flex-direction:column;gap:10px}
+    .card-header{display:flex;align-items:center;justify-content:space-between;gap:8px}
     .card h3{
-      margin:0 0 8px;font-size:12px;color:var(--brand);
+      margin:0;font-size:12px;color:var(--brand);
       text-transform:uppercase; letter-spacing:.35px
     }
 
     /* Поездка — чистые строки (без координат) */
-    .timeline{display:grid;grid-template-columns:18px 1fr;gap:8px}
-    .tl{position:relative}
-    .dot{
-      width:8px;height:8px;border-radius:50%;background:var(--accent);margin-top:3px;
-      box-shadow:0 0 0 2px #fff inset, 0 0 0 2px var(--accent);
-    }
-    .bar{position:absolute;left:3px;top:14px;width:2px;height:calc(100% - 14px);background:var(--stroke)}
-    .leg{border:1px dashed var(--stroke);border-radius:10px;padding:8px 10px;margin-bottom:8px}
-    .leg h4{margin:0 0 3px;font-size:14px}
-    .line{margin:2px 0;color:var(--muted);font-size:var(--fz-sm);line-height:1.35}
+    .timeline{display:flex;flex-direction:column;gap:12px}
+    .stop{display:grid;grid-template-columns:32px 1fr;gap:10px}
+    .stop-icon{width:32px;height:32px;border-radius:12px;border:1px solid var(--stroke);display:flex;align-items:center;justify-content:center;background:#fff}
+    .stop-icon svg{width:18px;height:18px;stroke:var(--brand);stroke-width:1.8;fill:none}
+    .stop-body{display:flex;flex-direction:column;gap:6px}
+    .stop-header{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap}
+    .stop-header h4{margin:0;font-size:14px}
+    .stop-time{font-size:20px;font-weight:800;color:var(--ink);display:flex;align-items:baseline;gap:8px}
+    .stop-time small{font-size:11px;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:.4px}
+    .line{margin:0;color:var(--muted);font-size:var(--fz-sm);line-height:1.35}
     .pill{
-      display:inline-block;padding:4px 8px;border-radius:999px;
-      background:#fff6ea;border:1px solid #ffdfb8;color:#a65300;font-weight:800;font-size:12px
+      display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;
+      background:#fff4e8;border:1px solid #ffdcb6;color:#b45309;font-weight:800;font-size:12px
     }
 
     /* Таблички */
     .dl{display:grid;grid-template-columns:44% 56%;gap:6px 10px}
     .dl .k{color:var(--muted)} .dl .v{font-weight:800}
-    .stop-info{margin-top:6px;display:flex;flex-direction:column;gap:4px}
+    .stop-info{display:flex;flex-direction:column;gap:4px}
     .stop-description{color:var(--ink);font-size:var(--fz-sm);line-height:1.35}
     .stop-description strong{color:var(--muted);font-weight:600;margin-right:4px;font-size:var(--fz-sm)}
     .stop-location{color:var(--brand);font-weight:700;font-size:var(--fz-sm)}
     .stop-location:hover{filter:brightness(1.05)}
 
+    .fine-print{margin-top:6px;color:var(--muted);font-size:var(--fz-sm);line-height:1.35}
+
     /* Подвал */
     .footer{border-top:1px solid var(--stroke);padding:8px 12px;color:var(--muted);font-size:var(--fz-sm);
-            display:flex;justify-content:space-between;gap:10px;flex-wrap:wrap}
+            display:flex;justify-content:center;gap:10px;flex-wrap:wrap;text-align:center}
+
+    @media print{
+      .btn{padding:0;border:none;background:none;color:var(--brand);box-shadow:none;margin-top:0;text-decoration:underline}
+      .stop-location{display:none}
+      .cta{margin-top:4px}
+    }
   </style>
 </head>
 <body>
@@ -135,21 +164,35 @@
     <div class="top">
       <div>
         <div class="brandline">
-          <div class="logo"></div>
-          <h1 class="title"><span class="brandname">{{ i18n.brand_name }}</span> · {{ i18n.ticket_label }}</h1>
+          <h1 class="title"><span class="logo"></span><span class="brandname">{{ i18n.brand_name }}</span> · {{ i18n.ticket_label }}</h1>
+          {% if status_chip %}<span class="stamp {{ status_chip.css_class }}">
+            {% if status_chip.css_class == 'ok' %}<svg viewBox="0 0 24 24"><path d="m5 12 4 4 10-10"/></svg>{% elif status_chip.css_class == 'warn' %}<svg viewBox="0 0 24 24"><path d="M12 8v4l2 2m8-2a10 10 0 1 1-20 0 10 10 0 0 1 20 0Z"/></svg>{% elif status_chip.css_class == 'cancelled' %}<svg viewBox="0 0 24 24"><path d="m7 7 10 10M17 7 7 17"/></svg>{% endif %}
+            {{ status_chip.text }}
+          </span>{% endif %}
         </div>
-        <div class="route">
-          <div class="city">{{ route.from_city }}</div><div>→</div><div class="city">{{ route.to_city }}</div>
+        <div class="route-row">
+          <div class="route-names">
+            <div class="city">{{ route.from_city }}</div><div>→</div><div class="city">{{ route.to_city }}</div>
+          </div>
+          {% if ticket.seat_number %}
+          <span class="chip place">
+            <svg viewBox="0 0 24 24"><path d="M7 3h10M8 3v6m8-6v6M6 9h12l1 12H5l1-12Zm3 5h6"/></svg>
+            {{ i18n.seat_label }}: <b>{{ ticket.seat_number }}</b>
+          </span>
+          {% endif %}
         </div>
         <div class="meta">
-          {{ i18n.ticket_number_label }} <b>{{ ticket.number }}</b>
-          {% if ticket.order_number %} · {{ i18n.order_label }} <b>{{ ticket.order_number }}</b>{% endif %}
-          {% if ticket.trip_date %} · {{ i18n.trip_date_label }} <b>{{ ticket.trip_date }}</b>{% endif %}
+          <span>{{ i18n.ticket_number_label }} <b>{{ ticket.number }}</b></span>
+          {% if ticket.order_number %}<span>{{ i18n.order_label }} <b>{{ ticket.order_number }}</b></span>{% endif %}
+          {% if ticket.trip_date %}<span>{{ i18n.trip_date_label }} <b>{{ ticket.trip_date }}</b></span>{% endif %}
         </div>
         <div class="chips">
-          {% if status_chip %}<span class="chip {{ status_chip.css_class }}">{{ status_chip.text }}</span>{% endif %}
-          {% if ticket.seat_number %}<span class="chip place">{{ i18n.seat_label }}: <b>{{ ticket.seat_number }}</b></span>{% endif %}
-          {% if ticket.baggage_text %}<span class="chip bag">{{ i18n.baggage_label }}: <b>{{ ticket.baggage_text }}</b></span>{% endif %}
+          {% if ticket.baggage_text %}
+          <span class="chip bag">
+            <svg viewBox="0 0 24 24"><path d="M8 7V5a4 4 0 0 1 8 0v2m-9 0h10l1 12H6L7 7Zm3 4v6m4-6v6"/></svg>
+            {{ ticket.baggage_text }}
+          </span>
+          {% endif %}
         </div>
       </div>
 
@@ -163,7 +206,6 @@
           {% if deep_link %}
           <div class="cta">
             <a class="btn" href="{{ deep_link }}" target="_blank">{{ i18n.manage_online_button }}</a>
-            <div class="hint">{{ i18n.manage_online_hint }}</div>
           </div>
           {% endif %}
         </div>
@@ -182,53 +224,57 @@
     <div class="content">
       <!-- Поездка -->
       <div class="card">
-        <h3>{{ i18n.trip_section }}</h3>
+        <div class="card-header">
+          <h3>{{ i18n.trip_section }}</h3>
+          {% if timeline.duration_text %}
+          <span class="chip duration">
+            <svg viewBox="0 0 24 24"><path d="M12 6v6l3 3m6-3a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>
+            {{ timeline.duration_text }}
+          </span>
+          {% endif %}
+        </div>
         <div class="timeline">
-          <div class="tl"><div class="dot"></div><div class="bar"></div></div>
-          <div class="leg">
-            <h4>{{ departure.title }}</h4>
-            {% if departure.date or departure.time %}
-            <div class="line">{{ i18n.datetime_label }}:
-              {% if departure.date %}<span class="nowrap">{{ departure.date }}</span>{% endif %}
-              {% if departure.date and departure.time %} · {% endif %}
-              {% if departure.time %}<span class="nowrap">{{ departure.time }}</span>{% endif %}
+          <div class="stop">
+            <div class="stop-icon">
+              <svg viewBox="0 0 24 24"><path d="M5 13V7a4 4 0 0 1 4-4h6a4 4 0 0 1 4 4v6m-9 8 3-3 3 3"/></svg>
             </div>
-            {% endif %}
-            {% if departure.address or departure.map_url %}
-            <div class="stop-info">
-              {% if departure.address %}<div class="stop-description"><strong>{{ i18n.address_label }}:</strong> {{ departure.address }}</div>{% endif %}
-              {% if departure.map_url %}<a href="{{ departure.map_url }}" target="_blank" class="stop-location">{{ i18n.view_exact_location }}</a>{% endif %}
+            <div class="stop-body">
+              <div class="stop-header">
+                <h4>{{ departure.title }}</h4>
+                {% if departure.time %}<div class="stop-time">{{ departure.time }}<small>{{ i18n.timezone_label }}</small></div>{% endif %}
+              </div>
+              {% if departure.date %}<div class="line"><strong>{{ departure.date }}</strong></div>{% endif %}
+              {% if departure.address or departure.map_url %}<div class="stop-info">
+                {% if departure.address %}<div class="stop-description">{{ departure.address }}</div>{% endif %}
+                {% if departure.map_url %}<a href="{{ departure.map_url }}" target="_blank" class="stop-location">{{ i18n.view_exact_location }}</a>{% endif %}
+              </div>{% endif %}
             </div>
-            {% endif %}
           </div>
 
-          <div class="tl"><div class="dot"></div></div>
-          <div class="leg">
-            <h4>{{ arrival.title }}</h4>
-            {% if arrival.date or arrival.time %}
-            <div class="line">{{ i18n.datetime_label }}:
-              {% if arrival.date %}<span class="nowrap">{{ arrival.date }}</span>{% endif %}
-              {% if arrival.date and arrival.time %} · {% endif %}
-              {% if arrival.time %}<span class="nowrap">{{ arrival.time }}</span>{% endif %}
+          <div class="stop">
+            <div class="stop-icon">
+              <svg viewBox="0 0 24 24"><path d="M5 11v6a4 4 0 0 0 4 4h6a4 4 0 0 0 4-4v-6m-9-8 3 3 3-3"/></svg>
             </div>
-            {% endif %}
-            {% if arrival.address or arrival.map_url %}
-            <div class="stop-info">
-              {% if arrival.address %}<div class="stop-description"><strong>{{ i18n.address_label }}:</strong> {{ arrival.address }}</div>{% endif %}
-              {% if arrival.map_url %}<a href="{{ arrival.map_url }}" target="_blank" class="stop-location">{{ i18n.view_exact_location }}</a>{% endif %}
+            <div class="stop-body">
+              <div class="stop-header">
+                <h4>{{ arrival.title }}</h4>
+                {% if arrival.time %}<div class="stop-time">{{ arrival.time }}<small>{{ i18n.timezone_label }}</small></div>{% endif %}
+              </div>
+              {% if arrival.date %}<div class="line"><strong>{{ arrival.date }}</strong></div>{% endif %}
+              {% if arrival.address or arrival.map_url %}<div class="stop-info">
+                {% if arrival.address %}<div class="stop-description">{{ arrival.address }}</div>{% endif %}
+                {% if arrival.map_url %}<a href="{{ arrival.map_url }}" target="_blank" class="stop-location">{{ i18n.view_exact_location }}</a>{% endif %}
+              </div>{% endif %}
             </div>
-            {% endif %}
           </div>
         </div>
-
-        {% if timeline.duration_text %}
-        <div class="line" style="margin-top:6px;">{{ i18n.duration_label }}: <span class="pill">{{ timeline.duration_text }}</span></div>
-        {% endif %}
       </div>
 
       <!-- Пассажир + Оплата -->
       <div class="card">
-        <h3>{{ i18n.passenger_section }}</h3>
+        <div class="card-header">
+          <h3>{{ i18n.passenger_section }}</h3>
+        </div>
         <div class="dl">
           <div class="k">{{ i18n.full_name_label }}</div><div class="v">{{ passenger.name }}</div>
           {% if passenger.email %}<div class="k">E-mail</div><div class="v break">{{ passenger.email }}</div>{% endif %}
@@ -236,20 +282,21 @@
           {% if ticket.seat_number %}<div class="k">{{ i18n.seat_label }}</div><div class="v">{{ ticket.seat_number }}</div>{% endif %}
           {% if ticket.baggage_text %}<div class="k">{{ i18n.baggage_label }}</div><div class="v">{{ ticket.baggage_text }}</div>{% endif %}
         </div>
-
-        <h3 style="margin-top:10px;">{{ i18n.payment_section }}</h3>
+        <div class="card-header">
+          <h3>{{ i18n.payment_section }}</h3>
+        </div>
         <div class="dl">
           <div class="k">{{ i18n.status_label }}</div><div class="v"{% if payment.status_color %} style="color:{{ payment.status_color }}"{% endif %}>{{ payment.status_text }}</div>
           <div class="k">{{ i18n.method_label }}</div><div class="v">{{ payment.method_text }}</div>
           <div class="k">{{ i18n.amount_label }}</div><div class="v">{{ payment.amount_text }}</div>
         </div>
+        <div class="fine-print">{{ i18n.refund_rules_short }}</div>
       </div>
     </div>
 
     <!-- ПОДВАЛ -->
     <div class="footer">
-      <div>{{ i18n.footer_note }}</div>
-      <div>{{ i18n.footer_brand }}</div>
+      <div>{{ i18n.footer_line }}</div>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- redesign the ticket PDF header with a single status stamp, prominent seat/baggage chips, and condensed identifiers
- refresh the trip timeline by emphasising departure/arrival times, adding icons, and surfacing duration and refund notes inline
- update i18n strings and QR generation to deliver a clearer hint, timezone badge, and higher resolution QR code

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da9114c8a08327bc896a3b0778f73c