### PR TITLE
Add CheckBox fiscal receipt URL/payload persistence and expose fields in admin APIs

### DIFF
--- a/backend/routers/purchase_admin.py
+++ b/backend/routers/purchase_admin.py
@@ -30,6 +30,10 @@ class PurchaseRow(BaseModel):
     status: str
     deadline: Optional[str]
     payment_method: str
+    fiscal_status: Optional[str] = None
+    fiscal_last_error: Optional[str] = None
+    checkbox_receipt_id: Optional[str] = None
+    fiscal_receipt_url: Optional[str] = None
 
 @router.get("/", response_model=List[PurchaseRow])
 def list_purchases(
@@ -66,7 +70,11 @@ def list_purchases(
               pu.amount_due,
               pu.status,
               pu.deadline,
-              pu.payment_method
+              pu.payment_method,
+              pu.fiscal_status,
+              pu.fiscal_last_error,
+              pu.checkbox_receipt_id,
+              pu.fiscal_receipt_url
             FROM purchase pu
             {where_clause}
             ORDER BY pu.id DESC
@@ -87,6 +95,10 @@ def list_purchases(
                     "status": r[6],
                     "deadline": r[7].isoformat() if r[7] else None,
                     "payment_method": r[8],
+                    "fiscal_status": r[9],
+                    "fiscal_last_error": r[10],
+                    "checkbox_receipt_id": r[11],
+                    "fiscal_receipt_url": r[12],
                 }
             )
         return purchases
@@ -114,6 +126,11 @@ class TicketInfo(BaseModel):
 class PurchaseInfo(BaseModel):
     tickets: List[TicketInfo]
     logs: List[PurchaseLog]
+    fiscal_status: Optional[str] = None
+    fiscal_last_error: Optional[str] = None
+    checkbox_receipt_id: Optional[str] = None
+    fiscal_receipt_url: Optional[str] = None
+    fiscal_payload: Optional[dict] = None
 
 
 @router.get("/{purchase_id}", response_model=PurchaseInfo)
@@ -177,7 +194,25 @@ def purchase_info(purchase_id: int):
             for r in s_rows
         ]
 
-        return {"tickets": tickets, "logs": logs}
+        cur.execute(
+            """
+            SELECT fiscal_status, fiscal_last_error, checkbox_receipt_id, fiscal_receipt_url, fiscal_payload
+            FROM purchase
+            WHERE id=%s
+            """,
+            (purchase_id,),
+        )
+        p_row = cur.fetchone()
+
+        return {
+            "tickets": tickets,
+            "logs": logs,
+            "fiscal_status": p_row[0] if p_row else None,
+            "fiscal_last_error": p_row[1] if p_row else None,
+            "checkbox_receipt_id": p_row[2] if p_row else None,
+            "fiscal_receipt_url": p_row[3] if p_row else None,
+            "fiscal_payload": p_row[4] if p_row else None,
+        }
     finally:
         cur.close()
         conn.close()

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -9,6 +9,7 @@ import logging
 import os
 import time
 import threading
+import json
 from typing import Any
 
 import httpx
@@ -213,6 +214,25 @@ def get_receipt_png_url(receipt_id: str) -> str:
     return f"{_api_url()}/api/v1/receipts/{receipt_id}/png"
 
 
+def _sanitize_receipt_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Keep only operator-safe subset of CheckBox receipt payload."""
+    keep_fields = {
+        "id",
+        "status",
+        "serial",
+        "fiscal_code",
+        "created_at",
+        "updated_at",
+        "total_sum",
+        "payments",
+    }
+    sanitized: dict[str, Any] = {}
+    for key in keep_fields:
+        if key in payload:
+            sanitized[key] = payload[key]
+    return sanitized
+
+
 # ---------------------------------------------------------------------------
 # Data loading for receipt items
 # ---------------------------------------------------------------------------
@@ -348,6 +368,8 @@ def fiscalize_purchase(purchase_id: int) -> None:
         # Poll until DONE
         receipt_data = _poll_receipt(receipt_id)
         fiscal_code = receipt_data.get("fiscal_code", "")
+        receipt_url = get_receipt_png_url(receipt_id)
+        sanitized_payload = _sanitize_receipt_payload(receipt_data)
 
         # Success — persist final state
         cur.execute(
@@ -356,12 +378,14 @@ def fiscalize_purchase(purchase_id: int) -> None:
                SET fiscal_status = 'done',
                    checkbox_receipt_id = %s,
                    checkbox_fiscal_code = %s,
+                   fiscal_receipt_url = %s,
+                   fiscal_payload = %s::jsonb,
                    fiscal_last_error = NULL,
                    fiscalized_at = NOW(),
                    update_at = NOW()
              WHERE id = %s
             """,
-            (receipt_id, fiscal_code, purchase_id),
+            (receipt_id, fiscal_code, receipt_url, json.dumps(sanitized_payload), purchase_id),
         )
         conn.commit()
         logger.info(

--- a/db/migrations/023_add_purchase_fiscal_receipt_payload.sql
+++ b/db/migrations/023_add_purchase_fiscal_receipt_payload.sql
@@ -1,0 +1,15 @@
+-- Add persisted CheckBox receipt URL and sanitized payload for operator visibility/audit.
+ALTER TABLE public.purchase
+    ADD COLUMN IF NOT EXISTS fiscal_receipt_url TEXT,
+    ADD COLUMN IF NOT EXISTS fiscal_payload JSONB;
+
+-- Keep fiscal status constrained to known values when present.
+ALTER TABLE public.purchase
+    DROP CONSTRAINT IF EXISTS purchase_fiscal_status_check;
+
+ALTER TABLE public.purchase
+    ADD CONSTRAINT purchase_fiscal_status_check
+    CHECK (
+        fiscal_status IS NULL
+        OR fiscal_status IN ('pending', 'processing', 'done', 'failed')
+    );


### PR DESCRIPTION
### Motivation
- Persist CheckBox terminal response and receipt URL for operator visibility and auditability of fiscalization results.
- Constrain `fiscal_status` to known states and keep payment state (`purchase.status='paid'`) independent from CheckBox failures.

### Description
- Added migration `db/migrations/023_add_purchase_fiscal_receipt_payload.sql` to add `fiscal_receipt_url TEXT` and `fiscal_payload JSONB` to `purchase` and to enforce a `purchase_fiscal_status_check` constraint allowing `NULL` or `pending/processing/done/failed`.
- Updated `backend/services/checkbox.py` to build a sanitized subset via `_sanitize_receipt_payload`, obtain the receipt image URL via `get_receipt_png_url`, and persist `fiscal_receipt_url` and `fiscal_payload` (JSONB) when fiscalization succeeds inside `fiscalize_purchase`.
- Kept existing idempotency and terminal-status handling in `fiscalize_purchase`, and preserved the existing behavior that CheckBox errors set `fiscal_status='failed'` and `fiscal_last_error` without rolling back `purchase.status`.
- Exposed the new fields to operators by updating admin DTOs and queries in `backend/routers/purchase_admin.py` to include `fiscal_status`, `fiscal_last_error`, `checkbox_receipt_id`, `fiscal_receipt_url` in list view and the same plus `fiscal_payload` in purchase detail.

### Testing
- Ran `pytest -q tests/test_admin_purchases.py tests/test_payment_resolve.py` to exercise admin purchase responses and payment resolve flow.
- Tests could not complete in this environment because importing the app requires the `JWT_SECRET` environment variable, causing the run to fail before assertions (error: missing `JWT_SECRET`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34ba084248327bcf36e8738fc62b1)