### PR TITLE
Handle missing LiqPay columns in payment resolve

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -637,25 +637,53 @@ def resolve_payment(order_id: str = Query(..., min_length=3, max_length=128, pat
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT id, status, amount_due, customer_email, customer_name,
-                       liqpay_order_id, liqpay_status
-                  FROM purchase
-                 WHERE id=%s
-                """,
-                (purchase_id,),
+                SELECT column_name
+                  FROM information_schema.columns
+                 WHERE table_schema='public'
+                   AND table_name='purchase'
+                   AND column_name IN ('liqpay_order_id','liqpay_status')
+                """
             )
+            liqpay_columns = {r[0] for r in (cur.fetchall() or [])}
+            has_liqpay_tracking = {'liqpay_order_id', 'liqpay_status'}.issubset(liqpay_columns)
+
+            if has_liqpay_tracking:
+                cur.execute(
+                    """
+                    SELECT id, status, amount_due, customer_email, customer_name,
+                           liqpay_order_id, liqpay_status
+                      FROM purchase
+                     WHERE id=%s
+                    """,
+                    (purchase_id,),
+                )
+            else:
+                logger.error(
+                    "liqpay_tracking_schema_missing purchase_id=%s columns=%s action=run_migrations_018_019_021",
+                    purchase_id,
+                    sorted(liqpay_columns),
+                )
+                cur.execute(
+                    """
+                    SELECT id, status, amount_due, customer_email, customer_name
+                      FROM purchase
+                     WHERE id=%s
+                    """,
+                    (purchase_id,),
+                )
+
             row = cur.fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="Purchase not found")
     finally:
         conn.close()
 
-    stored_order_id = row[5]
+    stored_order_id = row[5] if has_liqpay_tracking else None
     if stored_order_id and stored_order_id != order_id:
         raise HTTPException(status_code=404, detail="order_id does not match purchase")
 
     purchase_status = str(row[1] or "")
-    liqpay_status = row[6]
+    liqpay_status = row[6] if has_liqpay_tracking else None
 
     resolved_status = "pending"
     if purchase_status == "paid":


### PR DESCRIPTION
### Motivation
- Prevent `GET /public/payments/resolve` from raising `UndefinedColumn` when the `purchase` table lacks LiqPay tracking columns, which caused 500 responses during frontend polling.
- Keep the endpoint working on older DB schemas while providing an operational error log that suggests the required migration.

### Description
- Added a runtime schema check against `information_schema.columns` to detect presence of `liqpay_order_id` and `liqpay_status` before selecting them. 
- When both columns exist the original `SELECT ... liqpay_order_id, liqpay_status` is used; otherwise the code falls back to a reduced `SELECT` that omits LiqPay fields. 
- Use a `has_liqpay_tracking` boolean to safely populate `stored_order_id` and `liqpay_status` only when those columns are available. 
- Log `liqpay_tracking_schema_missing` with the found columns and a migration hint (`run_migrations_018_019_021`) to keep operational visibility.

### Testing
- Successfully compiled the modified module with `python -m py_compile backend/routers/public.py` (passes).
- Attempted to run `pytest -q tests/test_book_then_purchase.py` and `PYTHONPATH=. pytest -q tests/test_book_then_purchase.py`, but the test run failed in the local environment due to import/env setup errors (`ModuleNotFoundError: backend` and missing `JWT_SECRET`), not due to the code change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f353e622108327aac42a9ca0e70813)