### PR TITLE
Skip fiscalization when DB lacks fiscal columns; add column checks and handle SMTP errors

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -635,7 +635,14 @@ def _sync_purchase_paid_from_liqpay_callback(
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
         from ..services.checkbox import is_enabled as checkbox_enabled
 
-        fiscal_columns = ("fiscal_status", "checkbox_receipt_id", "checkbox_fiscal_code")
+        fiscal_columns = (
+            "fiscal_status",
+            "checkbox_receipt_id",
+            "checkbox_fiscal_code",
+            "fiscal_last_error",
+            "fiscal_attempts",
+            "fiscalized_at",
+        )
         missing_fiscal_columns = _missing_purchase_columns(cur, fiscal_columns)
         if missing_fiscal_columns:
             logger.warning(

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -87,6 +87,34 @@ def _auth_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {_get_token()}"}
 
 
+
+def _purchase_has_column(cur, column_name: str) -> bool:
+    cur.execute(
+        """
+        SELECT 1
+          FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = 'purchase'
+           AND column_name = %s
+         LIMIT 1
+        """,
+        (column_name,),
+    )
+    return cur.fetchone() is not None
+
+
+def _has_required_fiscal_columns(cur) -> tuple[bool, list[str]]:
+    required = (
+        "fiscal_status",
+        "checkbox_receipt_id",
+        "checkbox_fiscal_code",
+        "fiscal_last_error",
+        "fiscal_attempts",
+        "fiscalized_at",
+    )
+    missing = [name for name in required if not _purchase_has_column(cur, name)]
+    return (len(missing) == 0, missing)
+
 # ---------------------------------------------------------------------------
 # Shift management
 # ---------------------------------------------------------------------------
@@ -295,6 +323,15 @@ def fiscalize_purchase(purchase_id: int) -> None:
     conn = get_connection()
     cur = conn.cursor()
     try:
+        has_columns, missing_columns = _has_required_fiscal_columns(cur)
+        if not has_columns:
+            logger.warning(
+                "Skipping fiscalization for purchase=%s; missing columns: %s",
+                purchase_id,
+                ", ".join(missing_columns),
+            )
+            return
+
         # Lock the row and check current fiscal status
         cur.execute(
             "SELECT fiscal_status, checkbox_receipt_id FROM purchase WHERE id = %s FOR UPDATE",

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -215,12 +215,15 @@ def send_ticket_email(
         smtp_cls = smtplib.SMTP
         smtp_kwargs = {}
 
-    with smtp_cls(host, port, timeout=30, **smtp_kwargs) as server:
-        if not use_ssl:
-            server.starttls(context=context)
-        if username and password:
-            server.login(username, password)
-        server.send_message(message)
+    try:
+        with smtp_cls(host, port, timeout=30, **smtp_kwargs) as server:
+            if not use_ssl:
+                server.starttls(context=context)
+            if username and password:
+                server.login(username, password)
+            server.send_message(message)
+    except (smtplib.SMTPException, OSError) as exc:
+        logger.warning("Failed to send ticket email to %s: %s", to, exc)
 
 
 def send_otp_email(to: str, code: str, lang: str | None = None) -> None:


### PR DESCRIPTION
### Motivation
- Make fiscalization resilient to deployments where additional fiscal columns may not exist on the `purchase` table so purchases are not blocked by missing schema columns.
- Ensure the CheckBox fiscalization routine is idempotent and fails safely when DB schema is incomplete by logging and skipping work instead of raising.
- Avoid mail-sending failures from raising unhandled exceptions during ticket email delivery so the process continues while the error is recorded.

### Description
- Expanded the fiscal column set used during post-payment processing in `backend/routers/public.py` to include `fiscal_last_error`, `fiscal_attempts`, and `fiscalized_at`, and preserved the existing missing-column fallback path with a warning log.
- Added `_purchase_has_column` and `_has_required_fiscal_columns` helpers in `backend/services/checkbox.py` to detect presence of the required fiscal columns on the `purchase` table at runtime.
- Updated `fiscalize_purchase` in `backend/services/checkbox.py` to early-return with a warning when required fiscal columns are missing, avoiding further processing and DB updates that would fail.
- Wrapped the SMTP send path in `backend/services/email.py` with a `try/except` that catches `smtplib.SMTPException` and `OSError` and logs a warning instead of bubbling the error.

### Testing
- Ran the backend test suite with `pytest` for modified modules and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5da2aa40c832792859c2591c2d4a7)