### PR TITLE
Backfill LiqPay and fiscal DB columns, add runtime safety checks, and make email sending resilient

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -63,6 +63,40 @@ def get_connection():
 from pathlib import Path
 
 
+def _ensure_purchase_schema_compatibility(cur) -> None:
+    """Backfill critical purchase columns when historical migrations were marked but not applied."""
+    cur.execute("ALTER TYPE public.payment_method_type ADD VALUE IF NOT EXISTS 'liqpay'")
+    cur.execute(
+        """
+        ALTER TABLE public.purchase
+            ADD COLUMN IF NOT EXISTS liqpay_order_id TEXT,
+            ADD COLUMN IF NOT EXISTS liqpay_status TEXT,
+            ADD COLUMN IF NOT EXISTS liqpay_payment_id TEXT,
+            ADD COLUMN IF NOT EXISTS liqpay_payload JSONB,
+            ADD COLUMN IF NOT EXISTS fiscal_status TEXT DEFAULT NULL,
+            ADD COLUMN IF NOT EXISTS checkbox_receipt_id TEXT,
+            ADD COLUMN IF NOT EXISTS checkbox_fiscal_code TEXT,
+            ADD COLUMN IF NOT EXISTS fiscal_last_error TEXT,
+            ADD COLUMN IF NOT EXISTS fiscal_attempts INTEGER DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS fiscalized_at TIMESTAMP
+        """
+    )
+    cur.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS purchase_liqpay_order_id_uidx
+            ON public.purchase (liqpay_order_id)
+            WHERE liqpay_order_id IS NOT NULL
+        """
+    )
+    cur.execute(
+        """
+        CREATE INDEX IF NOT EXISTS purchase_fiscal_status_pending_idx
+            ON public.purchase (id)
+            WHERE fiscal_status IN ('pending', 'failed')
+        """
+    )
+
+
 def run_migrations() -> None:
     """Apply SQL migrations found in db/migrations."""
     migrations_dir = Path(__file__).resolve().parents[1] / "db" / "migrations"
@@ -90,6 +124,9 @@ def run_migrations() -> None:
             "INSERT INTO schema_migrations (filename) VALUES (%s)", (path.name,)
         )
         conn.commit()
+
+    _ensure_purchase_schema_compatibility(cur)
+    conn.commit()
     cur.close()
     conn.close()
 

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -635,7 +635,14 @@ def _sync_purchase_paid_from_liqpay_callback(
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
         from ..services.checkbox import is_enabled as checkbox_enabled
 
-        fiscal_columns = ("fiscal_status", "checkbox_receipt_id", "checkbox_fiscal_code")
+        fiscal_columns = (
+            "fiscal_status",
+            "checkbox_receipt_id",
+            "checkbox_fiscal_code",
+            "fiscal_last_error",
+            "fiscal_attempts",
+            "fiscalized_at",
+        )
         missing_fiscal_columns = _missing_purchase_columns(cur, fiscal_columns)
         if missing_fiscal_columns:
             logger.warning(

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -87,6 +87,34 @@ def _auth_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {_get_token()}"}
 
 
+
+def _purchase_has_column(cur, column_name: str) -> bool:
+    cur.execute(
+        """
+        SELECT 1
+          FROM information_schema.columns
+         WHERE table_schema = current_schema()
+           AND table_name = 'purchase'
+           AND column_name = %s
+         LIMIT 1
+        """,
+        (column_name,),
+    )
+    return cur.fetchone() is not None
+
+
+def _has_required_fiscal_columns(cur) -> tuple[bool, list[str]]:
+    required = (
+        "fiscal_status",
+        "checkbox_receipt_id",
+        "checkbox_fiscal_code",
+        "fiscal_last_error",
+        "fiscal_attempts",
+        "fiscalized_at",
+    )
+    missing = [name for name in required if not _purchase_has_column(cur, name)]
+    return (len(missing) == 0, missing)
+
 # ---------------------------------------------------------------------------
 # Shift management
 # ---------------------------------------------------------------------------
@@ -295,6 +323,15 @@ def fiscalize_purchase(purchase_id: int) -> None:
     conn = get_connection()
     cur = conn.cursor()
     try:
+        has_columns, missing_columns = _has_required_fiscal_columns(cur)
+        if not has_columns:
+            logger.warning(
+                "Skipping fiscalization for purchase=%s; missing columns: %s",
+                purchase_id,
+                ", ".join(missing_columns),
+            )
+            return
+
         # Lock the row and check current fiscal status
         cur.execute(
             "SELECT fiscal_status, checkbox_receipt_id FROM purchase WHERE id = %s FOR UPDATE",

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -215,12 +215,15 @@ def send_ticket_email(
         smtp_cls = smtplib.SMTP
         smtp_kwargs = {}
 
-    with smtp_cls(host, port, timeout=30, **smtp_kwargs) as server:
-        if not use_ssl:
-            server.starttls(context=context)
-        if username and password:
-            server.login(username, password)
-        server.send_message(message)
+    try:
+        with smtp_cls(host, port, timeout=30, **smtp_kwargs) as server:
+            if not use_ssl:
+                server.starttls(context=context)
+            if username and password:
+                server.login(username, password)
+            server.send_message(message)
+    except (smtplib.SMTPException, OSError) as exc:
+        logger.warning("Failed to send ticket email to %s: %s", to, exc)
 
 
 def send_otp_email(to: str, code: str, lang: str | None = None) -> None:

--- a/db/migrations/022_backfill_fiscal_columns.sql
+++ b/db/migrations/022_backfill_fiscal_columns.sql
@@ -1,0 +1,13 @@
+-- Backfill migration for deployments that missed 020_add_fiscal_columns.sql.
+-- Safe to run multiple times.
+ALTER TABLE public.purchase
+    ADD COLUMN IF NOT EXISTS fiscal_status TEXT DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS checkbox_receipt_id TEXT,
+    ADD COLUMN IF NOT EXISTS checkbox_fiscal_code TEXT,
+    ADD COLUMN IF NOT EXISTS fiscal_last_error TEXT,
+    ADD COLUMN IF NOT EXISTS fiscal_attempts INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS fiscalized_at TIMESTAMP;
+
+CREATE INDEX IF NOT EXISTS purchase_fiscal_status_pending_idx
+    ON public.purchase (id)
+    WHERE fiscal_status IN ('pending', 'failed');

--- a/db/migrations/023_backfill_liqpay_and_fiscal_columns.sql
+++ b/db/migrations/023_backfill_liqpay_and_fiscal_columns.sql
@@ -1,0 +1,24 @@
+-- Emergency backfill for deployments where schema_migrations says applied,
+-- but purchase table still misses LiqPay/fiscal columns.
+
+ALTER TYPE public.payment_method_type ADD VALUE IF NOT EXISTS 'liqpay';
+
+ALTER TABLE public.purchase
+    ADD COLUMN IF NOT EXISTS liqpay_order_id TEXT,
+    ADD COLUMN IF NOT EXISTS liqpay_status TEXT,
+    ADD COLUMN IF NOT EXISTS liqpay_payment_id TEXT,
+    ADD COLUMN IF NOT EXISTS liqpay_payload JSONB,
+    ADD COLUMN IF NOT EXISTS fiscal_status TEXT DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS checkbox_receipt_id TEXT,
+    ADD COLUMN IF NOT EXISTS checkbox_fiscal_code TEXT,
+    ADD COLUMN IF NOT EXISTS fiscal_last_error TEXT,
+    ADD COLUMN IF NOT EXISTS fiscal_attempts INTEGER DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS fiscalized_at TIMESTAMP;
+
+CREATE UNIQUE INDEX IF NOT EXISTS purchase_liqpay_order_id_uidx
+    ON public.purchase (liqpay_order_id)
+    WHERE liqpay_order_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS purchase_fiscal_status_pending_idx
+    ON public.purchase (id)
+    WHERE fiscal_status IN ('pending', 'failed');


### PR DESCRIPTION
### Motivation
- Ensure deployments that missed prior migrations still have necessary LiqPay and fiscal columns on `purchase` so payment and fiscal flows work.
- Prevent runtime errors when fiscal-related columns are missing by short-circuiting fiscalization and LiqPay callback handling.
- Avoid crashing or raising on transient SMTP failures when sending ticket emails.

### Description
- Added an emergency backfill routine `_ensure_purchase_schema_compatibility` in `backend/database.py` and call it from `run_migrations()` to add LiqPay and fiscal columns and related indexes if missing, and to add `liqpay` to `payment_method_type` safely.
- Added new SQL migration files `db/migrations/022_backfill_fiscal_columns.sql` and `db/migrations/023_backfill_liqpay_and_fiscal_columns.sql` that perform the same safe `ALTER TABLE`/`CREATE INDEX` operations for deployments that missed earlier migrations.
- Expanded fiscal column checks in `backend/routers/public.py` to include `fiscal_last_error`, `fiscal_attempts`, and `fiscalized_at` when deciding whether to update fiscal fields during LiqPay callbacks.
- In `backend/services/checkbox.py` added `_purchase_has_column` and `_has_required_fiscal_columns` helpers and added a guard in `fiscalize_purchase` to log and return early when required fiscal columns are missing to avoid runtime exceptions.
- Made email sending in `backend/services/email.py` resilient by wrapping the SMTP send block in a `try/except` and logging a warning on `smtplib.SMTPException` or `OSError` instead of letting the error propagate.

### Testing
- No automated tests were run as part of this change.
- The migrations are written to be idempotent by using `IF NOT EXISTS` and safe to run multiple times via the existing `run_migrations()` mechanism.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5da2aa40c832792859c2591c2d4a7)