### PR TITLE
Add structured logs for LiqPay/CheckBox flows and payload sanitization

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -28,7 +28,7 @@ from ._ticket_link_helpers import (
     combine_departure_datetime,
 )
 from ..utils.client_app import get_client_app_base
-from ..services.integration_events import record_event
+from ..services.integration_events import record_event, sanitize_payload
 
 session_router = APIRouter(tags=["public"])
 router = APIRouter(prefix="/public", tags=["public"])
@@ -520,6 +520,7 @@ def _sync_purchase_paid_from_liqpay_callback(
     tickets: list[dict[str, Any]] = []
     customer_email: str | None = None
     try:
+        sanitized_payload = sanitize_payload(payload)
         cur.execute(
             "SELECT amount_due, status, customer_email FROM purchase WHERE id=%s FOR UPDATE",
             (purchase_id,),
@@ -539,7 +540,7 @@ def _sync_purchase_paid_from_liqpay_callback(
                    update_at=NOW()
              WHERE id=%s
             """,
-            (order_id, liqpay_status or None, payment_id, json.dumps(payload), purchase_id),
+            (order_id, liqpay_status or None, payment_id, json.dumps(sanitized_payload), purchase_id),
         )
 
         normalized = _normalize_liqpay_result_status(liqpay_status)
@@ -553,7 +554,7 @@ def _sync_purchase_paid_from_liqpay_callback(
         )
         if normalized != "paid":
             conn.commit()
-            record_event(provider="liqpay", event_type="payment_status_transition", purchase_id=purchase_id, external_id=payment_id, status="failed" if normalized=="failed" else "pending", payload={"from": purchase_status, "to": purchase_status, "liqpay_status": liqpay_status})
+            record_event(provider="liqpay", event_type="payment_status_transition", purchase_id=purchase_id, external_id=payment_id, status="failed" if normalized=="failed" else "pending", payload={"purchase_id": purchase_id, "order_id": order_id, "payment_id": payment_id, "amount": amount_due, "from": purchase_status, "to": purchase_status, "liqpay_status": liqpay_status})
             return normalized, payment_id
 
         if purchase_status == "paid":
@@ -564,6 +565,10 @@ def _sync_purchase_paid_from_liqpay_callback(
                 payment_id,
             )
             conn.commit()
+            logger.info(
+                "fiscalization_skipped_existing_receipt purchase_id=%s order_id=%s payment_id=%s amount=%s status=%s",
+                purchase_id, order_id, payment_id, amount_due, purchase_status,
+            )
             return "paid", payment_id
 
         if purchase_status != "reserved":
@@ -573,7 +578,7 @@ def _sync_purchase_paid_from_liqpay_callback(
         from ..services.checkbox import is_enabled as checkbox_enabled
         fiscal_clause = ", fiscal_status='pending'" if checkbox_enabled() else ""
         cur.execute(f"UPDATE purchase SET status='paid', update_at=NOW(){fiscal_clause} WHERE id=%s", (purchase_id,))
-        record_event(provider="liqpay", event_type="payment_status_transition", purchase_id=purchase_id, external_id=payment_id, status="success", payload={"from": purchase_status, "to": "paid", "liqpay_status": liqpay_status})
+        record_event(provider="liqpay", event_type="payment_status_transition", purchase_id=purchase_id, external_id=payment_id, status="success", payload={"purchase_id": purchase_id, "order_id": order_id, "payment_id": payment_id, "amount": amount_due, "from": purchase_status, "to": "paid", "liqpay_status": liqpay_status})
         _log_action(cur, purchase_id, "paid", amount_due, by="liqpay", method="online")
         try:
             tickets = issue_ticket_links(ticket_specs, None, conn=conn)
@@ -772,9 +777,12 @@ async def liqpay_callback(request: Request, background_tasks: BackgroundTasks) -
         raise HTTPException(status_code=400, detail="Missing LiqPay data")
 
     if not liqpay.verify_signature(data, signature):
+        logger.warning("liqpay_signature_invalid purchase_id=%s order_id=%s status=invalid", None, None)
         raise HTTPException(status_code=400, detail="Invalid LiqPay signature")
+    logger.info("liqpay_signature_valid status=valid")
 
     payload = liqpay.decode_payload(data)
+    payload = sanitize_payload(payload)
     record_event(provider="liqpay", event_type="callback_received", status="success", payload=payload)
     order_id = str(payload.get("order_id") or "")
     purchase_id = _extract_purchase_id_from_order(order_id)

--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -501,6 +501,7 @@ def create_purchase(data: PurchaseCreate, background_tasks: BackgroundTasks):
         tickets = issue_ticket_links(ticket_specs, data.lang, conn=conn)
         tickets = enrich_ticket_link_results(tickets, data.lang, conn=conn)
         conn.commit()
+        logger.info("purchase_created purchase_id=%s order_id=%s payment_id=%s amount=%s status=%s", purchase_id, None, None, amount_due, "reserved")
         record_event(provider="purchase", event_type="create_purchase", purchase_id=purchase_id, status="success", payload={"tickets": len(ticket_specs), "amount_due": amount_due})
     except HTTPException:
         conn.rollback()
@@ -552,6 +553,7 @@ def pay_purchase(
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
 
         cur.execute("UPDATE purchase SET status='paid', update_at=NOW() WHERE id=%s", (purchase_id,))
+        logger.info("purchase_paid purchase_id=%s order_id=%s payment_id=%s amount=%s status=%s", purchase_id, None, None, amount_due, "paid")
         record_event(provider="purchase", event_type="payment_status_transition", purchase_id=purchase_id, status="success", payload={"from": purchase_status, "to": "paid", "method": "offline"})
         _log_action(cur, purchase_id, "paid", amount_due, by=actor, method=ADMIN_PAY_METHOD)
         tickets = issue_ticket_links(ticket_specs, None, conn=conn)

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -290,7 +290,8 @@ def fiscalize_purchase(purchase_id: int) -> None:
     if not is_enabled():
         return
 
-    record_event(provider="checkbox", event_type="fiscalize_start", purchase_id=purchase_id, status="start")
+    logger.info("checkbox_fiscalize_start purchase_id=%s status=start", purchase_id)
+    record_event(provider="checkbox", event_type="fiscalize_start", purchase_id=purchase_id, status="start", payload={"purchase_id": purchase_id})
 
     from ..database import get_connection
 
@@ -311,7 +312,7 @@ def fiscalize_purchase(purchase_id: int) -> None:
 
         # Idempotency: skip if already done
         if fiscal_status == "done":
-            logger.info("Purchase %s already fiscalized, skipping", purchase_id)
+            logger.info("fiscalization_skipped_existing_receipt purchase_id=%s status=%s receipt_id=%s", purchase_id, fiscal_status, existing_receipt_id)
             conn.commit()
             return
 
@@ -367,12 +368,12 @@ def fiscalize_purchase(purchase_id: int) -> None:
             "Purchase %s fiscalized successfully: receipt=%s fiscal_code=%s",
             purchase_id, receipt_id, fiscal_code,
         )
-        record_event(provider="checkbox", event_type="fiscalize_success", purchase_id=purchase_id, external_id=str(receipt_id), status="success", payload={"fiscal_code": fiscal_code})
+        record_event(provider="checkbox", event_type="fiscalize_success", purchase_id=purchase_id, external_id=str(receipt_id), status="success", payload={"purchase_id": purchase_id, "receipt_id": receipt_id, "status": "done", "fiscal_code": fiscal_code})
 
     except Exception as exc:
         conn.rollback()
         error_msg = str(exc)[:500]
-        record_event(provider="checkbox", event_type="fiscalize_error", purchase_id=purchase_id, status="error", error_message=error_msg)
+        record_event(provider="checkbox", event_type="fiscalize_error", purchase_id=purchase_id, status="error", error_message=error_msg, payload={"purchase_id": purchase_id, "status": "failed"})
         logger.exception("Fiscalization failed for purchase %s", purchase_id)
 
         # If auth-related, invalidate cached token for next attempt

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -171,6 +171,7 @@ def send_ticket_email(
 ) -> None:
     """Send a ticket email with the provided HTML body and PDF attachment."""
 
+    logger.info("ticket_email_send_started purchase_id=%s ticket=%s status=started recipient=%s", None, subject, to)
     try:
         host = _get_env("SMTP_HOST")
         port_raw = _get_env("SMTP_PORT")
@@ -179,7 +180,7 @@ def send_ticket_email(
         from_email = _get_env("SMTP_FROM")
         from_name = _get_env("SMTP_FROM_NAME", required=False)
     except EmailConfigurationError:
-        logger.info("Skipping ticket email delivery because SMTP is not configured")
+        logger.info("ticket_email_skipped_smtp_not_configured status=skipped recipient=%s", to)
         return
 
     port = int(port_raw) if port_raw else 587
@@ -221,6 +222,7 @@ def send_ticket_email(
         if username and password:
             server.login(username, password)
         server.send_message(message)
+    logger.info("ticket_email_send_finished status=success recipient=%s", to)
 
 
 def send_otp_email(to: str, code: str, lang: str | None = None) -> None:

--- a/backend/services/integration_events.py
+++ b/backend/services/integration_events.py
@@ -11,6 +11,15 @@ _SENSITIVE_KEYS = {
     "token", "access_token", "refresh_token", "secret", "password", "signature",
     "authorization", "auth", "api_key", "private_key", "card", "pan", "cvv", "cvc",
 }
+_SENSITIVE_VALUE_PATTERNS = ("card", "pan", "token", "secret", "password", "private_key")
+
+
+def _mask_card_like(value: str) -> str:
+    digits = "".join(ch for ch in value if ch.isdigit())
+    if len(digits) < 12:
+        return value
+    tail = digits[-4:]
+    return f"***{tail}"
 
 
 def _sanitize(value: Any) -> Any:
@@ -29,7 +38,16 @@ def _sanitize(value: Any) -> Any:
         return [_sanitize(v) for v in value]
     if isinstance(value, (datetime, Decimal)):
         return str(value)
+    if isinstance(value, str):
+        lowered = value.lower()
+        if any(pattern in lowered for pattern in _SENSITIVE_VALUE_PATTERNS):
+            return "***"
+        return _mask_card_like(value)
     return value
+
+
+def sanitize_payload(payload: Any) -> Any:
+    return _sanitize(payload)
 
 
 def record_event(
@@ -43,7 +61,7 @@ def record_event(
     payload: Any | None = None,
     error_message: str | None = None,
 ) -> None:
-    payload_json = json.dumps(_sanitize(payload), ensure_ascii=False) if payload is not None else None
+    payload_json = json.dumps(sanitize_payload(payload), ensure_ascii=False) if payload is not None else None
     conn = None
     cur = None
     try:


### PR DESCRIPTION
### Motivation
- Improve observability of payment and fiscalization flows with explicit, structured log events for key steps and idempotent paths.
- Ensure sensitive data (tokens/passwords/private keys/card-like values) is masked before persisting or logging LiqPay/integration payloads.

### Description
- Introduced `sanitize_payload` (and a card-like masker) in `backend/services/integration_events.py` and switched `record_event` to use it when storing `payload_json`.
- Persist LiqPay callback payloads sanitized in `backend/routers/public.py`, added explicit logs `liqpay_signature_valid` / `liqpay_signature_invalid`, and enriched LiqPay `payment_status_transition` events with consistent keys (`purchase_id`, `order_id`, `payment_id`, `amount`).
- Added explicit idempotent skip log `fiscalization_skipped_existing_receipt` and more structured fiscalization start/success/error integration events in `backend/services/checkbox.py`.
- Added ticket email lifecycle logs (`ticket_email_send_started`, skip reason, `ticket_email_send_finished`) in `backend/services/email.py`.
- Added structured purchase lifecycle logs (`purchase_created`, `purchase_paid`) in `backend/routers/purchase.py`.

### Testing
- Compiled modified modules with `python -m py_compile backend/routers/purchase.py backend/routers/public.py backend/services/checkbox.py backend/services/email.py backend/services/integration_events.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34ae2c64c832786a62f71754c987a)