### PR TITLE
Add payment/fiscal fields to admin purchases and retry-fiscalization endpoint + UI

### DIFF
--- a/backend/routers/purchase_admin.py
+++ b/backend/routers/purchase_admin.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from typing import List, Optional
 from ..database import get_connection
@@ -30,6 +30,10 @@ class PurchaseRow(BaseModel):
     status: str
     deadline: Optional[str]
     payment_method: str
+    payment_status: Optional[str] = None
+    liqpay_order_id: Optional[str] = None
+    liqpay_payment_id: Optional[str] = None
+    liqpay_status: Optional[str] = None
     fiscal_status: Optional[str] = None
     fiscal_last_error: Optional[str] = None
     checkbox_receipt_id: Optional[str] = None
@@ -71,6 +75,10 @@ def list_purchases(
               pu.status,
               pu.deadline,
               pu.payment_method,
+              pu.status AS payment_status,
+              pu.liqpay_order_id,
+              pu.liqpay_payment_id,
+              pu.liqpay_status,
               pu.fiscal_status,
               pu.fiscal_last_error,
               pu.checkbox_receipt_id,
@@ -95,10 +103,14 @@ def list_purchases(
                     "status": r[6],
                     "deadline": r[7].isoformat() if r[7] else None,
                     "payment_method": r[8],
-                    "fiscal_status": r[9],
-                    "fiscal_last_error": r[10],
-                    "checkbox_receipt_id": r[11],
-                    "fiscal_receipt_url": r[12],
+                    "payment_status": r[9],
+                    "liqpay_order_id": r[10],
+                    "liqpay_payment_id": r[11],
+                    "liqpay_status": r[12],
+                    "fiscal_status": r[13],
+                    "fiscal_last_error": r[14],
+                    "checkbox_receipt_id": r[15],
+                    "fiscal_receipt_url": r[16],
                 }
             )
         return purchases
@@ -126,6 +138,10 @@ class TicketInfo(BaseModel):
 class PurchaseInfo(BaseModel):
     tickets: List[TicketInfo]
     logs: List[PurchaseLog]
+    payment_status: Optional[str] = None
+    liqpay_order_id: Optional[str] = None
+    liqpay_payment_id: Optional[str] = None
+    liqpay_status: Optional[str] = None
     fiscal_status: Optional[str] = None
     fiscal_last_error: Optional[str] = None
     checkbox_receipt_id: Optional[str] = None
@@ -196,7 +212,8 @@ def purchase_info(purchase_id: int):
 
         cur.execute(
             """
-            SELECT fiscal_status, fiscal_last_error, checkbox_receipt_id, fiscal_receipt_url, fiscal_payload
+            SELECT status, liqpay_order_id, liqpay_payment_id, liqpay_status,
+                   fiscal_status, fiscal_last_error, checkbox_receipt_id, fiscal_receipt_url, fiscal_payload
             FROM purchase
             WHERE id=%s
             """,
@@ -207,11 +224,71 @@ def purchase_info(purchase_id: int):
         return {
             "tickets": tickets,
             "logs": logs,
-            "fiscal_status": p_row[0] if p_row else None,
-            "fiscal_last_error": p_row[1] if p_row else None,
-            "checkbox_receipt_id": p_row[2] if p_row else None,
-            "fiscal_receipt_url": p_row[3] if p_row else None,
-            "fiscal_payload": p_row[4] if p_row else None,
+            "payment_status": p_row[0] if p_row else None,
+            "liqpay_order_id": p_row[1] if p_row else None,
+            "liqpay_payment_id": p_row[2] if p_row else None,
+            "liqpay_status": p_row[3] if p_row else None,
+            "fiscal_status": p_row[4] if p_row else None,
+            "fiscal_last_error": p_row[5] if p_row else None,
+            "checkbox_receipt_id": p_row[6] if p_row else None,
+            "fiscal_receipt_url": p_row[7] if p_row else None,
+            "fiscal_payload": p_row[8] if p_row else None,
+        }
+    finally:
+        cur.close()
+        conn.close()
+
+
+@router.post("/{purchase_id}/retry-fiscalization")
+def retry_fiscalization(purchase_id: int):
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT id, status, fiscal_status, checkbox_receipt_id
+            FROM purchase
+            WHERE id = %s
+            """,
+            (purchase_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Purchase not found")
+        _, status, fiscal_status, receipt_id = row
+        if status != "paid":
+            raise HTTPException(status_code=409, detail=f"Purchase must be paid (current status: {status})")
+        if receipt_id:
+            raise HTTPException(status_code=409, detail=f"Purchase already has receipt id: {receipt_id}")
+        if fiscal_status not in ("pending", "failed"):
+            raise HTTPException(status_code=409, detail=f"Fiscal status does not allow retry: {fiscal_status}")
+    finally:
+        cur.close()
+        conn.close()
+
+    from ..services.checkbox import fiscalize_purchase
+
+    fiscalize_purchase(purchase_id)
+
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT status, fiscal_status, checkbox_receipt_id, fiscal_receipt_url, fiscal_last_error
+            FROM purchase
+            WHERE id = %s
+            """,
+            (purchase_id,),
+        )
+        status, fiscal_status, receipt_id, receipt_url, fiscal_last_error = cur.fetchone()
+        return {
+            "purchase_id": purchase_id,
+            "payment_status": status,
+            "fiscal_status": fiscal_status,
+            "checkbox_receipt_id": receipt_id,
+            "fiscal_receipt_url": receipt_url,
+            "fiscal_last_error": fiscal_last_error,
         }
     finally:
         cur.close()

--- a/frontend/src/pages/PurchasesPage.js
+++ b/frontend/src/pages/PurchasesPage.js
@@ -128,6 +128,9 @@ export default function PurchasesPage() {
   const handleRefund = (id) => {
     axios.post(`${API}/purchase/${id}/refund`).then(load).catch(console.error);
   };
+  const handleRetryFiscalization = (id) => {
+    axios.post(`${API}/admin/purchases/${id}/retry-fiscalization`).then(load).catch(console.error);
+  };
 
   const handleTicketDownload = async (ticketId) => {
     try {
@@ -235,6 +238,10 @@ export default function PurchasesPage() {
   };
 
   const modalPurchaseInfo = modalState.open ? info[modalState.orderId] : null;
+  const canRetryFiscalization = (purchase, purchaseInfo) =>
+    (purchaseInfo?.payment_status || purchase?.payment_status || purchase?.status) === "paid"
+    && ["pending", "failed"].includes(purchaseInfo?.fiscal_status || purchase?.fiscal_status)
+    && !(purchaseInfo?.checkbox_receipt_id || purchase?.checkbox_receipt_id);
 
   const renderTicketsTable = (purchaseInfo) => {
     const tickets = purchaseInfo?.tickets ?? [];
@@ -537,6 +544,22 @@ export default function PurchasesPage() {
 
                             <div className="purchases-card">
                               <div className="purchases-card__header">
+                                <span>Оплата и фискализация</span>
+                              </div>
+                              <div className="purchases-card__body">
+                                <div><b>payment_status:</b> {info[p.id]?.payment_status || p.payment_status || "—"}</div>
+                                <div><b>liqpay_order_id:</b> {info[p.id]?.liqpay_order_id || p.liqpay_order_id || "—"}</div>
+                                <div><b>liqpay_payment_id:</b> {info[p.id]?.liqpay_payment_id || p.liqpay_payment_id || "—"}</div>
+                                <div><b>liqpay_status:</b> {info[p.id]?.liqpay_status || p.liqpay_status || "—"}</div>
+                                <div><b>fiscal_status:</b> {info[p.id]?.fiscal_status || p.fiscal_status || "—"}</div>
+                                <div><b>checkbox_receipt_id:</b> {info[p.id]?.checkbox_receipt_id || p.checkbox_receipt_id || "—"}</div>
+                                <div><b>fiscal_receipt_url:</b> {(info[p.id]?.fiscal_receipt_url || p.fiscal_receipt_url) ? <a href={info[p.id]?.fiscal_receipt_url || p.fiscal_receipt_url} target="_blank" rel="noreferrer">Открыть</a> : "—"}</div>
+                                <div><b>fiscal_last_error:</b> {info[p.id]?.fiscal_last_error || p.fiscal_last_error || "—"}</div>
+                              </div>
+                            </div>
+
+                            <div className="purchases-card">
+                              <div className="purchases-card__header">
                                 <span>Действия</span>
                               </div>
                               <div className="purchases-actions-card">
@@ -586,6 +609,18 @@ export default function PurchasesPage() {
                                     Оформить возврат
                                   </button>
                                 )}
+                                {canRetryFiscalization(p, info[p.id]) && (
+                                  <button
+                                    type="button"
+                                    className="purchases-btn purchases-btn--primary"
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleRetryFiscalization(p.id);
+                                    }}
+                                  >
+                                    Retry fiscalization
+                                  </button>
+                                )}
                               </div>
                             </div>
                           </div>
@@ -626,6 +661,16 @@ export default function PurchasesPage() {
                 className={`purchases-modal__scroll${modalScrolled ? " purchases-scroll--scrolled" : ""}`}
                 ref={modalScrollRef}
               >
+                <div className="purchases-card__body">
+                  <div><b>payment_status:</b> {modalPurchaseInfo?.payment_status || "—"}</div>
+                  <div><b>liqpay_order_id:</b> {modalPurchaseInfo?.liqpay_order_id || "—"}</div>
+                  <div><b>liqpay_payment_id:</b> {modalPurchaseInfo?.liqpay_payment_id || "—"}</div>
+                  <div><b>liqpay_status:</b> {modalPurchaseInfo?.liqpay_status || "—"}</div>
+                  <div><b>fiscal_status:</b> {modalPurchaseInfo?.fiscal_status || "—"}</div>
+                  <div><b>checkbox_receipt_id:</b> {modalPurchaseInfo?.checkbox_receipt_id || "—"}</div>
+                  <div><b>fiscal_receipt_url:</b> {modalPurchaseInfo?.fiscal_receipt_url ? <a href={modalPurchaseInfo.fiscal_receipt_url} target="_blank" rel="noreferrer">Открыть</a> : "—"}</div>
+                  <div><b>fiscal_last_error:</b> {modalPurchaseInfo?.fiscal_last_error || "—"}</div>
+                </div>
                 {modalState.section === "tickets" && renderTicketsTable(modalPurchaseInfo)}
                 {modalState.section === "logs" && renderLogsTable(modalPurchaseInfo)}
                 <button type="button" className="purchases-to-top" onClick={handleModalToTop}>

--- a/tests/test_admin_purchases.py
+++ b/tests/test_admin_purchases.py
@@ -12,6 +12,18 @@ class DummyCursor:
         self.query = query
         self.queries.append((query, params))
     def fetchone(self):
+        if "FROM purchase" in self.query:
+            return (
+                "paid",
+                "order-1",
+                "payment-1",
+                "success",
+                "pending",
+                None,
+                None,
+                None,
+                None,
+            )
         return None
     def fetchall(self):
         if "FROM purchase" in self.query:
@@ -27,6 +39,14 @@ class DummyCursor:
                 "reserved",
                 datetime(2025, 8, 9, 12, 0, 0),
                 "online",
+                "reserved",
+                "order-1",
+                "payment-1",
+                "success",
+                "pending",
+                None,
+                None,
+                None,
             )]
         if "FROM ticket" in self.query:
             return [(


### PR DESCRIPTION
### Motivation
- Expose payment tracking and CheckBox fiscalization metadata in admin purchase endpoints so the admin UI can display liqpay/fiscal state and allow manual retry when needed.
- Provide a simple admin-scoped retry action to re-run fiscalization for paid purchases that are pending/failed and lack a receipt id.

### Description
- Extended `/admin/purchases/` list and `/admin/purchases/{id}` detail responses to include `payment_status`, `liqpay_order_id`, `liqpay_payment_id`, `liqpay_status`, `fiscal_status`, `checkbox_receipt_id`, `fiscal_receipt_url`, and `fiscal_last_error` in `backend/routers/purchase_admin.py`.
- Added `POST /admin/purchases/{purchase_id}/retry-fiscalization` endpoint which validates the purchase (must be `paid`, fiscal status in `pending|failed`, no receipt id), invokes `services.checkbox.fiscalize_purchase`, and returns the updated purchase fiscal/payment payload.
- Updated `frontend/src/pages/PurchasesPage.js` to show the new payment/fiscal fields in expanded rows and in the modal, and added a `Retry fiscalization` button that is shown only when the purchase is paid, fiscal status is `pending` or `failed`, and no receipt id exists; the button calls the new admin retry endpoint and refreshes the UI.
- Adjusted `tests/test_admin_purchases.py` dummy DB fixtures to reflect the expanded response schema used by the admin endpoints.

### Testing
- Ran `pytest -q tests/test_admin_purchases.py` which failed during test setup due to a missing environment variable (`KeyError: 'JWT_SECRET'`) in the test environment, so backend unit tests could not be fully executed here.
- Manual smoke: frontend code calls the new retry endpoint and triggers `load()` on success (no automated frontend tests were executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34c5337d48327966b7cd62b8b4499)