### PR TITLE
Restrict `/purchase/{purchase_id}/pay` to admin-only offline payments

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -94,6 +94,7 @@
 | PUT | `/tours/{tour_id}` | Обновление рейса и доступности мест. |
 | DELETE | `/tours/{tour_id}` | Удаление рейса (с опцией `force`). |
 | PUT | `/seat/block` | Блокировка/разблокировка места рейса. |
+| POST | `/purchase/{purchase_id}/pay` | **Внутренний admin-only** endpoint: пометка заказа как оплаченного офлайн, без LiqPay. Доступен только админскому фронту с bearer JWT. |
 
 ## Маршруты с проверкой билетного токена (scope) или админа
 
@@ -105,10 +106,12 @@
 | POST | `/tickets/{ticket_id}/seat` | `seat` | Смена места в рамках того же рейса. |
 | POST | `/tickets/{ticket_id}/reschedule` | `reschedule` | Перенос билета на другой рейс или сегмент. |
 | POST | `/tickets/reassign` | `edit` | Массовая пересадка между местами внутри рейса. |
-| POST | `/purchase/{purchase_id}/pay` | `pay` | Изменение статуса заказа на `paid`, запись продажи с `method=offline` и повторная выдача ссылок. |
+| POST | `/purchase/{purchase_id}/pay` | — | **Только внутренний админ-фронт**: офлайн-оплата заказа (`method=offline`). Требуется `Authorization: Bearer <admin JWT>`. Билетные токены (`X-Ticket-Token`, `?token=`) не поддерживаются. |
 | POST | `/purchase/{purchase_id}/cancel` | `cancel` | Отмена заказа с освобождением мест и записью в лог продаж. |
 
 ### Отдельный режим авторизации для внешнего фронта (`POST /pay`)
+
+> Важно: `POST /purchase/{purchase_id}/pay` — другой endpoint, он **не** для внешнего клиента; только для внутреннего админ-фронта.
 
 ### Ответы `POST /pay`
 

--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -7,7 +7,7 @@ from threading import Lock
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request, Response
 from pydantic import BaseModel, EmailStr, Field
 
-from ..auth import optional_scope, require_scope
+from ..auth import optional_scope, require_admin_token, require_scope
 from ..database import get_connection
 from ..ticket_utils import free_ticket
 from ._ticket_link_helpers import (
@@ -509,12 +509,16 @@ def create_purchase(data: PurchaseCreate, background_tasks: BackgroundTasks):
     return {"purchase_id": purchase_id, "amount_due": amount_due, "tickets": tickets}
 
 
-@router.post("/{purchase_id}/pay", status_code=204)
+@router.post(
+    "/{purchase_id}/pay",
+    status_code=204,
+    summary="Admin offline payment only, no LiqPay",
+    description="Admin offline payment only, no LiqPay",
+)
 def pay_purchase(
     purchase_id: int,
-    request: Request,
     background_tasks: BackgroundTasks,
-    context=Depends(require_scope("pay")),
+    admin_payload: dict = Depends(require_admin_token),
 ):
     conn = get_connection()
     cur = conn.cursor()
@@ -522,13 +526,7 @@ def pay_purchase(
     tickets: List[TicketLinkResult] = []
     customer_email: str | None = None
     try:
-        actor, jti = _resolve_actor(request)
-        guard_public_request(
-            request,
-            "pay",
-            purchase_id=purchase_id,
-            context=context,
-        )
+        actor = str(admin_payload.get("sub") or admin_payload.get("id") or "admin")
         cur.execute(
             "SELECT amount_due, status, customer_email FROM purchase WHERE id=%s",
             (purchase_id,),
@@ -547,8 +545,6 @@ def pay_purchase(
         _log_action(cur, purchase_id, "paid", amount_due, by=actor, method=ADMIN_PAY_METHOD)
         tickets = issue_ticket_links(ticket_specs, None, conn=conn)
         conn.commit()
-        if jti:
-            logger.info("Purchase %s paid with token jti=%s", purchase_id, jti)
     except HTTPException:
         conn.rollback()
         raise


### PR DESCRIPTION
### Motivation
- Закрыть возможность внешним клиентам отмечать заказ как оплаченного офлайн через ticket-token и явно зафиксировать поведение в OpenAPI и документации.

### Description
- Заменён dependency в `pay_purchase` с `Depends(require_scope("pay"))` на `Depends(require_admin_token)`, чтобы требовать только admin bearer JWT.
- Удалён путь выполнения через ticket-token (`X-Ticket-Token` / `?token=`) и связанный `Request`/`guard_public_request` код; актор теперь определяется из payload админ-токена (`sub`/`id`).
- Обновлён OpenAPI для маршрута (`summary` и `description`) на `Admin offline payment only, no LiqPay`.
- Обновлён `ENDPOINTS.md`, где явно зафиксировано, что `POST /purchase/{purchase_id}/pay` — внутренний endpoint только для админ-фронта и что билетные токены не поддерживаются.

### Testing
- Собран/скомпилирован модуль командой `python -m compileall backend/routers/purchase.py ENDPOINTS.md`, компиляция прошла успешно without syntax errors.
- Проверена корректность импорта/парсинга изменённого файла `backend/routers/purchase.py` посредством компиляции, ошибок не обнаружено.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dd6d97ab083279539194a2f670019)