### PR TITLE
Add backend startup guard for required LiqPay tracking migrations

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -94,4 +94,38 @@ def run_migrations() -> None:
     conn.close()
 
 
+REQUIRED_MIGRATIONS = (
+    "018_add_liqpay_tracking.sql",
+    "019_liqpay_payment_method_and_tracking.sql",
+    "021_guard_liqpay_tracking_columns.sql",
+)
+
+
+def validate_required_migrations() -> None:
+    """Fail fast when critical schema revisions are missing."""
+    conn = psycopg2.connect(DATABASE_URL)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT filename
+        FROM schema_migrations
+        WHERE filename = ANY(%s)
+        """,
+        (list(REQUIRED_MIGRATIONS),),
+    )
+    applied = {row[0] for row in cur.fetchall()}
+    cur.close()
+    conn.close()
+
+    missing = [name for name in REQUIRED_MIGRATIONS if name not in applied]
+    if missing:
+        required_revision = REQUIRED_MIGRATIONS[-1]
+        raise RuntimeError(
+            "Database schema is outdated: required migration revision "
+            f"{required_revision} is missing dependencies {missing}. "
+            "Run project migrations in the backend runtime environment."
+        )
+
+
 run_migrations()
+validate_required_migrations()


### PR DESCRIPTION
### Motivation
- Prevent runtime failures like `liqpay_tracking_schema_missing` by surfacing missing LiqPay-related schema revisions at service startup. 
- Ensure deployments using older databases fail fast with an actionable message pointing to the required migration revision. 

### Description
- Added `REQUIRED_MIGRATIONS` listing `018_add_liqpay_tracking.sql`, `019_liqpay_payment_method_and_tracking.sql`, and `021_guard_liqpay_tracking_columns.sql` in `backend/database.py`. 
- Implemented `validate_required_migrations()` which queries `schema_migrations` and raises a `RuntimeError` listing any missing required files and the required revision. 
- Invoke `validate_required_migrations()` immediately after the existing `run_migrations()` call while preserving the original migration runner behavior. 

### Testing
- Compiled the modified file with `python -m compileall backend/database.py`, which succeeded. 
- Could not run Docker-based integration steps (`docker compose`) in this environment because the `docker` CLI is unavailable, so runtime migration execution and callback/resolve scenario checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f357c76b84832794667b99a17dd818)