### PR TITLE
Skip fiscalization when columns missing, add backfill migration, and harden email sending

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -635,7 +635,14 @@ def _sync_purchase_paid_from_liqpay_callback(
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
         from ..services.checkbox import is_enabled as checkbox_enabled
 
-        fiscal_columns = ("fiscal_status", "checkbox_receipt_id", "checkbox_fiscal_code")
+        fiscal_columns = (
+            "fiscal_status",
+            "checkbox_receipt_id",
+            "checkbox_fiscal_code",
+            "fiscal_last_error",
+            "fiscal_attempts",
+            "fiscalized_at",
+        )
         missing_fiscal_columns = _missing_purchase_columns(cur, fiscal_columns)
         if missing_fiscal_columns:
             logger.warning(

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -87,6 +87,34 @@ def _auth_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {_get_token()}"}
 
 
+
+def _purchase_has_column(cur, column_name: str) -> bool:
+    cur.execute(
+        """
+        SELECT 1
+          FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = 'purchase'
+           AND column_name = %s
+         LIMIT 1
+        """,
+        (column_name,),
+    )
+    return cur.fetchone() is not None
+
+
+def _has_required_fiscal_columns(cur) -> tuple[bool, list[str]]:
+    required = (
+        "fiscal_status",
+        "checkbox_receipt_id",
+        "checkbox_fiscal_code",
+        "fiscal_last_error",
+        "fiscal_attempts",
+        "fiscalized_at",
+    )
+    missing = [name for name in required if not _purchase_has_column(cur, name)]
+    return (len(missing) == 0, missing)
+
 # ---------------------------------------------------------------------------
 # Shift management
 # ---------------------------------------------------------------------------
@@ -295,6 +323,15 @@ def fiscalize_purchase(purchase_id: int) -> None:
     conn = get_connection()
     cur = conn.cursor()
     try:
+        has_columns, missing_columns = _has_required_fiscal_columns(cur)
+        if not has_columns:
+            logger.warning(
+                "Skipping fiscalization for purchase=%s; missing columns: %s",
+                purchase_id,
+                ", ".join(missing_columns),
+            )
+            return
+
         # Lock the row and check current fiscal status
         cur.execute(
             "SELECT fiscal_status, checkbox_receipt_id FROM purchase WHERE id = %s FOR UPDATE",

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -215,12 +215,15 @@ def send_ticket_email(
         smtp_cls = smtplib.SMTP
         smtp_kwargs = {}
 
-    with smtp_cls(host, port, timeout=30, **smtp_kwargs) as server:
-        if not use_ssl:
-            server.starttls(context=context)
-        if username and password:
-            server.login(username, password)
-        server.send_message(message)
+    try:
+        with smtp_cls(host, port, timeout=30, **smtp_kwargs) as server:
+            if not use_ssl:
+                server.starttls(context=context)
+            if username and password:
+                server.login(username, password)
+            server.send_message(message)
+    except (smtplib.SMTPException, OSError) as exc:
+        logger.warning("Failed to send ticket email to %s: %s", to, exc)
 
 
 def send_otp_email(to: str, code: str, lang: str | None = None) -> None:

--- a/db/migrations/022_backfill_fiscal_columns.sql
+++ b/db/migrations/022_backfill_fiscal_columns.sql
@@ -1,0 +1,13 @@
+-- Backfill migration for deployments that missed 020_add_fiscal_columns.sql.
+-- Safe to run multiple times.
+ALTER TABLE public.purchase
+    ADD COLUMN IF NOT EXISTS fiscal_status TEXT DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS checkbox_receipt_id TEXT,
+    ADD COLUMN IF NOT EXISTS checkbox_fiscal_code TEXT,
+    ADD COLUMN IF NOT EXISTS fiscal_last_error TEXT,
+    ADD COLUMN IF NOT EXISTS fiscal_attempts INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS fiscalized_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS purchase_fiscal_status_pending_idx
+    ON public.purchase (id)
+    WHERE fiscal_status IN ('pending', 'failed');


### PR DESCRIPTION
### Motivation
- Prevent runtime errors and inconsistent state when deployments lack newly introduced fiscal columns on the `purchase` table.
- Ensure fiscalization is idempotent and safe to run on deployments that missed a previous migration.
- Avoid crashing the email path on transient SMTP/network errors.

### Description
- Extend the fiscal column list used during LiqPay callback handling to include `fiscal_last_error`, `fiscal_attempts`, and `fiscalized_at` so updates consider all fiscal fields. (`backend/routers/public.py`)
- Add helpers to `services/checkbox.py` to detect whether required fiscal columns exist and skip fiscalization early when columns are missing, and use those helpers in `fiscalize_purchase`. (`backend/services/checkbox.py`)
- Wrap the SMTP send block in `send_ticket_email` with exception handling to log a warning instead of raising on `smtplib.SMTPException` or `OSError`. (`backend/services/email.py`)
- Add a backfill migration `022_backfill_fiscal_columns.sql` that safely adds the missing fiscal columns and a partial index for pending fiscal status, using `IF NOT EXISTS` so it is safe to run multiple times. (`db/migrations/022_backfill_fiscal_columns.sql`)

### Testing
- Ran the project's automated test suite locally and verified no regressions in unit tests related to email and fiscalization (tests passed).
- Applied the new migration against a local dev database and validated that the `purchase` table gained the expected columns and index without errors.
- Exercised the LiqPay callback and `fiscalize_purchase` flows in a development environment to confirm fiscalization is skipped when columns are absent and that email failures are logged rather than raising exceptions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5da2aa40c832792859c2591c2d4a7)