### PR TITLE
Configure public ticket link URLs and add token-based redirect endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ CORS_ORIGINS=http://localhost:3000
 
 # Front-end (optional)
 FRONTEND_PORT=3000
+PUBLIC_APP_URL=http://localhost:3000
+PUBLIC_API_BASE=http://localhost:8000
 APP_PUBLIC_URL=http://localhost:3000
 
 # LiqPay

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ cp .env.example .env
 | `JWT_SECRET` | Секретный ключ подписи JWT-токенов администратора | `changeme` |
 | `TICKET_LINK_SECRET` | Секрет для подписания публичных ссылок на билеты | `changeme` |
 | `TICKET_LINK_TTL_DAYS` | Максимальный срок действия ссылки (в днях, но не позднее суток после отправления) | `7` |
-| `APP_PUBLIC_URL` | Публичный URL приложения, используемый в письмах | `http://localhost:${FRONTEND_PORT}` |
+| `PUBLIC_APP_URL` | Публичный URL фронтенда для редиректов после проверки токена | `http://localhost:${FRONTEND_PORT}` |
+| `PUBLIC_API_BASE` | Публичный вход в API (через прокси, например `${PUBLIC_APP_URL}/api`) | `http://localhost:${BACKEND_PORT}` |
+| `APP_PUBLIC_URL` | (устар.) Публичный URL приложения, используемый в письмах | `http://localhost:${FRONTEND_PORT}` |
 
 Эндпоинт `/auth/login` выдаёт токен из `ADMIN_TOKEN`. Его нужно передавать в заголовке `Authorization`
 при обращении к административным маршрутам.
@@ -262,4 +264,3 @@ pytest
 - `docker compose exec backend alembic upgrade head` — пример миграции БД (если вы добавите Alembic).
 - `docker compose exec db psql -U postgres test1` — подключение к базе из контейнера.
 - `npm run build --prefix frontend` — сборка фронтенда для продакшена.
-

--- a/backend/routers/ticket.py
+++ b/backend/routers/ticket.py
@@ -3,7 +3,6 @@
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from datetime import datetime
-import os
 
 import logging
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
@@ -17,6 +16,7 @@ from ._ticket_link_helpers import (
     combine_departure_datetime,
     issue_ticket_links,
     enrich_ticket_link_results,
+    resolve_public_api_base,
 )
 from ..services.ticket_dto import get_ticket_dto
 from ..services.ticket_pdf import render_ticket_pdf
@@ -102,10 +102,7 @@ def get_ticket_pdf(
         logger.exception("Failed to resolve ticket link session for %s", ticket_id)
         raise HTTPException(500, "Failed to prepare ticket link") from exc
 
-    base_url = os.getenv("TICKET_LINK_BASE_URL") or os.getenv(
-        "APP_PUBLIC_URL", "http://localhost:8000"
-    )
-    deep_link = build_deep_link(opaque, base_url=base_url)
+    deep_link = build_deep_link(opaque, base_url=resolve_public_api_base())
 
     pdf_bytes = render_ticket_pdf(dto, deep_link)
     headers = {


### PR DESCRIPTION
### Motivation
- Ensure ticket/QR links point to the public frontend API entry (e.g. `https://client-mt.netlify.app/api/...`) and avoid hardcoded `localhost` values in production.
- Make the ticket link flow validate tokens on the backend and redirect users to the frontend (so the browser never hits the backend directly).
- Centralize base URL resolution via environment variables so deployment proxies (Netlify) can forward `/api/*` to the backend.

### Description
- Added `resolve_public_app_url`, `resolve_public_api_base`, and `_normalize_base_url` to `backend/routers/_ticket_link_helpers.py` and updated `build_deep_link` to use the resolved API base instead of hardcoded/env fallbacks that default to `localhost`.
- Updated `backend/routers/ticket.py` and `backend/routers/public.py` to call `build_deep_link(..., base_url=resolve_public_api_base())` when embedding deep links in PDFs and messages.
- Reworked public redirect targets to use `resolve_public_app_url()` (so redirects point to the frontend `PUBLIC_APP_URL`), and added a new public endpoint `GET /public/ticket-link?token=...` that verifies the ticket token via `ticket_links.verify` and returns a `302` redirect to the frontend (`/purchase/<id>` or `/` with query params) on success and `401` on invalid tokens.
- Exported the new helper functions from the ticket link helpers, updated `.env.example` to include `PUBLIC_APP_URL` and `PUBLIC_API_BASE`, and documented the new variables in `README.md`.

### Testing
- No automated tests were run as part of this change (no `pytest` or CI jobs executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698099806ffc8327acdaf365f26e2b24)