### PR TITLE
Add integration_events auditing for purchases, payments, CheckBox and email errors

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -28,6 +28,7 @@ from ._ticket_link_helpers import (
     combine_departure_datetime,
 )
 from ..utils.client_app import get_client_app_base
+from ..services.integration_events import record_event
 
 session_router = APIRouter(tags=["public"])
 router = APIRouter(prefix="/public", tags=["public"])
@@ -552,6 +553,7 @@ def _sync_purchase_paid_from_liqpay_callback(
         )
         if normalized != "paid":
             conn.commit()
+            record_event(provider="liqpay", event_type="payment_status_transition", purchase_id=purchase_id, external_id=payment_id, status="failed" if normalized=="failed" else "pending", payload={"from": purchase_status, "to": purchase_status, "liqpay_status": liqpay_status})
             return normalized, payment_id
 
         if purchase_status == "paid":
@@ -571,6 +573,7 @@ def _sync_purchase_paid_from_liqpay_callback(
         from ..services.checkbox import is_enabled as checkbox_enabled
         fiscal_clause = ", fiscal_status='pending'" if checkbox_enabled() else ""
         cur.execute(f"UPDATE purchase SET status='paid', update_at=NOW(){fiscal_clause} WHERE id=%s", (purchase_id,))
+        record_event(provider="liqpay", event_type="payment_status_transition", purchase_id=purchase_id, external_id=payment_id, status="success", payload={"from": purchase_status, "to": "paid", "liqpay_status": liqpay_status})
         _log_action(cur, purchase_id, "paid", amount_due, by="liqpay", method="online")
         try:
             tickets = issue_ticket_links(ticket_specs, None, conn=conn)
@@ -772,6 +775,7 @@ async def liqpay_callback(request: Request, background_tasks: BackgroundTasks) -
         raise HTTPException(status_code=400, detail="Invalid LiqPay signature")
 
     payload = liqpay.decode_payload(data)
+    record_event(provider="liqpay", event_type="callback_received", status="success", payload=payload)
     order_id = str(payload.get("order_id") or "")
     purchase_id = _extract_purchase_id_from_order(order_id)
     if purchase_id is None:

--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -24,6 +24,7 @@ from ..services.access_guard import guard_public_request
 from ..services.email import render_ticket_email, send_ticket_email
 from ..services.ticket_dto import get_ticket_dto
 from ..services.ticket_pdf import render_ticket_pdf
+from ..services.integration_events import record_event
 
 logger = logging.getLogger(__name__)
 
@@ -255,8 +256,9 @@ def _send_ticket_email_task(
         subject, html_body = render_ticket_email(dto, deep_link, lang_value)
         send_ticket_email(recipient, subject, html_body, pdf_bytes)
         logger.info("Sent ticket email for ticket %s to %s", ticket_id, recipient)
-    except Exception:
+    except Exception as exc:
         logger.exception("Failed to send ticket email for ticket %s", ticket_id)
+        record_event(provider="email", event_type="ticket_email_send", status="error", ticket_id=ticket_id, payload={"recipient": recipient}, error_message=str(exc))
 
 
 def _create_purchase(
@@ -499,11 +501,13 @@ def create_purchase(data: PurchaseCreate, background_tasks: BackgroundTasks):
         tickets = issue_ticket_links(ticket_specs, data.lang, conn=conn)
         tickets = enrich_ticket_link_results(tickets, data.lang, conn=conn)
         conn.commit()
+        record_event(provider="purchase", event_type="create_purchase", purchase_id=purchase_id, status="success", payload={"tickets": len(ticket_specs), "amount_due": amount_due})
     except HTTPException:
         conn.rollback()
         raise
     except Exception as exc:
         conn.rollback()
+        record_event(provider="purchase", event_type="create_purchase", status="error", payload={"tour_id": data.tour_id, "seats": data.seat_nums}, error_message=str(exc))
         raise HTTPException(500, str(exc))
     finally:
         cur.close()
@@ -548,6 +552,7 @@ def pay_purchase(
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
 
         cur.execute("UPDATE purchase SET status='paid', update_at=NOW() WHERE id=%s", (purchase_id,))
+        record_event(provider="purchase", event_type="payment_status_transition", purchase_id=purchase_id, status="success", payload={"from": purchase_status, "to": "paid", "method": "offline"})
         _log_action(cur, purchase_id, "paid", amount_due, by=actor, method=ADMIN_PAY_METHOD)
         tickets = issue_ticket_links(ticket_specs, None, conn=conn)
         conn.commit()
@@ -558,6 +563,7 @@ def pay_purchase(
         raise
     except Exception as exc:
         conn.rollback()
+        record_event(provider="purchase", event_type="payment_status_transition", purchase_id=purchase_id, status="error", payload={"to": "paid", "method": "offline"}, error_message=str(exc))
         raise HTTPException(500, str(exc))
     finally:
         cur.close()
@@ -654,6 +660,7 @@ def book_seat(data: PurchaseCreate, request: Request, background_tasks: Backgrou
         tickets = issue_ticket_links(ticket_specs, data.lang, conn=conn)
         tickets = enrich_ticket_link_results(tickets, data.lang, conn=conn)
         conn.commit()
+        record_event(provider="purchase", event_type="create_purchase", purchase_id=purchase_id, status="success", payload={"tickets": len(ticket_specs), "amount_due": amount_due, "flow": "book"})
     except HTTPException:
         conn.rollback()
         raise

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -13,6 +13,8 @@ from typing import Any
 
 import httpx
 
+from .integration_events import record_event
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -288,6 +290,8 @@ def fiscalize_purchase(purchase_id: int) -> None:
     if not is_enabled():
         return
 
+    record_event(provider="checkbox", event_type="fiscalize_start", purchase_id=purchase_id, status="start")
+
     from ..database import get_connection
 
     conn = get_connection()
@@ -363,10 +367,12 @@ def fiscalize_purchase(purchase_id: int) -> None:
             "Purchase %s fiscalized successfully: receipt=%s fiscal_code=%s",
             purchase_id, receipt_id, fiscal_code,
         )
+        record_event(provider="checkbox", event_type="fiscalize_success", purchase_id=purchase_id, external_id=str(receipt_id), status="success", payload={"fiscal_code": fiscal_code})
 
     except Exception as exc:
         conn.rollback()
         error_msg = str(exc)[:500]
+        record_event(provider="checkbox", event_type="fiscalize_error", purchase_id=purchase_id, status="error", error_message=error_msg)
         logger.exception("Fiscalization failed for purchase %s", purchase_id)
 
         # If auth-related, invalidate cached token for next attempt

--- a/backend/services/integration_events.py
+++ b/backend/services/integration_events.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Mapping
+
+from ..database import get_connection
+
+_SENSITIVE_KEYS = {
+    "token", "access_token", "refresh_token", "secret", "password", "signature",
+    "authorization", "auth", "api_key", "private_key", "card", "pan", "cvv", "cvc",
+}
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        out: dict[str, Any] = {}
+        for k, v in value.items():
+            key = str(k)
+            if any(s in key.lower() for s in _SENSITIVE_KEYS):
+                out[key] = "***"
+            else:
+                out[key] = _sanitize(v)
+        return out
+    if isinstance(value, list):
+        return [_sanitize(v) for v in value]
+    if isinstance(value, tuple):
+        return [_sanitize(v) for v in value]
+    if isinstance(value, (datetime, Decimal)):
+        return str(value)
+    return value
+
+
+def record_event(
+    *,
+    provider: str,
+    event_type: str,
+    status: str,
+    purchase_id: int | None = None,
+    ticket_id: int | None = None,
+    external_id: str | None = None,
+    payload: Any | None = None,
+    error_message: str | None = None,
+) -> None:
+    payload_json = json.dumps(_sanitize(payload), ensure_ascii=False) if payload is not None else None
+    conn = None
+    cur = None
+    try:
+        conn = get_connection()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            INSERT INTO integration_events
+              (provider, event_type, purchase_id, ticket_id, external_id, status, payload_json, error_message, created_at)
+            VALUES (%s,%s,%s,%s,%s,%s,%s,%s,NOW())
+            """,
+            (provider, event_type, purchase_id, ticket_id, external_id, status, payload_json, error_message),
+        )
+        conn.commit()
+    except Exception:
+        if conn:
+            conn.rollback()
+    finally:
+        if cur:
+            cur.close()
+        if conn:
+            conn.close()

--- a/db/migrations/022_create_integration_events.sql
+++ b/db/migrations/022_create_integration_events.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS integration_events (
+    id BIGSERIAL PRIMARY KEY,
+    provider TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    purchase_id BIGINT REFERENCES purchase(id) ON DELETE SET NULL,
+    ticket_id BIGINT REFERENCES ticket(id) ON DELETE SET NULL,
+    external_id TEXT,
+    status TEXT NOT NULL,
+    payload_json JSONB,
+    error_message TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_events_created_at
+    ON integration_events (created_at);
+
+CREATE INDEX IF NOT EXISTS idx_integration_events_provider
+    ON integration_events (provider);
+
+CREATE INDEX IF NOT EXISTS idx_integration_events_purchase_id
+    ON integration_events (purchase_id);


### PR DESCRIPTION
### Motivation
- Provide a lightweight, auditable store of external integration events (payments, fiscalization, email delivery) to assist debugging and reconciliation.
- Ensure recorded payloads do not leak secrets by sanitizing sensitive fields before persistence.

### Description
- Add migration `db/migrations/022_create_integration_events.sql` to create the `integration_events` table with columns `id`, `provider`, `event_type`, `purchase_id`, `ticket_id`, `external_id`, `status`, `payload_json`, `error_message`, `created_at` and indexes on `created_at`, `provider`, and `purchase_id`.
- Add service `backend/services/integration_events.py` implementing `record_event(...)` and `_sanitize(...)` which redacts sensitive keys (e.g. `token`, `secret`, `password`, `signature`, `api_key`, `card`, `cvv`) and serializes common types safely.
- Wire `record_event(...)` into key flows: purchase creation (`backend/routers/purchase.py`), offline admin payment transition (`/purchase/{id}/pay`), LiqPay callback and payment status transitions (`backend/routers/public.py`), CheckBox fiscalization start/success/error (`backend/services/checkbox.py`), and ticket email send errors (`backend/routers/purchase.py`).
- Event writes are best-effort and will not propagate errors into the main business logic (errors during event recording are swallowed after rollback).

### Testing
- Compiled the modified package with `python -m compileall backend` and the run completed successfully.
- Verified the new files and edits were staged and committed (`backend/services/integration_events.py`, `db/migrations/022_create_integration_events.sql`, and modifications to `backend/routers/purchase.py`, `backend/routers/public.py`, `backend/services/checkbox.py`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34835969c83278d7aa09d388596cd)