### PR TITLE
Handle missing SMTP configuration when sending ticket emails

### DIFF
--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -171,12 +171,16 @@ def send_ticket_email(
 ) -> None:
     """Send a ticket email with the provided HTML body and PDF attachment."""
 
-    host = _get_env("SMTP_HOST")
-    port_raw = _get_env("SMTP_PORT")
-    username = _get_env("SMTP_USERNAME", required=False)
-    password = _get_env("SMTP_PASSWORD", required=False)
-    from_email = _get_env("SMTP_FROM")
-    from_name = _get_env("SMTP_FROM_NAME", required=False)
+    try:
+        host = _get_env("SMTP_HOST")
+        port_raw = _get_env("SMTP_PORT")
+        username = _get_env("SMTP_USERNAME", required=False)
+        password = _get_env("SMTP_PASSWORD", required=False)
+        from_email = _get_env("SMTP_FROM")
+        from_name = _get_env("SMTP_FROM_NAME", required=False)
+    except EmailConfigurationError:
+        logger.info("Skipping ticket email delivery because SMTP is not configured")
+        return
 
     port = int(port_raw) if port_raw else 587
 


### PR DESCRIPTION
## Summary
- skip sending ticket emails when SMTP environment variables are absent instead of raising
- log a clear info message so background tasks continue without failure

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbd7f585e4832783723de32490d7a0