### PR TITLE
Implement public ticket session and OTP scaffolding

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -26,6 +26,7 @@ from .routers import (
     purchase,
     auth,
     bundle,
+    public,
 )
 from .routers.ticket_admin import router as admin_tickets_router
 from .routers.purchase_admin import router as admin_purchases_router
@@ -74,6 +75,8 @@ app.include_router(available.router)
 app.include_router(seat.router)
 app.include_router(search.router)
 app.include_router(bundle.router)
+app.include_router(public.session_router)
+app.include_router(public.router)
 app.include_router(admin_tickets_router)
 app.include_router(admin_purchases_router)
 app.include_router(auth.router)

--- a/backend/routers/_ticket_link_helpers.py
+++ b/backend/routers/_ticket_link_helpers.py
@@ -111,7 +111,7 @@ def build_deep_link(opaque: str, *, base_url: str | None = None) -> str:
 
     configured = base_url or os.getenv("TICKET_LINK_BASE_URL")
     if not configured:
-        configured = os.getenv("APP_PUBLIC_URL", "https://t.example.com")
+        configured = os.getenv("APP_PUBLIC_URL", "http://localhost:8000")
     configured = configured.rstrip("/")
     return f"{configured}/q/{opaque}"
 

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import RedirectResponse, Response
+
+from ..database import get_connection
+from ..services import link_sessions
+from ..services.access_guard import guard_public_request
+from ..services.ticket_dto import get_ticket_dto
+from ..services.ticket_pdf import render_ticket_pdf
+from ._ticket_link_helpers import build_deep_link
+
+session_router = APIRouter(tags=["public"])
+router = APIRouter(prefix="/public", tags=["public"])
+
+
+def _redirect_base_url(ticket_id: int) -> str:
+    return f"http://localhost:3001/ticket/{ticket_id}"
+
+
+def _require_view_session(request: Request, ticket_id: int | None = None) -> link_sessions.LinkSession:
+    session_id = request.cookies.get("minicab")
+    if not session_id:
+        raise HTTPException(status_code=401, detail="Missing ticket session")
+
+    session = link_sessions.get_session(
+        session_id,
+        scope="view",
+        require_redeemed=True,
+    )
+    if not session:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    now = datetime.now(timezone.utc)
+    if session.exp <= now:
+        raise HTTPException(status_code=401, detail="Session expired")
+
+    if ticket_id is not None and session.ticket_id != ticket_id:
+        raise HTTPException(status_code=403, detail="Session does not match ticket")
+
+    return session
+
+
+@session_router.get("/q/{opaque}")
+def exchange_qr_session(opaque: str, request: Request) -> RedirectResponse:
+    guard_public_request(request, "qr_exchange")
+    session = link_sessions.redeem_session(opaque, scope="view")
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    now = datetime.now(timezone.utc)
+    if session.exp <= now:
+        raise HTTPException(status_code=410, detail="Session expired")
+
+    guard_public_request(request, "qr_exchange", ticket_id=session.ticket_id)
+
+    remaining = int((session.exp - now).total_seconds())
+    if remaining <= 0:
+        remaining = 60
+
+    response = RedirectResponse(
+        url=_redirect_base_url(session.ticket_id),
+        status_code=302,
+    )
+    response.set_cookie(
+        "minicab",
+        session.jti,
+        max_age=remaining,
+        httponly=True,
+        samesite="lax",
+        path="/",
+        domain="localhost",
+    )
+    return response
+
+
+@router.get("/tickets/{ticket_id}")
+def get_public_ticket(ticket_id: int, request: Request) -> Any:
+    session = _require_view_session(request, ticket_id)
+    guard_public_request(request, "ticket_view", ticket_id=ticket_id)
+
+    link_sessions.touch_session_usage(session.jti, scope="view")
+
+    conn = get_connection()
+    try:
+        try:
+            dto = get_ticket_dto(ticket_id, "bg", conn)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail="Ticket not found") from exc
+    finally:
+        conn.close()
+
+    return jsonable_encoder(dto)
+
+
+@router.get("/tickets/{ticket_id}/pdf")
+def get_public_ticket_pdf(ticket_id: int, request: Request) -> Response:
+    session = _require_view_session(request, ticket_id)
+    guard_public_request(request, "ticket_pdf", ticket_id=ticket_id)
+
+    link_sessions.touch_session_usage(session.jti, scope="view")
+
+    conn = get_connection()
+    try:
+        try:
+            dto = get_ticket_dto(ticket_id, "bg", conn)
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail="Ticket not found") from exc
+    finally:
+        conn.close()
+
+    deep_link = build_deep_link(session.jti)
+    pdf_bytes = render_ticket_pdf(dto, deep_link)
+
+    headers = {
+        "Content-Disposition": f'inline; filename="ticket-{ticket_id}.pdf"',
+    }
+    return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)
+
+
+__all__ = ["router", "session_router"]

--- a/backend/services/otp.py
+++ b/backend/services/otp.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+import secrets
+import string
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from ..database import get_connection
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CHALLENGE_TTL_MINUTES = 10
+_DEFAULT_TOKEN_TTL_MINUTES = 15
+
+
+@dataclass
+class OTPChallenge:
+    id: str
+    ticket_id: int
+    purchase_id: Optional[int]
+    action: str
+    code: str
+    exp: datetime
+    attempts: int
+    verified_at: Optional[datetime]
+    created_at: datetime
+
+
+@dataclass
+class OperationToken:
+    token: str
+    ticket_id: int
+    purchase_id: Optional[int]
+    action: str
+    exp: datetime
+    created_at: datetime
+    used_at: Optional[datetime]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ensure_schema(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute("SELECT 1")
+
+
+def _generate_code() -> str:
+    return f"{secrets.randbelow(1_000_000):06d}"
+
+
+def _generate_token() -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(48))
+
+
+def create_challenge(
+    ticket_id: int,
+    purchase_id: int | None,
+    action: str,
+    *,
+    conn=None,
+    ttl_minutes: int = _DEFAULT_CHALLENGE_TTL_MINUTES,
+) -> OTPChallenge:
+    owns_connection = conn is None
+    connection = conn or get_connection()
+    try:
+        _ensure_schema(connection)
+        challenge_id = str(uuid.uuid4())
+        code = _generate_code()
+        exp = _utcnow() + timedelta(minutes=ttl_minutes)
+        with connection.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO otp_challenge (id, ticket_id, purchase_id, action, code, exp)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                RETURNING id, ticket_id, purchase_id, action, code, exp, attempts, verified_at, created_at
+                """,
+                (challenge_id, ticket_id, purchase_id, action, code, exp),
+            )
+            row = cur.fetchone()
+        if owns_connection:
+            connection.commit()
+        return OTPChallenge(*row)
+    finally:
+        if owns_connection:
+            connection.close()
+
+
+def verify_challenge(
+    challenge_id: str,
+    code: str,
+    *,
+    conn=None,
+    ttl_minutes: int = _DEFAULT_TOKEN_TTL_MINUTES,
+) -> OperationToken | None:
+    owns_connection = conn is None
+    connection = conn or get_connection()
+    try:
+        _ensure_schema(connection)
+        with connection.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, ticket_id, purchase_id, action, code, exp, attempts, verified_at, created_at
+                  FROM otp_challenge
+                 WHERE id = %s
+                """,
+                (challenge_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            challenge = OTPChallenge(*row)
+            now = _utcnow()
+            if challenge.exp <= now:
+                return None
+            if challenge.verified_at is not None:
+                cur.execute(
+                    """
+                    SELECT token, ticket_id, purchase_id, action, exp, created_at, used_at
+                      FROM op_token
+                     WHERE ticket_id = %s
+                       AND action = %s
+                       AND used_at IS NULL
+                       AND exp > NOW()
+                     ORDER BY exp DESC
+                     LIMIT 1
+                    """,
+                    (challenge.ticket_id, challenge.action),
+                )
+                token_row = cur.fetchone()
+                if token_row:
+                    return OperationToken(*token_row)
+                return None
+            if challenge.code != code:
+                cur.execute(
+                    "UPDATE otp_challenge SET attempts = attempts + 1 WHERE id = %s",
+                    (challenge_id,),
+                )
+                connection.commit()
+                return None
+            token_value = _generate_token()
+            token_exp = now + timedelta(minutes=ttl_minutes)
+            cur.execute(
+                """
+                INSERT INTO op_token (token, ticket_id, purchase_id, action, exp)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING token, ticket_id, purchase_id, action, exp, created_at, used_at
+                """,
+                (token_value, challenge.ticket_id, challenge.purchase_id, challenge.action, token_exp),
+            )
+            token_row = cur.fetchone()
+            cur.execute(
+                "UPDATE otp_challenge SET verified_at = %s WHERE id = %s",
+                (now, challenge_id),
+            )
+        if owns_connection:
+            connection.commit()
+        return OperationToken(*token_row)
+    finally:
+        if owns_connection:
+            connection.close()
+
+
+def consume_op_token(token: str, action: str, ticket_id: int, *, conn=None) -> bool:
+    owns_connection = conn is None
+    connection = conn or get_connection()
+    try:
+        _ensure_schema(connection)
+        with connection.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE op_token
+                   SET used_at = NOW()
+                 WHERE token = %s
+                   AND action = %s
+                   AND ticket_id = %s
+                   AND used_at IS NULL
+                   AND exp > NOW()
+                RETURNING token
+                """,
+                (token, action, ticket_id),
+            )
+            row = cur.fetchone()
+        if owns_connection:
+            connection.commit()
+        return bool(row)
+    finally:
+        if owns_connection:
+            connection.close()
+
+
+__all__ = [
+    "create_challenge",
+    "verify_challenge",
+    "consume_op_token",
+    "OTPChallenge",
+    "OperationToken",
+]

--- a/db/migrations/015_recreate_link_sessions.sql
+++ b/db/migrations/015_recreate_link_sessions.sql
@@ -1,0 +1,21 @@
+DROP TABLE IF EXISTS link_sessions;
+
+CREATE TABLE link_sessions (
+    jti VARCHAR(255) PRIMARY KEY,
+    ticket_id INTEGER NOT NULL,
+    purchase_id INTEGER,
+    scope VARCHAR(32) NOT NULL,
+    exp TIMESTAMPTZ NOT NULL,
+    redeemed TIMESTAMPTZ,
+    used TIMESTAMPTZ,
+    revoked TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_link_sessions_ticket_scope
+    ON link_sessions (ticket_id, scope)
+    WHERE revoked IS NULL;
+
+CREATE INDEX idx_link_sessions_purchase_scope
+    ON link_sessions (purchase_id, scope)
+    WHERE revoked IS NULL;

--- a/db/migrations/016_create_public_otp.sql
+++ b/db/migrations/016_create_public_otp.sql
@@ -1,0 +1,28 @@
+CREATE TABLE otp_challenge (
+    id UUID PRIMARY KEY,
+    ticket_id INTEGER NOT NULL,
+    purchase_id INTEGER,
+    action VARCHAR(32) NOT NULL,
+    code VARCHAR(6) NOT NULL,
+    exp TIMESTAMPTZ NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    verified_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_otp_challenge_ticket
+    ON otp_challenge (ticket_id, action);
+
+CREATE TABLE op_token (
+    token VARCHAR(255) PRIMARY KEY,
+    ticket_id INTEGER NOT NULL,
+    purchase_id INTEGER,
+    action VARCHAR(32) NOT NULL,
+    exp TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    used_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_op_token_ticket
+    ON op_token (ticket_id, action)
+    WHERE used_at IS NULL;


### PR DESCRIPTION
## Summary
- recreate the `link_sessions` table and add OTP-related tables via new migrations
- rework the link session service to mint opaque codes and build public-facing ticket deep links
- add public routes for QR redemption, ticket data/PDF access, and scaffold OTP challenge/token handling

## Testing
- pytest tests/test_ticket_pdf_endpoint.py

------
https://chatgpt.com/codex/tasks/task_e_68dae0e837908327873f55975cc29a92