### PR TITLE
Fix purchase view query for updated schema

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -180,7 +180,7 @@ def _load_purchase_view(purchase_id: int, lang: str = _DEFAULT_LANG) -> Mapping[
             cur.execute(
                 """
                 SELECT id, status, amount_due, customer_name, customer_email,
-                       customer_phone, created_at, update_at
+                       customer_phone, update_at
                   FROM purchase
                  WHERE id = %s
                 """,
@@ -201,6 +201,7 @@ def _load_purchase_view(purchase_id: int, lang: str = _DEFAULT_LANG) -> Mapping[
             cur.close()
 
         tickets = [get_ticket_dto(tid, lang, conn) for tid in ticket_ids]
+        timestamp = row[6]
         return {
             "id": purchase_id,
             "status": row[1],
@@ -210,8 +211,8 @@ def _load_purchase_view(purchase_id: int, lang: str = _DEFAULT_LANG) -> Mapping[
                 "email": row[4],
                 "phone": row[5],
             },
-            "created_at": row[6].isoformat() if row[6] else None,
-            "updated_at": row[7].isoformat() if row[7] else None,
+            "created_at": timestamp.isoformat() if timestamp else None,
+            "updated_at": timestamp.isoformat() if timestamp else None,
             "tickets": tickets,
         }
     finally:


### PR DESCRIPTION
## Summary
- adjust the public purchase view query to match the current purchase table schema
- reuse the stored update_at timestamp when populating created_at and updated_at values in the response

## Testing
- pytest tests/test_book_then_purchase.py -k public --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68dbc87a255c8327a5f019b81da09763