### PR TITLE
Add provider health endpoints, make LiqPay tracking schema-safe, and improve Checkbox fiscalization logging/events

### DIFF
--- a/backend/routers/ops_admin.py
+++ b/backend/routers/ops_admin.py
@@ -84,6 +84,50 @@ def ops_health() -> dict[str, Any]:
         conn.close()
 
 
+@router.get("/health/liqpay")
+def liqpay_health() -> dict[str, Any]:
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT COUNT(*),
+                   COUNT(*) FILTER (WHERE status IN ('success', 'paid', 'ok')),
+                   COUNT(*) FILTER (WHERE status IN ('failed', 'error')),
+                   MAX(created_at)
+            FROM integration_events
+            WHERE provider = 'liqpay'
+            """
+        )
+        total, success, failed, last_event_at = cur.fetchone()
+        return {"provider": "liqpay", "total_events": int(total or 0), "success_events": int(success or 0), "failed_events": int(failed or 0), "last_event_at": last_event_at.isoformat() if last_event_at else None}
+    finally:
+        cur.close()
+        conn.close()
+
+
+@router.get("/health/checkbox")
+def checkbox_health() -> dict[str, Any]:
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT COUNT(*),
+                   COUNT(*) FILTER (WHERE status IN ('success', 'done', 'ok')),
+                   COUNT(*) FILTER (WHERE status IN ('failed', 'error')),
+                   MAX(created_at)
+            FROM integration_events
+            WHERE provider = 'checkbox'
+            """
+        )
+        total, success, failed, last_event_at = cur.fetchone()
+        return {"provider": "checkbox", "total_events": int(total or 0), "success_events": int(success or 0), "failed_events": int(failed or 0), "last_event_at": last_event_at.isoformat() if last_event_at else None}
+    finally:
+        cur.close()
+        conn.close()
+
+
 @router.get("/events")
 def list_events(
     provider: Optional[str] = Query(None, description="Filter by integration provider (liqpay/checkbox/email/...)"),

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -532,29 +532,39 @@ def _sync_purchase_paid_from_liqpay_callback(
         amount_due, purchase_status, customer_email = float(row[0]), row[1], row[2]
         cur.execute(
             """
-            UPDATE purchase
-               SET liqpay_order_id=%s,
-                   liqpay_status=%s,
-                   liqpay_payment_id=%s,
-                   liqpay_payload=%s,
-                   update_at=NOW()
-             WHERE id=%s
-            """,
-            (order_id, liqpay_status or None, payment_id, json.dumps(sanitized_payload), purchase_id),
+            SELECT column_name
+              FROM information_schema.columns
+             WHERE table_schema='public'
+               AND table_name='purchase'
+               AND column_name IN ('liqpay_order_id','liqpay_status','liqpay_payment_id','liqpay_payload')
+            """
         )
+        liqpay_columns = {r[0] for r in (cur.fetchall() or [])}
+        if len(liqpay_columns) == 4:
+            cur.execute(
+                """
+                UPDATE purchase
+                   SET liqpay_order_id=%s,
+                       liqpay_status=%s,
+                       liqpay_payment_id=%s,
+                       liqpay_payload=%s,
+                       update_at=NOW()
+                 WHERE id=%s
+                """,
+                (order_id, liqpay_status or None, payment_id, json.dumps(sanitized_payload), purchase_id),
+            )
+        else:
+            logger.error(
+                "liqpay_tracking_schema_missing purchase_id=%s columns=%s action=run_migrations_018_019_021",
+                purchase_id,
+                sorted(liqpay_columns),
+            )
 
         normalized = _normalize_liqpay_result_status(liqpay_status)
-        logger.info(
-            "LiqPay callback processed for purchase=%s order_id=%s payment_id=%s liqpay_status=%s normalized=%s",
-            purchase_id,
-            order_id,
-            payment_id,
-            liqpay_status or None,
-            normalized,
-        )
+        logger.info("liqpay_payment_saved purchase_id=%s status=%s payment_id=%s", purchase_id, normalized, payment_id)
         if normalized != "paid":
             conn.commit()
-            record_event(provider="liqpay", event_type="payment_status_transition", purchase_id=purchase_id, external_id=payment_id, status="failed" if normalized=="failed" else "pending", payload={"purchase_id": purchase_id, "order_id": order_id, "payment_id": payment_id, "amount": amount_due, "from": purchase_status, "to": purchase_status, "liqpay_status": liqpay_status})
+            record_event(provider="liqpay", event_type="liqpay_payment_failed" if normalized=="failed" else "liqpay_payment_pending", purchase_id=purchase_id, external_id=payment_id, status="failed" if normalized=="failed" else "pending", payload={"purchase_id": purchase_id, "order_id": order_id, "payment_id": payment_id, "amount": amount_due, "from": purchase_status, "to": purchase_status, "liqpay_status": liqpay_status})
             return normalized, payment_id
 
         if purchase_status == "paid":
@@ -578,7 +588,7 @@ def _sync_purchase_paid_from_liqpay_callback(
         from ..services.checkbox import is_enabled as checkbox_enabled
         fiscal_clause = ", fiscal_status='pending'" if checkbox_enabled() else ""
         cur.execute(f"UPDATE purchase SET status='paid', update_at=NOW(){fiscal_clause} WHERE id=%s", (purchase_id,))
-        record_event(provider="liqpay", event_type="payment_status_transition", purchase_id=purchase_id, external_id=payment_id, status="success", payload={"purchase_id": purchase_id, "order_id": order_id, "payment_id": payment_id, "amount": amount_due, "from": purchase_status, "to": "paid", "liqpay_status": liqpay_status})
+        record_event(provider="liqpay", event_type="liqpay_payment_success", purchase_id=purchase_id, external_id=payment_id, status="success", payload={"purchase_id": purchase_id, "order_id": order_id, "payment_id": payment_id, "amount": amount_due, "from": purchase_status, "to": "paid", "liqpay_status": liqpay_status})
         _log_action(cur, purchase_id, "paid", amount_due, by="liqpay", method="online")
         try:
             tickets = issue_ticket_links(ticket_specs, None, conn=conn)
@@ -779,11 +789,17 @@ async def liqpay_callback(request: Request, background_tasks: BackgroundTasks) -
     if not liqpay.verify_signature(data, signature):
         logger.warning("liqpay_signature_invalid purchase_id=%s order_id=%s status=invalid", None, None)
         raise HTTPException(status_code=400, detail="Invalid LiqPay signature")
-    logger.info("liqpay_signature_valid status=valid")
+    logger.info("liqpay_signature_valid")
 
     payload = liqpay.decode_payload(data)
     payload = sanitize_payload(payload)
-    record_event(provider="liqpay", event_type="callback_received", status="success", payload=payload)
+    logger.info(
+        "liqpay_callback_received order_id=%s raw_status=%s payment_id=%s",
+        payload.get("order_id"),
+        payload.get("status"),
+        payload.get("payment_id"),
+    )
+    record_event(provider="liqpay", event_type="liqpay_callback_received", status="success", payload=payload)
     order_id = str(payload.get("order_id") or "")
     purchase_id = _extract_purchase_id_from_order(order_id)
     if purchase_id is None:

--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -177,6 +177,19 @@ def _validate_purchase_payable(amount_due: float, status: str) -> None:
 
 def _save_liqpay_order_id(cur, purchase_id: int, order_id: str) -> None:
     cur.execute(
+        """
+        SELECT 1
+          FROM information_schema.columns
+         WHERE table_schema='public' AND table_name='purchase' AND column_name='liqpay_order_id'
+        """
+    )
+    if not cur.fetchone():
+        logger.error(
+            "liqpay_tracking_schema_missing purchase_id=%s missing_column=liqpay_order_id action=run_migrations_018_019_021",
+            purchase_id,
+        )
+        return
+    cur.execute(
         "UPDATE purchase SET liqpay_order_id=%s, update_at=NOW() WHERE id=%s",
         (order_id, purchase_id),
     )
@@ -501,7 +514,15 @@ def create_purchase(data: PurchaseCreate, background_tasks: BackgroundTasks):
         tickets = issue_ticket_links(ticket_specs, data.lang, conn=conn)
         tickets = enrich_ticket_link_results(tickets, data.lang, conn=conn)
         conn.commit()
-        logger.info("purchase_created purchase_id=%s order_id=%s payment_id=%s amount=%s status=%s", purchase_id, None, None, amount_due, "reserved")
+        first_ticket_id = ticket_specs[0]["ticket_id"] if ticket_specs else None
+        logger.info(
+            "purchase_created purchase_id=%s ticket_id=%s amount=%s email=%s liqpay_order_id=%s",
+            purchase_id,
+            first_ticket_id,
+            amount_due,
+            data.passenger_email,
+            None,
+        )
         record_event(provider="purchase", event_type="create_purchase", purchase_id=purchase_id, status="success", payload={"tickets": len(ticket_specs), "amount_due": amount_due})
     except HTTPException:
         conn.rollback()
@@ -795,6 +816,14 @@ def public_purchase_and_pay(
         order_id = payload.get("order_id") if isinstance(payload, dict) else None
         if order_id:
             _save_liqpay_order_id(cur, purchase_id, str(order_id))
+            logger.info(
+                "purchase_created purchase_id=%s ticket_id=%s amount=%s email=%s liqpay_order_id=%s",
+                purchase_id,
+                (ticket_specs[0]["ticket_id"] if ticket_specs else None),
+                amount_due,
+                data.passenger_email,
+                order_id,
+            )
 
         conn.commit()
     except HTTPException:
@@ -922,6 +951,14 @@ def pay_booking(
         order_id = payload.get("order_id") if isinstance(payload, dict) else None
         if order_id:
             _save_liqpay_order_id(cur, data.purchase_id, str(order_id))
+            logger.info(
+                "purchase_created purchase_id=%s ticket_id=%s amount=%s email=%s liqpay_order_id=%s",
+                data.purchase_id,
+                None,
+                amount_due,
+                row[2] if row else None,
+                order_id,
+            )
         conn.commit()
         return checkout
     except HTTPException:

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -310,8 +310,8 @@ def fiscalize_purchase(purchase_id: int) -> None:
     if not is_enabled():
         return
 
-    logger.info("checkbox_fiscalize_start purchase_id=%s status=start", purchase_id)
-    record_event(provider="checkbox", event_type="fiscalize_start", purchase_id=purchase_id, status="start", payload={"purchase_id": purchase_id})
+    logger.info("checkbox_fiscalization_started purchase_id=%s amount=%s", purchase_id, None)
+    record_event(provider="checkbox", event_type="checkbox_started", purchase_id=purchase_id, status="start", payload={"purchase_id": purchase_id})
 
     from ..database import get_connection
 
@@ -332,7 +332,7 @@ def fiscalize_purchase(purchase_id: int) -> None:
 
         # Idempotency: skip if already done
         if fiscal_status == "done":
-            logger.info("fiscalization_skipped_existing_receipt purchase_id=%s status=%s receipt_id=%s", purchase_id, fiscal_status, existing_receipt_id)
+            logger.info("fiscalization_skipped_existing_receipt purchase_id=%s fiscal_receipt_id=%s", purchase_id, existing_receipt_id)
             conn.commit()
             return
 
@@ -356,7 +356,19 @@ def fiscalize_purchase(purchase_id: int) -> None:
         # instead of creating a duplicate
         receipt_id = existing_receipt_id
         if not receipt_id:
-            _ensure_shift()
+            try:
+                _get_token()
+                logger.info("checkbox_auth_success purchase_id=%s", purchase_id)
+            except Exception:
+                logger.exception("checkbox_auth_failed purchase_id=%s", purchase_id)
+                raise
+            try:
+                _ensure_shift()
+                logger.info("checkbox_shift_checked purchase_id=%s", purchase_id)
+            except Exception:
+                logger.exception("checkbox_shift_error purchase_id=%s", purchase_id)
+                raise
+            logger.info("checkbox_receipt_create_started purchase_id=%s receipt_uuid=%s amount=%s", purchase_id, None, total_kopecks)
             receipt_id = _create_receipt(items, total_kopecks)
             # Persist receipt_id immediately so we don't create duplicates on retry
             cur.execute(
@@ -388,17 +400,14 @@ def fiscalize_purchase(purchase_id: int) -> None:
             (receipt_id, fiscal_code, receipt_url, json.dumps(sanitized_payload), purchase_id),
         )
         conn.commit()
-        logger.info(
-            "Purchase %s fiscalized successfully: receipt=%s fiscal_code=%s",
-            purchase_id, receipt_id, fiscal_code,
-        )
-        record_event(provider="checkbox", event_type="fiscalize_success", purchase_id=purchase_id, external_id=str(receipt_id), status="success", payload={"purchase_id": purchase_id, "receipt_id": receipt_id, "status": "done", "fiscal_code": fiscal_code})
+        logger.info("checkbox_receipt_created purchase_id=%s fiscal_receipt_id=%s fiscal_status=%s fiscal_receipt_url=%s", purchase_id, receipt_id, "done", receipt_url)
+        record_event(provider="checkbox", event_type="checkbox_receipt_created", purchase_id=purchase_id, external_id=str(receipt_id), status="success", payload={"purchase_id": purchase_id, "receipt_id": receipt_id, "status": "done", "fiscal_code": fiscal_code})
 
     except Exception as exc:
         conn.rollback()
         error_msg = str(exc)[:500]
-        record_event(provider="checkbox", event_type="fiscalize_error", purchase_id=purchase_id, status="error", error_message=error_msg, payload={"purchase_id": purchase_id, "status": "failed"})
-        logger.exception("Fiscalization failed for purchase %s", purchase_id)
+        record_event(provider="checkbox", event_type="checkbox_receipt_failed", purchase_id=purchase_id, status="error", error_message=error_msg, payload={"purchase_id": purchase_id, "status": "failed"})
+        logger.exception("checkbox_receipt_failed purchase_id=%s error=%s", purchase_id, error_msg)
 
         # If auth-related, invalidate cached token for next attempt
         if "401" in error_msg or "403" in error_msg or "Unauthorized" in error_msg:


### PR DESCRIPTION
### Motivation
- Provide per-provider health endpoints to make integration event diagnostics easier for ops. 
- Avoid runtime errors on deployments where LiqPay tracking columns may be missing by checking schema before writing. 
- Improve observability and unify event naming and logs for CheckBox fiscalization to aid debugging and retries. 

### Description
- Added `/health/liqpay` and `/health/checkbox` endpoints that return totals, success/failed counts and last event timestamp from `integration_events` in `ops_admin.py`. 
- Made LiqPay tracking writes schema-safe in `public.py` by querying `information_schema.columns` before updating `purchase` and logging when expected columns are absent, and changed LiqPay-related `record_event` types and logging to more specific names (e.g. `liqpay_callback_received`, `liqpay_payment_success`, `liqpay_payment_failed`). 
- Introduced `_save_liqpay_order_id` schema check in `purchase.py` and added structured `logger.info` calls when purchases are created / LiqPay orders are generated. 
- Overhauled CheckBox fiscalization telemetry in `services/checkbox.py` by renaming event types to `checkbox_*`, adding finer-grained logs around auth/shift/receipt creation, ensuring token retrieval before shift checks, and improving error recording and messages when fiscalization fails. 

### Testing
- Ran the project's automated unit test suite with `pytest` and the tests completed successfully. 
- Executed basic smoke checks against the new `/health/liqpay` and `/health/checkbox` handlers and LiqPay callback code paths in a local environment; those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34d2743688327af94b8e53999091b)