### PR TITLE
Handle missing purchase totals data

### DIFF
--- a/frontend/src/pages/PurchasesPage.js
+++ b/frontend/src/pages/PurchasesPage.js
@@ -4,11 +4,33 @@ import { API } from "../config";
 import { downloadTicketPdf } from "../utils/ticket";
 import "../styles/PurchasesPage.css";
 
+const EMPTY_TOTALS = { pax_count: 0, baggage_count: 0, hand_baggage_count: 0 };
+
 const formatDateShort = (date) => {
   if (!date) return "";
   const d = new Date(date);
   const pad = (n) => String(n).padStart(2, "0");
   return `${pad(d.getDate())}/${pad(d.getMonth() + 1)}`;
+};
+
+const normalizePurchaseDetails = (details) => {
+  if (!details || typeof details !== "object") {
+    return { tickets: [], logs: [], totals: { ...EMPTY_TOTALS } };
+  }
+
+  const tickets = Array.isArray(details.tickets) ? details.tickets : [];
+  const logs = Array.isArray(details.logs) ? details.logs : [];
+
+  const rawTotals = details.totals && typeof details.totals === "object" ? details.totals : {};
+  const totals = {
+    pax_count: Number.isFinite(rawTotals.pax_count) ? rawTotals.pax_count : 0,
+    baggage_count: Number.isFinite(rawTotals.baggage_count) ? rawTotals.baggage_count : 0,
+    hand_baggage_count: Number.isFinite(rawTotals.hand_baggage_count)
+      ? rawTotals.hand_baggage_count
+      : 0,
+  };
+
+  return { ...details, tickets, logs, totals };
 };
 
 export default function PurchasesPage() {
@@ -30,7 +52,11 @@ export default function PurchasesPage() {
             axios
               .get(`${API}/admin/purchases/${p.id}`)
               .then((res) => {
-                map[p.id] = res.data;
+                map[p.id] = normalizePurchaseDetails(res.data);
+              })
+              .catch((err) => {
+                console.error(err);
+                map[p.id] = normalizePurchaseDetails();
               })
           )
         );
@@ -96,141 +122,159 @@ export default function PurchasesPage() {
           </tr>
         </thead>
         <tbody>
-          {items.map((p) => (
-            <React.Fragment key={p.id}>
-              <tr data-id={p.id}>
-                <td>{p.id}</td>
-                <td>
-                  {p.customer_name}<br />
-                  {p.customer_phone && <small>{p.customer_phone}<br /></small>}
-                  {p.customer_email && <small>{p.customer_email}</small>}
-                </td>
-                <td>
-                  {info[p.id]
-                    ? Array.from(new Set(info[p.id].tickets.map((t) => t.passenger_id))).length
-                    : ""}
-                </td>
-                <td>{info[p.id] ? info[p.id].tickets.length : ""}</td>
-                <td>
-                  {info[p.id]
-                    ? Array.from(new Set(info[p.id].tickets.map((t) => formatDateShort(t.tour_date)))).join(", ")
-                    : ""}
-                </td>
-                <td>{p.amount_due}</td>
-                <td>{statusBadge(p.status)}</td>
-                <td>{p.payment_method || "-"}</td>
-                <td>
-                  <button className="btn" onClick={() => toggleInfo(p.id)}>
-                    {expandedId === p.id ? "Скрыть" : "Инфо"}
-                  </button>
-                  {p.status === "reserved" && (
-                    <>
-                      <button className="btn primary" onClick={() => handlePay(p.id)}>Pay</button>
-                      <button className="btn" onClick={() => handleCancel(p.id)}>Cancel</button>
-                    </>
-                  )}
-                  {p.status === "paid" && (
-                    <button className="btn" onClick={() => handleRefund(p.id)}>Refund</button>
-                  )}
-                </td>
-              </tr>
-              {expandedId === p.id && info[p.id] && (
-                <tr className="details" data-details-for={p.id}>
-                  <td colSpan="9">
-                    <div className="details-inner">
-                      <div className="card">
-                        <h4>Билеты</h4>
-                        <table className="table-mini">
-                          <thead>
-                            <tr>
-                              <th>Пассажир</th>
-                              <th>Откуда</th>
-                              <th>Куда</th>
-                              <th>Дата</th>
-                              <th>Место</th>
-                              <th>Багаж</th>
-                              <th>Действия</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {info[p.id].tickets.map((t) => (
-                              <tr key={t.id}>
-                                <td>{t.passenger_name}</td>
-                                <td>{t.from_stop_name}</td>
-                                <td>{t.to_stop_name}</td>
-                                <td>{formatDateShort(t.tour_date)}</td>
-                                <td>{t.seat_num}</td>
-                                <td>{t.extra_baggage ? "Да" : "—"}</td>
-                                <td>
-                                  <button
-                                    type="button"
-                                    className="btn btn--sm"
-                                    onClick={() => handleTicketDownload(t.id)}
-                                  >
-                                    Скачать
-                                  </button>
-                                </td>
-                              </tr>
-                            ))}
-                          </tbody>
-                        </table>
-                      </div>
-                      <div className="card">
-                        <h4>Логи заказа</h4>
-                        <table className="table-mini">
-                          <thead>
-                            <tr>
-                              <th>Действие</th>
-                              <th>Дата/время</th>
-                              <th>Пользователь</th>
-                              <th>Способ</th>
-                              <th>Сумма</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {info[p.id].logs.length ? (
-                              info[p.id].logs.map((l) => (
-                                <tr key={l.id}>
-                                  <td>{l.action}</td>
-                                  <td>{new Date(l.at).toLocaleString('ru-RU', { timeZone: 'Europe/Sofia', hour12: false })}</td>
-                                  <td>{l.by || '—'}</td>
-                                  <td>{l.method || '—'}</td>
-                                  <td>{l.amount}</td>
-                                </tr>
-                              ))
-                            ) : (
-                              <tr>
-                                <td colSpan="5">Нет действий</td>
-                              </tr>
-                            )}
-                          </tbody>
-                        </table>
-                      </div>
-                      <div className="card actions-col">
-                        <h4>Действия</h4>
-                        <button className="btn" onClick={() => toggleInfo(p.id)}>Скрыть</button>
-                        {p.status === "reserved" && (
-                          <>
-                            <button className="btn primary" onClick={() => handlePay(p.id)}>
-                              Отметить оплату (офлайн)
-                            </button>
-                            <button className="btn" onClick={() => handleCancel(p.id)}>
-                              Отменить бронь
-                            </button>
-                          </>
-                        )}
-                        {p.status === "paid" && (
-                          <button className="btn" onClick={() => handleRefund(p.id)}>
-                            Возврат
-                          </button>
-                        )}
-                      </div>
-                    </div>
+          {items.map((p) => {
+            const details = info[p.id];
+            const tickets = details?.tickets ?? [];
+            const logs = details?.logs ?? [];
+            const totals = details?.totals ?? { ...EMPTY_TOTALS };
+
+            const passengerCount = tickets.length
+              ? Array.from(new Set(tickets.map((t) => t.passenger_id))).length
+              : "";
+            const ticketCount = tickets.length || "";
+            const tourDates = tickets.length
+              ? Array.from(new Set(tickets.map((t) => formatDateShort(t.tour_date)))).join(", ")
+              : "";
+
+            return (
+              <React.Fragment key={p.id}>
+                <tr data-id={p.id}>
+                  <td>{p.id}</td>
+                  <td>
+                    {p.customer_name}<br />
+                    {p.customer_phone && <small>{p.customer_phone}<br /></small>}
+                    {p.customer_email && <small>{p.customer_email}</small>}
+                  </td>
+                  <td>{passengerCount}</td>
+                  <td>{ticketCount}</td>
+                  <td>{tourDates}</td>
+                  <td>{p.amount_due}</td>
+                  <td>{statusBadge(p.status)}</td>
+                  <td>{p.payment_method || "-"}</td>
+                  <td>
+                    <button className="btn" onClick={() => toggleInfo(p.id)}>
+                      {expandedId === p.id ? "Скрыть" : "Инфо"}
+                    </button>
+                    {p.status === "reserved" && (
+                      <>
+                        <button className="btn primary" onClick={() => handlePay(p.id)}>Pay</button>
+                        <button className="btn" onClick={() => handleCancel(p.id)}>Cancel</button>
+                      </>
+                    )}
+                    {p.status === "paid" && (
+                      <button className="btn" onClick={() => handleRefund(p.id)}>Refund</button>
+                    )}
                   </td>
                 </tr>
-              )}
-            </React.Fragment>
-          ))}
+                {expandedId === p.id && details && (
+                  <tr className="details" data-details-for={p.id}>
+                    <td colSpan="9">
+                      <div className="details-inner">
+                        <div className="card">
+                          <h4>Билеты</h4>
+                          <div className="tag-list">
+                            <span className="tag">Пассажиры: {totals.pax_count}</span>
+                            <span className="tag">Багаж: {totals.baggage_count}</span>
+                            <span className="tag">Ручная кладь: {totals.hand_baggage_count}</span>
+                          </div>
+                          <table className="table-mini">
+                            <thead>
+                              <tr>
+                                <th>Пассажир</th>
+                                <th>Откуда</th>
+                                <th>Куда</th>
+                                <th>Дата</th>
+                                <th>Место</th>
+                                <th>Багаж</th>
+                                <th>Действия</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {tickets.length ? (
+                                tickets.map((t) => (
+                                  <tr key={t.id}>
+                                    <td>{t.passenger_name}</td>
+                                    <td>{t.from_stop_name}</td>
+                                    <td>{t.to_stop_name}</td>
+                                    <td>{formatDateShort(t.tour_date)}</td>
+                                    <td>{t.seat_num}</td>
+                                    <td>{t.extra_baggage ? "Да" : "—"}</td>
+                                    <td>
+                                      <button
+                                        type="button"
+                                        className="btn btn--sm"
+                                        onClick={() => handleTicketDownload(t.id)}
+                                      >
+                                        Скачать
+                                      </button>
+                                    </td>
+                                  </tr>
+                                ))
+                              ) : (
+                                <tr>
+                                  <td colSpan="7">Нет билетов</td>
+                                </tr>
+                              )}
+                            </tbody>
+                          </table>
+                        </div>
+                        <div className="card">
+                          <h4>Логи заказа</h4>
+                          <table className="table-mini">
+                            <thead>
+                              <tr>
+                                <th>Действие</th>
+                                <th>Дата/время</th>
+                                <th>Пользователь</th>
+                                <th>Способ</th>
+                                <th>Сумма</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {logs.length ? (
+                                logs.map((l) => (
+                                  <tr key={l.id}>
+                                    <td>{l.action}</td>
+                                    <td>{new Date(l.at).toLocaleString('ru-RU', { timeZone: 'Europe/Sofia', hour12: false })}</td>
+                                    <td>{l.by || '—'}</td>
+                                    <td>{l.method || '—'}</td>
+                                    <td>{l.amount}</td>
+                                  </tr>
+                                ))
+                              ) : (
+                                <tr>
+                                  <td colSpan="5">Нет действий</td>
+                                </tr>
+                              )}
+                            </tbody>
+                          </table>
+                        </div>
+                        <div className="card actions-col">
+                          <h4>Действия</h4>
+                          <button className="btn" onClick={() => toggleInfo(p.id)}>Скрыть</button>
+                          {p.status === "reserved" && (
+                            <>
+                              <button className="btn primary" onClick={() => handlePay(p.id)}>
+                                Отметить оплату (офлайн)
+                              </button>
+                              <button className="btn" onClick={() => handleCancel(p.id)}>
+                                Отменить бронь
+                              </button>
+                            </>
+                          )}
+                          {p.status === "paid" && (
+                            <button className="btn" onClick={() => handleRefund(p.id)}>
+                              Возврат
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/frontend/src/styles/PurchasesPage.css
+++ b/frontend/src/styles/PurchasesPage.css
@@ -13,6 +13,8 @@ tr.details > td { background:#fafbff; padding:0; }
 .details-inner { display:grid; grid-template-columns: 2fr 1.2fr 0.8fr; gap:12px; padding:14px; }
 .card { background:#fff; border:1px solid #e5e7eb; border-radius:10px; padding:10px; }
 .card h4 { margin:0 0 8px; font-size:14px; color:#111827; }
+.tag-list { display:flex; flex-wrap:wrap; gap:6px; margin:0 0 8px; }
+.tag { display:inline-flex; align-items:center; padding:4px 10px; border-radius:999px; background:#f3f4f6; color:#374151; font-size:12px; }
 .table-mini { width:100%; border-collapse:collapse; }
 .table-mini th, .table-mini td { border-bottom:1px dashed #e5e7eb; padding:6px 8px; font-size:13px; }
 .actions-col { display:flex; flex-direction:column; gap:8px; }


### PR DESCRIPTION
## Summary
- normalize purchase detail responses so that totals, tickets, and logs always have safe defaults
- render purchase tables using the normalized data and show summary badges without runtime errors
- add styles for the new summary badge list in the purchase details view

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68dbd154d1e0832794f32fb97928f348