### PR TITLE
Harden ticket template rendering and add stress-render script

### DIFF
--- a/backend/scripts/render_ticket_stress.py
+++ b/backend/scripts/render_ticket_stress.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(REPO_ROOT))
+
+from backend.services.ticket_pdf import render_ticket_html, render_ticket_pdf
+
+
+def main() -> None:
+    output_dir = Path(__file__).resolve().parent / "output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    deep_link = (
+        "https://example.com/manage/"
+        "this-is-a-very-long-link-without-spaces-"
+        "and-it-keeps-going-to-test-overflow-behavior-"
+        "?order=1234567890&token=abcdefghijklmnopqrstuvwxyz0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    )
+
+    dto = {
+        "i18n": {
+            "brand_name": "Максимов Турс",
+            "manage_online_button": "Управлять поездкой",
+        },
+        "tour": {"date": "2026-02-09"},
+        "segment": {
+            "duration_minutes": 615,
+            "departure": {
+                "id": "dep-stop",
+                "name": "Очень-длинное-название-станции-отправления-без-пробелов"
+                "которое-нужно-переносить",
+                "time": "12:03",
+            },
+            "arrival": {
+                "id": "arr-stop",
+                "name": "Констанца",
+                "time": "13:10",
+            },
+        },
+        "route": {
+            "stops": [
+                {
+                    "id": "dep-stop",
+                    "name": "Болград",
+                    "description": (
+                        "Поворот на трассе Е95, возле АЗС\n"
+                        "Длинный адрес с переносами и кириллицей, "
+                        "который должен корректно переноситься в несколько строк"
+                    ),
+                    "location": "https://maps.example.com/very/long/path",
+                },
+                {
+                    "id": "arr-stop",
+                    "name": "Констанца",
+                    "description": (
+                        "OMV Заправка, улица Очень Длинная, дом 123456, "
+                        "подъезд 7, этаж 12, офис 999\n"
+                        "Еще одна строка адреса для стресс-теста"
+                    ),
+                    "location": "https://maps.example.com/another/very/long/path",
+                },
+            ]
+        },
+        "ticket": {
+            "id": "TICKET-2026-00000000000000000001",
+            "seat_number": "12A-ОченьДлинныйНомерМеста",
+            "extra_baggage": 2,
+        },
+        "purchase": {
+            "id": "ORDER-0000000000000000000001",
+            "amount_due": "1999.99",
+            "payment_method": "Карта Visa/Mastercard",
+            "customer": {
+                "name": "Дмитрий\nСтойков",
+                "email": "verylongemailaddresswithoutbreaks"
+                "andwithmanychars@exampleveryveryverylongdomain.com",
+                "phone": "+380-553-252-3523-EXT-9999",
+            },
+            "flags": {"status": "paid"},
+        },
+        "pricing": {"currency_code": "UAH"},
+    }
+
+    html = render_ticket_html(dto, deep_link)
+    (output_dir / "ticket_stress.html").write_text(html, encoding="utf-8")
+
+    pdf_bytes = render_ticket_pdf(dto, deep_link)
+    (output_dir / "ticket_stress.pdf").write_bytes(pdf_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/ticket_pdf.py
+++ b/backend/services/ticket_pdf.py
@@ -291,8 +291,8 @@ def _select_currency(dto: Mapping[str, Any], i18n: Mapping[str, Any]) -> str:
     return currency
 
 
-def render_ticket_pdf(dto: Mapping[str, Any], deep_link: Optional[str]) -> bytes:
-    """Render a ticket PDF from a DTO and a deep link."""
+def render_ticket_html(dto: Mapping[str, Any], deep_link: Optional[str]) -> str:
+    """Render ticket HTML from a DTO and a deep link."""
 
     if not isinstance(dto, Mapping):
         raise TypeError("dto must be a mapping")
@@ -366,7 +366,13 @@ def render_ticket_pdf(dto: Mapping[str, Any], deep_link: Optional[str]) -> bytes
         deep_link=deep_link,
         qr_data_uri=qr_data_uri,
     )
+    return html
 
+
+def render_ticket_pdf(dto: Mapping[str, Any], deep_link: Optional[str]) -> bytes:
+    """Render a ticket PDF from a DTO and a deep link."""
+
+    html = render_ticket_html(dto, deep_link)
     base_url = str(_TEMPLATES_DIR)
     pdf_bytes = HTML(string=html, base_url=base_url).write_pdf()
     return pdf_bytes

--- a/backend/templates/ticket.html
+++ b/backend/templates/ticket.html
@@ -1,1 +1,478 @@
+<!doctype html>
+<html lang="{{ i18n.lang or 'ru' }}">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>{{ page_title }}</title>
 
+<style>
+:root{
+  --bg:#F2F5FB;
+  --paper:#ffffff;
+  --ink:#0B1220;
+  --muted:#5F708A;
+  --line:#E6ECF5;
+
+  --primary:#1E4D7A;
+  --primary2:#0E2E4F;
+
+  --ok:#16A34A;
+  --bad:#EF4444;
+
+  --shadow:0 18px 45px rgba(15,23,42,.12);
+
+  --font: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+*{box-sizing:border-box}
+
+body{
+  margin:0;
+  background:#fff;
+  font-family:var(--font);
+  color:var(--ink);
+  font-size:14px;
+  -webkit-font-smoothing:antialiased;
+}
+
+.wrap{
+  display:flex;
+  justify-content:center;
+  padding:20px;
+}
+
+.sheet{
+  width:980px;
+  background:var(--bg);
+  border-radius:26px;
+  padding:16px;
+}
+
+.ticket{
+  background:var(--paper);
+  border-radius:26px;
+  box-shadow:var(--shadow);
+  overflow:hidden;
+}
+
+/* ===== TOP STRIPE ===== */
+.stripe{
+  background:linear-gradient(90deg,var(--primary2),var(--primary));
+  color:#fff;
+  padding:14px 18px;
+  display:grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items:center;
+}
+
+.brand{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  min-width:0;
+}
+.brandMark{
+  width:36px;height:36px;
+  border-radius:12px;
+  background:rgba(255,255,255,.15);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  flex:0 0 auto;
+}
+.brandMark img{width:22px;height:auto;filter:brightness(0) invert(1);display:block}
+.brandWord img{height:14px;filter:brightness(0) invert(1);display:block}
+
+.statusPill{
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  padding:8px 14px;
+  border-radius:999px;
+  font-size:12px;
+  font-weight:700;
+  letter-spacing:.08em;
+  border:1px solid rgba(255,255,255,.25);
+  background:rgba(255,255,255,.14);
+  white-space:nowrap;
+}
+.statusDot{
+  width:8px;height:8px;border-radius:50%;
+  background:var(--bad);
+}
+.statusPill.ok .statusDot{background:var(--ok)}
+
+.headerMeta{
+  justify-self:end;
+  text-align:right;
+  font-size:14px;
+  font-weight:700;
+  white-space:nowrap;
+}
+
+/* ===== MAIN GRID (strict math) ===== */
+/* inner width = 948px
+   left 630 + gap 18 + right 300 = 948 ✅ */
+.main{
+  padding:18px;
+  display:grid;
+  grid-template-columns: 630px 300px;
+  gap:18px;
+  align-items:start;
+}
+.main > *{min-width:0}
+
+/* ===== LEFT BOARD ===== */
+.board{
+  width:630px;
+  border:1px solid var(--line);
+  border-radius:22px;
+  background:#fff;
+  overflow:hidden;
+}
+
+/* ROUTE */
+.route{
+  padding:16px 18px;
+  border-bottom:1px solid var(--line);
+  display:flex;
+  justify-content:space-between;
+  gap:16px;
+}
+
+/* left route content */
+.routeGrid{
+  width:100%;
+  display:grid;
+  grid-template-columns: 1fr 34px 1fr;
+  gap:16px;
+  min-width:0;
+}
+.routeGrid > *{min-width:0}
+
+.city{
+  min-width:0;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.city.alignRight{text-align:right;align-items:flex-end}
+
+.citySub{
+  font-size:11px;
+  letter-spacing:.14em;
+  font-weight:700;
+  color:var(--muted);
+}
+
+.cityName{
+  font-size:30px;
+  font-weight:800;
+  letter-spacing:-.01em;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  max-width:100%;
+}
+
+.arrow{
+  width:34px;
+  text-align:center;
+  font-size:22px;
+  font-weight:700;
+  color:var(--muted);
+  margin-top:22px;
+}
+
+.stopTime{
+  font-family:var(--mono);
+  font-size:16px;
+  font-weight:700;
+  white-space:nowrap;
+}
+
+.stopLoc{
+  font-size:13px;
+  color:var(--muted);
+  font-weight:600;
+  max-width:100%;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+/* route right date inside hero */
+.routeRight{
+  width:130px;
+  text-align:right;
+  flex:0 0 auto;
+}
+.routeRight .date{
+  font-size:16px;
+  font-weight:800;
+  white-space:nowrap;
+}
+
+/* PASSENGER */
+.passenger{
+  padding:14px 18px;
+  border-bottom:1px solid var(--line);
+}
+.sectionLabel{
+  font-size:11px;
+  letter-spacing:.14em;
+  font-weight:700;
+  color:var(--muted);
+  margin-bottom:10px;
+}
+.pRow{
+  display:grid;
+  grid-template-columns:42% 58%;
+  gap:12px;
+  margin-bottom:8px;
+  min-width:0;
+}
+.pKey{
+  font-size:11px;
+  letter-spacing:.14em;
+  font-weight:700;
+  color:var(--muted);
+  min-width:0;
+}
+.pVal{
+  font-size:14px;
+  font-weight:700;
+  min-width:0;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  white-space:nowrap;
+}
+.pVal.mono{
+  font-family:var(--mono);
+  font-weight:600;
+}
+
+/* INCLUDED */
+.included{
+  padding:14px 18px 16px;
+}
+.pills{
+  display:grid;
+  grid-template-columns: 120px 1fr 140px;
+  gap:10px;
+  min-width:0;
+}
+.pill{
+  border:1px solid var(--line);
+  background:#F6F8FC;
+  border-radius:14px;
+  padding:10px 12px;
+  min-width:0;
+}
+.pill .k{
+  font-size:10px;
+  letter-spacing:.14em;
+  font-weight:700;
+  color:var(--muted);
+}
+.pill .v{
+  margin-top:4px;
+  font-family:var(--mono);
+  font-size:13px;
+  font-weight:700;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+}
+
+/* ===== QR ===== */
+.qr{
+  width:300px;
+  border:1px solid var(--line);
+  border-radius:22px;
+  background:#fff;
+  overflow:hidden;
+}
+
+.qrHead{
+  padding:14px;
+  border-bottom:1px solid var(--line);
+  font-size:11px;
+  letter-spacing:.14em;
+  font-weight:700;
+  color:var(--muted);
+}
+
+.qrBox{
+  padding:14px;
+  display:flex;
+  justify-content:center;
+}
+.qrBoxInner{
+  width:240px;
+  height:240px;
+  border:1px solid var(--line);
+  border-radius:18px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  position:relative;
+  overflow:hidden;
+  background:#fff;
+}
+.qrBoxInner img{width:100%;height:100%;object-fit:contain;display:block}
+.qrOffline{
+  position:absolute;
+  bottom:10px;left:12px;right:12px;
+  text-align:center;
+  font-size:12px;
+  color:var(--muted);
+  font-weight:700;
+}
+.qrFoot{
+  padding:14px;
+  border-top:1px solid var(--line);
+  min-width:0;
+}
+.btn{
+  width:100%;
+  padding:12px;
+  border-radius:14px;
+  background:var(--primary);
+  color:#fff;
+  border:none;
+  font-size:14px;
+  font-weight:800;
+  text-decoration:none;
+  display:inline-block;
+  text-align:center;
+}
+
+.break{
+  overflow-wrap:anywhere;
+  word-break:break-word;
+  white-space:normal;
+  overflow:visible;
+  text-overflow:clip;
+}
+
+@media print{
+  .ticket{box-shadow:none}
+  .sheet{background:#fff}
+}
+
+/* FOOTER */
+.footer{
+  background:#0B1220;
+  color:#fff;
+  padding:14px 18px;
+  display:flex;
+  justify-content:space-between;
+  font-size:13px;
+}
+.footer a{color:#fff;text-decoration:none}
+.footer b{font-weight:800}
+</style>
+</head>
+
+<body>
+{% macro nl2br(value) -%}
+{{ value|e|replace('\n', '<br>')|safe }}
+{%- endmacro %}
+<div class="wrap">
+  <div class="sheet">
+    <div class="ticket">
+
+      <div class="stripe">
+        <div class="brand">
+          <div class="brandMark"><img src="logo/logo.svg" alt="{{ i18n.brand_name|e }}"></div>
+          <div class="brandWord"><img src="logo/speling.svg" alt="{{ i18n.brand_name|e }}"></div>
+        </div>
+
+        <div class="statusPill {{ status_chip.css_class|e }}">
+          <span class="statusDot"></span>
+          <span>{{ status_chip.text|e }}</span>
+        </div>
+
+        <div class="headerMeta">{{ ticket.trip_date|default(i18n.value_not_available)|e }}</div>
+      </div>
+
+      <div class="main">
+
+        <div class="board">
+          <div class="route">
+            <div class="routeGrid">
+              <div class="city">
+                <div class="citySub">{{ i18n.departure_label|e|upper }}</div>
+                <div class="cityName break">{{ nl2br(route.from_city or i18n.value_not_available) }}</div>
+                <div class="stopTime">{{ departure.time|default(i18n.value_not_available)|e }}</div>
+                <div class="stopLoc break">{{ nl2br(departure.address or i18n.value_not_available) }}</div>
+              </div>
+
+              <div class="arrow">→</div>
+
+              <div class="city alignRight">
+                <div class="citySub">{{ i18n.arrival_label|e|upper }}</div>
+                <div class="cityName break">{{ nl2br(route.to_city or i18n.value_not_available) }}</div>
+                <div class="stopTime">{{ arrival.time|default(i18n.value_not_available)|e }}</div>
+                <div class="stopLoc break">{{ nl2br(arrival.address or i18n.value_not_available) }}</div>
+              </div>
+            </div>
+
+            <div class="routeRight">
+              <div class="date">{{ ticket.trip_date|default(i18n.value_not_available)|e }}</div>
+            </div>
+          </div>
+
+          <div class="passenger">
+            <div class="sectionLabel">{{ i18n.passenger_section|e|upper }}</div>
+            <div class="pRow"><div class="pKey">{{ i18n.full_name_label|e|upper }}</div><div class="pVal break">{{ nl2br(passenger.name or i18n.value_not_available) }}</div></div>
+            <div class="pRow"><div class="pKey">EMAIL</div><div class="pVal mono break">{{ nl2br(passenger.email or i18n.value_not_available) }}</div></div>
+            <div class="pRow"><div class="pKey">{{ i18n.phone_label|e|upper }}</div><div class="pVal mono break">{{ nl2br(passenger.phone or i18n.value_not_available) }}</div></div>
+          </div>
+
+          <div class="included">
+            <div class="sectionLabel">{{ i18n.trip_section|e|upper }}</div>
+            <div class="pills">
+              <div class="pill"><div class="k">{{ i18n.seat_label|e|upper }}</div><div class="v break">{{ nl2br(ticket.seat_number or i18n.value_not_available) }}</div></div>
+              <div class="pill"><div class="k">{{ i18n.baggage_label|e|upper }}</div><div class="v break">{{ nl2br(ticket.baggage_text or i18n.value_not_available) }}</div></div>
+              <div class="pill"><div class="k">{{ i18n.price_label|e|upper }}</div><div class="v break">{{ nl2br(ticket.price_text or i18n.value_not_available) }}</div></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="qr">
+          <div class="qrHead">SCAN</div>
+          <div class="qrBox">
+            <div class="qrBoxInner">
+              {% if qr_data_uri %}
+              <img src="{{ qr_data_uri }}" alt="QR">
+              {% else %}
+              <div class="qrOffline">{{ i18n.qr_unavailable|e }}</div>
+              {% endif %}
+            </div>
+          </div>
+          <div class="qrFoot">
+            {% if deep_link %}
+            <a class="btn break" href="{{ deep_link|e }}">{{ i18n.manage_online_button|e }}</a>
+            {% else %}
+            <span class="btn break">{{ i18n.manage_online_button|e }}</span>
+            {% endif %}
+          </div>
+        </div>
+
+      </div>
+
+      <div class="footer">
+        <b>{{ i18n.brand_name|e }}</b>
+        <span class="break">{{ i18n.company_phone|e }}</span>
+        <span class="break">{{ i18n.company_email|e }}</span>
+        <span class="break">{{ i18n.company_web|e }}</span>
+      </div>
+
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Prevent ticket HTML/PDF layout breakage caused by long/unbroken strings, newlines, non-Latin characters and missing optional fields.
- Ensure template rendering is safe against accidental HTML injection while still allowing controlled newline-to-<br> conversion where needed.
- Provide a reproducible developer workflow to verify layout stability under extreme inputs.

### Description
- Split rendering into `render_ticket_html` and `render_ticket_pdf` in `backend/services/ticket_pdf.py` so HTML can be rendered and inspected independently, and PDF generation now reuses the HTML renderer via `render_ticket_pdf`.
- Harden `backend/templates/ticket.html` by adding a `nl2br` macro that escapes input (`|e`) and converts `\n` to `<br>` safely, removing any uncontrolled `|safe` usage for external/user-provided fields.
- Add defensive escaping (`|e`) on all i18n and dynamic text and escape CSS class injection for `status_chip.css_class` to avoid markup/style injection.
- Improve CSS to be resilient to long tokens by adding a `.break` utility (`overflow-wrap:anywhere; word-break:break-word; white-space:normal;`) and applying `min-width:0` to grid/flex children and critical containers, and replace fragile key/value grid sizing with a stable `42% / 58%` layout for KV rows.
- Add `backend/scripts/render_ticket_stress.py`, a stress-render script that produces an HTML and PDF with extreme data (very long links/emails/addresses, Cyrillic, newlines) for quick verification of layout/escaping.

### Testing
- Ran the stress script `python backend/scripts/render_ticket_stress.py`, which renders the HTML via `render_ticket_html` and produces a PDF via `render_ticket_pdf`, and it completed successfully after adjusting import path so the script can load the package.
- No additional automated unit tests were added; the stress-render script is included for manual/automated smoke validation of layout and escaping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69899d02efb883279de11428217076a5)