### PR TITLE
Include DB migrations in backend container image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,6 +25,7 @@ RUN python -m venv /opt/venv \
 
 # copy your package as a subdirectory
 COPY backend ./backend
+COPY db ./db
 
 # --- STAGE 2: final image ---
 FROM python:3.12-slim
@@ -47,6 +48,7 @@ RUN apt-get update \
 # bring in the venv & code
 COPY --from=builder /opt/venv /opt/venv
 COPY --from=builder /app/backend /app/backend
+COPY --from=builder /app/db /app/db
 
 ENV PATH="/opt/venv/bin:$PATH"
 


### PR DESCRIPTION
### Motivation
- The backend validates required SQL migrations at startup but the runtime image only included `/app/backend`, preventing `run_migrations()` from finding `db/migrations` and causing startup failures about missing migration revisions.

### Description
- Add `COPY db ./db` to the builder stage of `backend/Dockerfile` so migrations are included in the build context.
- Add `COPY --from=builder /app/db /app/db` to the final runtime stage of `backend/Dockerfile` so the container can run migrations at startup.

### Testing
- Reproduced the issue on the development host by running `docker compose up -d --build`, which produced backend startup errors about missing migration revisions (automated container run failed). 
- Attempted to validate the fix here with `docker compose up -d --build backend` but the execution environment lacks `docker`, so runtime validation could not be executed (no automated run performed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35ad1e2548327af235e30e5ad3296)