### PR TITLE
Add fiscalization fields to payments/resolve and set pending on LiqPay success

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -90,6 +90,11 @@ class PaymentResolvePurchase(BaseModel):
 class PaymentResolveOut(BaseModel):
     status: Literal["paid", "pending", "failed"]
     purchaseId: int
+    amount_due: float
+    tickets: list[PaymentResolveTicket] = []
+    fiscal_status: Literal["pending", "processing", "done", "failed"] | None = None
+    fiscal_receipt_url: str | None = None
+    checkbox_fiscal_code: str | None = None
     purchase: PaymentResolvePurchase | None = None
 
 
@@ -629,8 +634,20 @@ def _sync_purchase_paid_from_liqpay_callback(
 
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
         from ..services.checkbox import is_enabled as checkbox_enabled
-        fiscal_clause = ", fiscal_status='pending'" if checkbox_enabled() else ""
-        cur.execute(f"UPDATE purchase SET status='paid', update_at=NOW(){fiscal_clause} WHERE id=%s", (purchase_id,))
+        if checkbox_enabled():
+            fiscal_sql = (
+                "UPDATE purchase "
+                "SET status='paid', fiscal_status='pending', update_at=NOW() "
+                "WHERE id=%s"
+            )
+        else:
+            fiscal_sql = (
+                "UPDATE purchase "
+                "SET status='paid', fiscal_status=NULL, checkbox_receipt_id=NULL, "
+                "checkbox_fiscal_code=NULL, update_at=NOW() "
+                "WHERE id=%s"
+            )
+        cur.execute(fiscal_sql, (purchase_id,))
         _log_action(cur, purchase_id, "paid", amount_due, by="liqpay", method="online")
         try:
             tickets = issue_ticket_links(ticket_specs, None, conn=conn)
@@ -683,7 +700,8 @@ def resolve_payment(order_id: str = Query(..., min_length=3, max_length=128, pat
                     cur.execute(
                         """
                         SELECT id, status, amount_due, customer_email, customer_name,
-                               liqpay_order_id, liqpay_status
+                               liqpay_order_id, liqpay_status,
+                               fiscal_status, checkbox_receipt_id, checkbox_fiscal_code
                           FROM purchase
                          WHERE id=%s
                         """,
@@ -697,7 +715,10 @@ def resolve_payment(order_id: str = Query(..., min_length=3, max_length=128, pat
                         """
                         SELECT id, status, amount_due, customer_email, customer_name,
                                NULL::TEXT AS liqpay_order_id,
-                               NULL::TEXT AS liqpay_status
+                               NULL::TEXT AS liqpay_status,
+                               NULL::TEXT AS fiscal_status,
+                               NULL::TEXT AS checkbox_receipt_id,
+                               NULL::TEXT AS checkbox_fiscal_code
                           FROM purchase
                          WHERE id=%s
                         """,
@@ -708,7 +729,10 @@ def resolve_payment(order_id: str = Query(..., min_length=3, max_length=128, pat
                     """
                     SELECT id, status, amount_due, customer_email, customer_name,
                            NULL::TEXT AS liqpay_order_id,
-                           NULL::TEXT AS liqpay_status
+                           NULL::TEXT AS liqpay_status,
+                           NULL::TEXT AS fiscal_status,
+                           NULL::TEXT AS checkbox_receipt_id,
+                           NULL::TEXT AS checkbox_fiscal_code
                       FROM purchase
                      WHERE id=%s
                     """,
@@ -759,6 +783,11 @@ def resolve_payment(order_id: str = Query(..., min_length=3, max_length=128, pat
                 else:
                     resolved_status = verified_status
 
+    from ..services.checkbox import get_receipt_png_url
+
+    receipt_id = str(row[8]) if row[8] else None
+    fiscal_receipt_url = get_receipt_png_url(receipt_id) if receipt_id else None
+
     purchase = {
         "id": int(row[0]),
         "status": resolved_status,
@@ -803,6 +832,11 @@ def resolve_payment(order_id: str = Query(..., min_length=3, max_length=128, pat
     return {
         "status": resolved_status,
         "purchaseId": int(row[0]),
+        "amount_due": _round_currency(float(row[2] or 0.0)),
+        "tickets": purchase["tickets"],
+        "fiscal_status": row[7],
+        "fiscal_receipt_url": fiscal_receipt_url,
+        "checkbox_fiscal_code": row[9],
         "purchase": purchase,
     }
 

--- a/tests/test_payment_resolve.py
+++ b/tests/test_payment_resolve.py
@@ -30,6 +30,9 @@ class ResolveCursor:
             return self._row
         return None
 
+    def fetchall(self):
+        return []
+
     def close(self):
         pass
 
@@ -57,7 +60,7 @@ def client(monkeypatch):
     monkeypatch.setenv("CLIENT_APP_BASE", "https://example.test")
 
     state = {
-        "row": [1, "reserved", 15.0, "a@b.com", "Alice", "purchase-1", None],
+        "row": [1, "reserved", 15.0, "a@b.com", "Alice", "purchase-1", None, None, None, None],
         "has_liqpay_column": True,
         "verify_called": 0,
         "synced": 0,
@@ -97,7 +100,7 @@ def client(monkeypatch):
 
 def test_payments_resolve_returns_paid_from_db(client):
     cli, state = client
-    state["row"] = [1, "paid", 15.0, "a@b.com", "Alice", "purchase-1", "success"]
+    state["row"] = [1, "paid", 15.0, "a@b.com", "Alice", "purchase-1", "success", "done", "rcpt-1", "CBX-1"]
 
     resp = cli.get("/public/payments/resolve", params={"order_id": "purchase-1"})
 
@@ -105,13 +108,16 @@ def test_payments_resolve_returns_paid_from_db(client):
     body = resp.json()
     assert body["status"] == "paid"
     assert body["purchaseId"] == 1
+    assert body["fiscal_status"] == "done"
+    assert body["fiscal_receipt_url"].endswith("/api/v1/receipts/rcpt-1/png")
+    assert body["checkbox_fiscal_code"] == "CBX-1"
     assert body["purchase"]["id"] == 1
     assert state["verify_called"] == 0
 
 
 def test_payments_resolve_verifies_and_syncs_pending_purchase(client):
     cli, state = client
-    state["row"] = [1, "reserved", 15.0, "a@b.com", "Alice", "purchase-1", None]
+    state["row"] = [1, "reserved", 15.0, "a@b.com", "Alice", "purchase-1", None, "pending", None, None]
 
     resp = cli.get("/public/payments/resolve", params={"order_id": "purchase-1"})
 
@@ -119,6 +125,7 @@ def test_payments_resolve_verifies_and_syncs_pending_purchase(client):
     body = resp.json()
     assert body["status"] == "paid"
     assert body["purchase"]["status"] == "paid"
+    assert body["fiscal_status"] == "pending"
     assert state["verify_called"] == 1
     assert state["synced"] == 1
 
@@ -133,7 +140,7 @@ def test_payments_resolve_rejects_unknown_order_format(client):
 
 def test_payments_resolve_handles_missing_liqpay_columns(client):
     cli, state = client
-    state["row"] = [1, "reserved", 15.0, "a@b.com", "Alice", None, None]
+    state["row"] = [1, "reserved", 15.0, "a@b.com", "Alice", None, None, None, None, None]
     state["has_liqpay_column"] = False
 
     resp = cli.get("/public/payments/resolve", params={"order_id": "purchase-1"})
@@ -147,7 +154,7 @@ def test_payments_resolve_handles_missing_liqpay_columns(client):
 
 def test_payments_resolve_handles_desynced_liqpay_schema(client):
     cli, state = client
-    state["row"] = [1, "reserved", 15.0, "a@b.com", "Alice", None, None]
+    state["row"] = [1, "reserved", 15.0, "a@b.com", "Alice", None, None, None, None, None]
 
     class UndefinedColumnError(Exception):
         pass


### PR DESCRIPTION
### Motivation
- Expose CheckBox fiscalization status and receipt metadata in the public payment resolution response so the frontend can poll and display fiscalization lifecycle and receipt links.
- Ensure LiqPay payment processing marks purchases for fiscalization when CheckBox integration is enabled and clears fiscal fields when not applicable.

### Description
- Extended the `GET /public/payments/resolve` response model (`PaymentResolveOut`) to include top-level `amount_due`, `tickets`, `fiscal_status`, `fiscal_receipt_url`, and `checkbox_fiscal_code` while keeping the nested `purchase` object for backwards compatibility.
- Updated LiqPay sync logic in `_sync_purchase_paid_from_liqpay_callback` to execute an `UPDATE purchase` that sets `fiscal_status='pending'` when `checkbox.is_enabled()` and to explicitly clear fiscal columns (`fiscal_status=NULL`, `checkbox_receipt_id=NULL`, `checkbox_fiscal_code=NULL`) when fiscalization is not enabled.
- Modified the `resolve` query to select `fiscal_status`, `checkbox_receipt_id`, and `checkbox_fiscal_code` (with safe fallbacks for older schemas) and derive `fiscal_receipt_url` via `checkbox.get_receipt_png_url(checkbox_receipt_id)` when present.
- Updated tests in `tests/test_payment_resolve.py` to include the new purchase row columns, assert the new fiscal fields, and supply a `fetchall()` stub on the cursor mock to support the ticket-list query.

### Testing
- Ran `PYTHONPATH=. pytest -q tests/test_payment_resolve.py` and all tests in that file passed (`7 passed`).
- Verified the modified endpoints and DB interaction logic through the updated unit tests which cover paid/pending states and schema-desync behaviour.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d4fcf5c08327a52f1caf74847e2e)