### PR TITLE
Handle missing fiscal columns in LiqPay purchase sync

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -634,7 +634,17 @@ def _sync_purchase_paid_from_liqpay_callback(
 
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
         from ..services.checkbox import is_enabled as checkbox_enabled
-        if checkbox_enabled():
+
+        fiscal_columns = ("fiscal_status", "checkbox_receipt_id", "checkbox_fiscal_code")
+        missing_fiscal_columns = _missing_purchase_columns(cur, fiscal_columns)
+        if missing_fiscal_columns:
+            logger.warning(
+                "Skipping fiscal purchase columns update for purchase=%s; missing columns: %s",
+                purchase_id,
+                ", ".join(missing_fiscal_columns),
+            )
+            fiscal_sql = "UPDATE purchase SET status='paid', update_at=NOW() WHERE id=%s"
+        elif checkbox_enabled():
             fiscal_sql = (
                 "UPDATE purchase "
                 "SET status='paid', fiscal_status='pending', update_at=NOW() "


### PR DESCRIPTION
### Motivation
- Prevent LiqPay callback/resolve flows from crashing when older databases don't have fiscalization columns on the `purchase` table.
- Runtime logs showed repeated `UndefinedColumn` errors for `fiscal_status` during LiqPay reconciliation, so the update must be resilient to partially migrated schemas.

### Description
- In `backend/routers/public.py` `_sync_purchase_paid_from_liqpay_callback` now checks for the presence of `fiscal_status`, `checkbox_receipt_id`, and `checkbox_fiscal_code` before building the `UPDATE purchase` SQL.
- If any fiscal columns are missing the code logs a warning and falls back to a safe `UPDATE purchase SET status='paid', update_at=NOW() WHERE id=%s` to avoid referencing non-existent columns.
- Preserves existing behavior for fully migrated schemas: when columns exist, the code still updates fiscal fields and respects `checkbox.is_enabled()` to set `fiscal_status='pending'` or clear fiscal fields.

### Testing
- `python -m py_compile backend/routers/public.py` was run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5d895aa488327b3b88528fc9eb547)