### PR TITLE
Make ticket PDF endpoint public in OpenAPI

### DIFF
--- a/backend/routers/ticket.py
+++ b/backend/routers/ticket.py
@@ -48,7 +48,7 @@ class TicketOut(BaseModel):
     deep_link: str
 
 
-@router.get("/{ticket_id}/pdf")
+@router.get("/{ticket_id}/pdf", openapi_extra={"security": []})
 def get_ticket_pdf(
     ticket_id: int,
     request: Request,


### PR DESCRIPTION
## Summary
- override the ticket PDF route's OpenAPI metadata so it no longer advertises authentication

## Testing
- pytest tests/test_ticket_pdf_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68dad48b85c48327b6d30837093fedb3