### PR TITLE
Add WeasyPrint-safe ticket template and debug tooling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -35,6 +35,7 @@ from .routers import (
 )
 from .routers.ticket_admin import router as admin_tickets_router
 from .routers.purchase_admin import router as admin_purchases_router
+from .routers.dev_ticket import router as dev_ticket_router
 
 
 app = FastAPI()
@@ -95,6 +96,8 @@ app.include_router(public.router)
 app.include_router(admin_tickets_router)
 app.include_router(admin_purchases_router)
 app.include_router(auth.router)
+if os.getenv("ENABLE_DEV_TICKET_ENDPOINTS") == "1":
+    app.include_router(dev_ticket_router)
 
 
 def _cancel_expired_loop():

--- a/backend/routers/dev_ticket.py
+++ b/backend/routers/dev_ticket.py
@@ -1,0 +1,33 @@
+"""Development-only endpoints for ticket PDF debugging."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, Query, Response
+
+from ..services.ticket_debug import build_stress_ticket_dto
+from ..services.ticket_pdf import render_ticket_html_pdf, render_ticket_pdf
+
+router = APIRouter(prefix="/dev/tickets", tags=["dev"])
+
+
+@router.get("/weasyprint")
+def get_weasyprint_debug_ticket(debug: bool = Query(False)) -> Response:
+    """Render a WeasyPrint PDF with stress-test data."""
+    dto = build_stress_ticket_dto()
+    deep_link = dto.get("deep_link")
+
+    html = render_ticket_html_pdf(dto, deep_link)
+    pdf_bytes = render_ticket_pdf(dto, deep_link)
+
+    if debug:
+        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+        html_path = Path("/tmp") / f"ticket_weasy_debug_{timestamp}.html"
+        pdf_path = Path("/tmp") / f"ticket_weasy_debug_{timestamp}.pdf"
+        html_path.write_text(html, encoding="utf-8")
+        pdf_path.write_bytes(pdf_bytes)
+
+    headers = {"Content-Disposition": 'inline; filename="ticket_weasy_debug.pdf"'}
+    return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)

--- a/backend/scripts/render_ticket_stress.py
+++ b/backend/scripts/render_ticket_stress.py
@@ -3,66 +3,14 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from datetime import datetime
 import sys
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT_DIR))
 
-from backend.services.ticket_pdf import render_ticket_html, render_ticket_pdf  # noqa: E402
-
-
-def _build_stress_dto() -> dict:
-    long_email = "very-long-email-address-with-a-lot-of-parts-and-tags+stress-test-1234567890@example-super-long-domain-name.tld"
-    long_link = (
-        "https://maximov.tours/manage?"
-        "order=1234567890&ticket=987654321&token="
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-    )
-    return {
-        "ticket": {
-            "id": 987654321,
-            "seat_number": "12A-ОченьДлинноеМестоБезПробеловИСКириллицей1234567890",
-            "extra_baggage": 2,
-        },
-        "purchase": {
-            "id": 123456,
-            "amount_due": 1234.56,
-            "payment_method": "card",
-            "status": "pending",
-            "customer": {
-                "name": "Иван-Пётр Сергеевич",
-                "email": long_email,
-                "phone": "+380-50-123-45-67",
-            },
-        },
-        "segment": {
-            "departure": {"id": 1, "name": "Одесса-ГлавнаяСтанцияБезПробелов", "time": "08:15"},
-            "arrival": {"id": 2, "name": "Кишинёв-ДлинноеНазваниеОстановки", "time": "11:45"},
-            "duration_minutes": 210,
-        },
-        "route": {
-            "stops": [
-                {
-                    "id": 1,
-                    "name": "Одесса-Главная",
-                    "description": "ул. Дерибасовская, 1\nПодъезд 2\nОфис 314",
-                    "location": "https://maps.example.com/location/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                },
-                {
-                    "id": 2,
-                    "name": "Кишинёв-Центр",
-                    "description": "Strada Alexandru cel Bun 5\nEtaj 3\nСекция B",
-                    "location": "https://maps.example.com/location/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-                },
-            ]
-        },
-        "tour": {"date": "2026-02-09"},
-        "pricing": {"currency_code": "UAH", "price": 1234.56},
-        "payment_status": {"status": "pending"},
-        "passenger": {"name": "Иван-Пётр Сергеевич"},
-        "deep_link": long_link,
-    }
+from backend.services.ticket_debug import build_stress_ticket_dto  # noqa: E402
+from backend.services.ticket_pdf import render_ticket_html_pdf, render_ticket_pdf  # noqa: E402
 
 
 def main() -> None:
@@ -72,20 +20,30 @@ def main() -> None:
         default=".",
         help="Directory to write ticket_stress.html and ticket_stress.pdf",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Write artifacts into /tmp with a timestamped prefix.",
+    )
     args = parser.parse_args()
 
     output_dir = Path(args.output_dir).resolve()
+    if args.debug:
+        output_dir = Path("/tmp").resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    dto = _build_stress_dto()
+    dto = build_stress_ticket_dto()
     deep_link = dto.get("deep_link")
 
-    html = render_ticket_html(dto, deep_link)
-    html_path = output_dir / "ticket_stress.html"
+    html = render_ticket_html_pdf(dto, deep_link)
+    suffix = ""
+    if args.debug:
+        suffix = "_" + datetime.now().strftime("%Y%m%d%H%M%S")
+    html_path = output_dir / f"ticket_stress{suffix}.html"
     html_path.write_text(html, encoding="utf-8")
 
     pdf_bytes = render_ticket_pdf(dto, deep_link)
-    pdf_path = output_dir / "ticket_stress.pdf"
+    pdf_path = output_dir / f"ticket_stress{suffix}.pdf"
     pdf_path.write_bytes(pdf_bytes)
 
     print(f"Wrote {html_path}")

--- a/backend/services/ticket_debug.py
+++ b/backend/services/ticket_debug.py
@@ -1,0 +1,69 @@
+"""Helpers for generating debug/stress ticket data."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def build_stress_ticket_dto() -> Dict[str, Any]:
+    long_email = (
+        "verylongemailaddresswithmultiplesectionsandtags"
+        "+stress-test-1234567890"
+        "@example-super-long-domain-name-with-many-parts.tld"
+    )
+    long_link = (
+        "https://client.maximov.tours/api/q/"
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        "?utm_source=stress_test&token=longtokenvalue"
+    )
+    long_address = (
+        "УкраинаОдесскаяОбластьГородОдесса"
+        "ОченьДлинноеНазваниеУлицыБезПробелов"
+        "Дом123Квартира456Подъезд7Этаж89"
+    )
+    return {
+        "ticket": {
+            "id": "TKT-999999999999999999999999",
+            "seat_number": "12A-ОченьДлинноеМестоБезПробеловИСКириллицей1234567890",
+            "extra_baggage": 3,
+        },
+        "purchase": {
+            "id": "ORD-888888888888888888888888",
+            "amount_due": 98765.43,
+            "payment_method": "card",
+            "status": "pending",
+            "customer": {
+                "name": "Иван-Пётр Сергеевич",
+                "email": long_email,
+                "phone": "+380-50-123-45-67",
+            },
+        },
+        "segment": {
+            "departure": {"id": 1, "name": "Одесса-ГлавнаяСтанцияБезПробелов", "time": "08:15"},
+            "arrival": {"id": 2, "name": "Кишинёв-ДлинноеНазваниеОстановки", "time": "11:45"},
+            "duration_minutes": 210,
+        },
+        "route": {
+            "stops": [
+                {
+                    "id": 1,
+                    "name": "Одесса-Главная",
+                    "description": long_address,
+                    "location": "https://maps.example.com/location/" + "a" * 80,
+                },
+                {
+                    "id": 2,
+                    "name": "Кишинёв-Центр",
+                    "description": "StradaAlexandruCelBun5Etaj3SectorBбезпробелов",
+                    "location": "https://maps.example.com/location/" + "b" * 80,
+                },
+            ]
+        },
+        "tour": {"date": "2026-02-09"},
+        "pricing": {"currency_code": "UAH", "price": 98765.43},
+        "payment_status": {"status": "pending"},
+        "passenger": {"name": "Иван-Пётр Сергеевич"},
+        "deep_link": long_link,
+    }

--- a/backend/services/ticket_pdf.py
+++ b/backend/services/ticket_pdf.py
@@ -372,9 +372,16 @@ def render_ticket_html(dto: Mapping[str, Any], deep_link: Optional[str]) -> str:
     return template.render(**context)
 
 
+def render_ticket_html_pdf(dto: Mapping[str, Any], deep_link: Optional[str]) -> str:
+    """Render a WeasyPrint-friendly ticket HTML from a DTO and a deep link."""
+    context = _build_ticket_context(dto, deep_link)
+    template = _ENV.get_template("ticket_weasy.html")
+    return template.render(**context)
+
+
 def render_ticket_pdf(dto: Mapping[str, Any], deep_link: Optional[str]) -> bytes:
     """Render a ticket PDF from a DTO and a deep link."""
-    html = render_ticket_html(dto, deep_link)
+    html = render_ticket_html_pdf(dto, deep_link)
 
     base_url = str(_TEMPLATES_DIR)
     pdf_bytes = HTML(string=html, base_url=base_url).write_pdf()

--- a/backend/templates/ticket_weasy.html
+++ b/backend/templates/ticket_weasy.html
@@ -1,0 +1,357 @@
+<!doctype html>
+<html lang="{{ i18n.lang or 'ru' }}">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>{{ page_title }}</title>
+<style>
+  :root {
+    --ink: #0b1220;
+    --muted: #5f708a;
+    --line: #e6ecf5;
+    --bg: #ffffff;
+    --accent: #1e4d7a;
+    --accent-soft: #eef4fb;
+    --success: #16a34a;
+    --danger: #ef4444;
+    --font: "Inter", "Segoe UI", Arial, sans-serif;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    margin: 0;
+    padding: 24px;
+    background: #ffffff;
+    color: var(--ink);
+    font-family: var(--font);
+    font-size: 13px;
+    line-height: 1.35;
+  }
+
+  table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: separate;
+    border-spacing: 12px;
+  }
+
+  td {
+    vertical-align: top;
+  }
+
+  a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .page {
+    background: var(--bg);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+  }
+
+  .brand {
+    font-size: 14px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent);
+  }
+
+  .ticket-label {
+    font-size: 16px;
+    font-weight: 700;
+    margin-top: 4px;
+  }
+
+  .route {
+    font-size: 22px;
+    font-weight: 800;
+    margin-top: 8px;
+  }
+
+  .subtle {
+    color: var(--muted);
+  }
+
+  .status-chip {
+    display: inline-block;
+    padding: 6px 10px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    background: #fff3f2;
+    color: var(--danger);
+  }
+
+  .status-chip.ok {
+    background: #ecfdf3;
+    color: var(--success);
+  }
+
+  .meta-table td {
+    padding: 0;
+  }
+
+  .meta-label {
+    font-size: 11px;
+    color: var(--muted);
+  }
+
+  .meta-value {
+    font-weight: 600;
+  }
+
+  .section-title {
+    font-size: 14px;
+    font-weight: 700;
+    margin-bottom: 6px;
+  }
+
+  .block {
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 10px;
+    background: #ffffff;
+  }
+
+  .block + .block {
+    margin-top: 12px;
+  }
+
+  .block-title {
+    font-size: 12px;
+    font-weight: 700;
+    margin-bottom: 6px;
+  }
+
+  .row {
+    margin-bottom: 6px;
+  }
+
+  .row:last-child {
+    margin-bottom: 0;
+  }
+
+  .label {
+    font-size: 11px;
+    color: var(--muted);
+    display: block;
+  }
+
+  .value {
+    font-weight: 600;
+    display: block;
+  }
+
+  .cta {
+    display: inline-block;
+    padding: 8px 10px;
+    background: var(--accent);
+    color: #ffffff;
+    border-radius: 10px;
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  .qr-box {
+    width: 132px;
+    height: 132px;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    background: #ffffff;
+    padding: 6px;
+  }
+
+  .qr-box img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+  }
+
+  .footer {
+    font-size: 11px;
+    color: var(--muted);
+    text-align: center;
+  }
+
+  .break {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+</style>
+</head>
+<body>
+  <table class="page">
+    <tr>
+      <td>
+        <table>
+          <tr>
+            <td>
+              <div class="brand">{{ i18n.brand_name }}</div>
+              <div class="ticket-label">{{ i18n.ticket_label }}</div>
+              <div class="route break">{{ route.label or i18n.value_not_available }}</div>
+              <div class="subtle">{{ i18n.trip_date_label }}: {{ ticket.trip_date or i18n.value_not_available }}</div>
+            </td>
+            <td>
+              <div class="status-chip {{ status_chip.css_class }}">{{ status_chip.text }}</div>
+              <table class="meta-table">
+                <tr>
+                  <td class="meta-label">{{ i18n.ticket_number_label }}</td>
+                  <td class="meta-value break">{{ ticket.number or i18n.value_not_available }}</td>
+                </tr>
+                <tr>
+                  <td class="meta-label">{{ i18n.order_label }}</td>
+                  <td class="meta-value break">{{ ticket.order_number or i18n.value_not_available }}</td>
+                </tr>
+                <tr>
+                  <td class="meta-label">{{ i18n.seat_label }}</td>
+                  <td class="meta-value">{{ ticket.seat_number or i18n.value_not_available }}</td>
+                </tr>
+                <tr>
+                  <td class="meta-label">{{ i18n.baggage_label }}</td>
+                  <td class="meta-value">{{ ticket.baggage_text or i18n.value_not_available }}</td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <table>
+          <colgroup>
+            <col style="width:60%"/>
+            <col style="width:40%"/>
+          </colgroup>
+          <tr>
+            <td>
+              <div class="section-title">{{ i18n.trip_section }}</div>
+              <div class="block">
+                <div class="block-title">{{ departure.title }}</div>
+                <div class="row">
+                  <span class="label">{{ i18n.datetime_label }}</span>
+                  <span class="value">{{ departure.date or i18n.value_not_available }} {{ departure.time or '' }}</span>
+                </div>
+                <div class="row">
+                  <span class="label">{{ i18n.address_label }}</span>
+                  <span class="value break">{{ departure.address or i18n.value_not_available }}</span>
+                </div>
+                {% if departure.map_url %}
+                <div class="row">
+                  <span class="label">{{ i18n.open_map }}</span>
+                  <span class="value break"><a href="{{ departure.map_url }}">{{ departure.map_url }}</a></span>
+                </div>
+                {% endif %}
+              </div>
+              <div class="block">
+                <div class="block-title">{{ arrival.title }}</div>
+                <div class="row">
+                  <span class="label">{{ i18n.datetime_label }}</span>
+                  <span class="value">{{ arrival.date or i18n.value_not_available }} {{ arrival.time or '' }}</span>
+                </div>
+                <div class="row">
+                  <span class="label">{{ i18n.address_label }}</span>
+                  <span class="value break">{{ arrival.address or i18n.value_not_available }}</span>
+                </div>
+                {% if arrival.map_url %}
+                <div class="row">
+                  <span class="label">{{ i18n.open_map }}</span>
+                  <span class="value break"><a href="{{ arrival.map_url }}">{{ arrival.map_url }}</a></span>
+                </div>
+                {% endif %}
+              </div>
+              {% if timeline.duration_text %}
+              <div class="block">
+                <div class="block-title">{{ i18n.duration_label }}</div>
+                <div class="value">{{ timeline.duration_text }}</div>
+              </div>
+              {% endif %}
+            </td>
+            <td>
+              <div class="section-title">{{ i18n.passenger_section }}</div>
+              <div class="block">
+                <div class="row">
+                  <span class="label">{{ i18n.full_name_label }}</span>
+                  <span class="value">{{ passenger.name or i18n.value_not_available }}</span>
+                </div>
+                <div class="row">
+                  <span class="label">{{ i18n.phone_label }}</span>
+                  <span class="value">{{ passenger.phone or i18n.value_not_available }}</span>
+                </div>
+                <div class="row">
+                  <span class="label">Email</span>
+                  <span class="value break">{{ passenger.email or i18n.value_not_available }}</span>
+                </div>
+              </div>
+              <div class="section-title">{{ i18n.payment_section }}</div>
+              <div class="block">
+                <div class="row">
+                  <span class="label">{{ i18n.status_label }}</span>
+                  <span class="value">{{ payment.status_text }}</span>
+                </div>
+                <div class="row">
+                  <span class="label">{{ i18n.method_label }}</span>
+                  <span class="value">{{ payment.method_text }}</span>
+                </div>
+                <div class="row">
+                  <span class="label">{{ i18n.amount_label }}</span>
+                  <span class="value">{{ payment.amount_text }}</span>
+                </div>
+              </div>
+              <div class="section-title">QR</div>
+              <div class="block">
+                <table>
+                  <colgroup>
+                    <col style="width:140px"/>
+                    <col style="width:auto"/>
+                  </colgroup>
+                  <tr>
+                    <td>
+                      <div class="qr-box">
+                        {% if qr_data_uri %}
+                        <img src="{{ qr_data_uri }}" alt="QR"/>
+                        {% else %}
+                        <div class="subtle">{{ i18n.qr_unavailable }}</div>
+                        {% endif %}
+                      </div>
+                    </td>
+                    <td>
+                      <div class="row">
+                        <span class="label">{{ i18n.manage_online_hint }}</span>
+                        <span class="value break">
+                          {% if deep_link %}
+                          <a href="{{ deep_link }}">{{ deep_link }}</a>
+                          {% else %}
+                          {{ i18n.value_not_available }}
+                          {% endif %}
+                        </span>
+                      </div>
+                      {% if deep_link %}
+                      <div class="row">
+                        <a class="cta" href="{{ deep_link }}">{{ i18n.manage_online_button }}</a>
+                      </div>
+                      {% endif %}
+                    </td>
+                  </tr>
+                </table>
+              </div>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <td class="footer">
+        Maximov Tours · на линии {{ i18n.company_phone }} · с 1991 года · Время может отличаться
+      </td>
+    </tr>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a WeasyPrint-friendly HTML template for PDF rendering that avoids fragile CSS (grid/complex flex) and ensures long strings and QR images do not break layout.

### Description
- Add a new template `backend/templates/ticket_weasy.html` implementing the required table-based layout, `table-layout: fixed`, `.break` class for aggressive wrapping, and a fixed `132×132px` QR container. 
- Switch PDF rendering to the new template by adding `render_ticket_html_pdf()` and using it from `render_ticket_pdf()` in `backend/services/ticket_pdf.py` while leaving the existing `ticket.html` untouched for browser views. 
- Add stress-test data generator `backend/services/ticket_debug.py` and update the script `backend/scripts/render_ticket_stress.py` to use the new template and optionally write timestamped artifacts to `/tmp` with `--debug`. 
- Add a dev-only endpoint `GET /dev/tickets/weasyprint` (`backend/routers/dev_ticket.py`) to render the stress PDF and optionally save debug artifacts; this endpoint is included in `backend/main.py` only when `ENABLE_DEV_TICKET_ENDPOINTS=1`.

### Testing
- Ran `python backend/scripts/render_ticket_stress.py --debug`, which executed `render_ticket_html_pdf()` and `render_ticket_pdf()` and wrote `ticket_stress_<timestamp>.html` and `ticket_stress_<timestamp>.pdf` to `/tmp`, confirming PDF generation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c509727883278305b76ea1b3a2ae)