### PR TITLE
Add admin health-check for CheckBox integration with UI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,3 +264,31 @@ pytest
 - `docker compose exec backend alembic upgrade head` — пример миграции БД (если вы добавите Alembic).
 - `docker compose exec db psql -U postgres test1` — подключение к базе из контейнера.
 - `npm run build --prefix frontend` — сборка фронтенда для продакшена.
+
+## CheckBox integration health-check (Admin)
+
+- Endpoint: `GET /admin/integrations/checkbox/health` (admin token required).
+- Admin UI: button **"Проверить CheckBox"** on the main admin page.
+
+Required env vars:
+- `CHECKBOX_ENABLED=true`
+- `CHECKBOX_CASHIER_LOGIN`
+- `CHECKBOX_CASHIER_PASSWORD`
+
+Optional env vars (recommended):
+- `CHECKBOX_ACCESS_KEY` не задается вручную в этой интеграции (получается сервисом при авторизации), поэтому в health-check не валидируется как обязательный env.
+
+- `CHECKBOX_LICENSE_KEY`
+- `CHECKBOX_API_URL` (default `https://api.checkbox.ua`)
+
+Status interpretation:
+- `ok`: auth and shift check passed.
+- `warning`: integration works but optional config is missing.
+- `disabled`: integration disabled by env.
+- `error`: integration failed (credentials, HTTP error, or network issue).
+
+Common diagnostics:
+- `401/403`: verify cashier login/password/keys.
+- `network`/timeout/DNS: verify internet access and `CHECKBOX_API_URL`.
+
+For support, use **"Скопировать детали"** in admin UI (secrets are never returned).

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,7 @@ from .routers import (
     auth,
     bundle,
     public,
+    integrations_admin,
 )
 from .routers.ticket_admin import router as admin_tickets_router
 from .routers.purchase_admin import router as admin_purchases_router
@@ -103,6 +104,7 @@ app.include_router(public.session_router)
 app.include_router(public.router)
 app.include_router(admin_tickets_router)
 app.include_router(admin_purchases_router)
+app.include_router(integrations_admin.router)
 app.include_router(auth.router)
 
 

--- a/backend/routers/integrations_admin.py
+++ b/backend/routers/integrations_admin.py
@@ -1,0 +1,93 @@
+from typing import Literal
+
+import httpx
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from ..auth import require_admin_token
+from ..services import checkbox
+
+router = APIRouter(
+    prefix="/admin/integrations",
+    tags=["admin_integrations"],
+    dependencies=[Depends(require_admin_token)],
+)
+
+
+class CheckBoxHealthResponse(BaseModel):
+    status: Literal["ok", "warning", "error", "disabled"]
+    http_status: int | None = None
+    message: str
+    details: list[str]
+
+
+@router.get("/checkbox/health", response_model=CheckBoxHealthResponse)
+def checkbox_health() -> CheckBoxHealthResponse:
+    if not checkbox.is_enabled():
+        return CheckBoxHealthResponse(
+            status="disabled",
+            message="CheckBox integration is disabled via CHECKBOX_ENABLED.",
+            details=["CHECKBOX_ENABLED=false"],
+        )
+
+    missing_required: list[str] = []
+    for key in ("CHECKBOX_CASHIER_LOGIN", "CHECKBOX_CASHIER_PASSWORD"):
+        if not checkbox._env(key):
+            missing_required.append(key)
+
+    optional_missing = [
+        key
+        for key in ("CHECKBOX_LICENSE_KEY",)
+        if not checkbox._env(key)
+    ]
+
+    if missing_required:
+        return CheckBoxHealthResponse(
+            status="error",
+            message="Missing required CheckBox credentials.",
+            details=[f"missing env: {k}" for k in missing_required],
+        )
+
+    details: list[str] = []
+    if optional_missing:
+        details.extend([f"optional env missing: {k}" for k in optional_missing])
+
+    try:
+        token = checkbox.get_token_for_healthcheck()
+        details.append("cashier signin: ok")
+
+        shift_http_status, shift_data = checkbox.get_cashier_shift_status(token)
+        shift_status = (shift_data or {}).get("status") if isinstance(shift_data, dict) else None
+        details.append(f"cashier shift check: http {shift_http_status}, status={shift_status or 'unknown'}")
+
+        return CheckBoxHealthResponse(
+            status="warning" if optional_missing else "ok",
+            http_status=shift_http_status,
+            message="CheckBox integration is operational." if not optional_missing else "CheckBox works but optional keys are missing.",
+            details=details,
+        )
+    except httpx.HTTPStatusError as exc:
+        code = exc.response.status_code
+        if code in (401, 403):
+            message = "CheckBox authorization failed: неверные креды/доступ."
+        else:
+            message = f"CheckBox returned HTTP {code}."
+        details.append(f"http error at {exc.request.method} {exc.request.url}")
+        return CheckBoxHealthResponse(
+            status="error",
+            http_status=code,
+            message=message,
+            details=details,
+        )
+    except (httpx.ConnectError, httpx.ReadTimeout, httpx.ConnectTimeout, httpx.NetworkError):
+        return CheckBoxHealthResponse(
+            status="error",
+            message="CheckBox network error (network): timeout/DNS/connectivity issue.",
+            details=["network"],
+        )
+    except RuntimeError as exc:
+        return CheckBoxHealthResponse(
+            status="error",
+            message=str(exc),
+            details=details,
+        )

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -87,6 +87,27 @@ def _auth_headers() -> dict[str, str]:
     return {"Authorization": f"Bearer {_get_token()}"}
 
 
+def get_token_for_healthcheck() -> str:
+    """Public wrapper for token retrieval used by health checks."""
+    return _get_token()
+
+
+def get_cashier_shift_status(token: str) -> tuple[int, dict[str, Any] | None]:
+    """Fetch current cashier shift status for diagnostics."""
+    license_key = _env("CHECKBOX_LICENSE_KEY")
+    headers = {"Authorization": f"Bearer {token}"}
+    if license_key:
+        headers["X-License-Key"] = license_key
+
+    resp = httpx.get(
+        f"{_api_url()}/api/v1/cashier/shift",
+        headers=headers,
+        timeout=10.0,
+    )
+    resp.raise_for_status()
+    return resp.status_code, resp.json()
+
+
 
 def _purchase_has_column(cur, column_name: str) -> bool:
     cur.execute(

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,6 +10,7 @@ import ReportPage from "./pages/ReportPage";
 import LoginPage from "./pages/LoginPage";
 import PurchasesPage from "./pages/PurchasesPage";
 import { ToastProvider } from "./components/Toast";
+import { useToast } from "./components/Toast";
 
 import './App.css';
 
@@ -44,6 +45,7 @@ function App() {
 
   return (
     <ToastProvider>
+    <AdminCheckBoxHealth />
     <Router>
       <nav>
         <ul>
@@ -103,5 +105,49 @@ function App() {
   );
 }
 
-export default App;
+function AdminCheckBoxHealth() {
+  const addToast = useToast();
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState(null);
+  const [checkedAt, setCheckedAt] = useState(null);
 
+  const runHealth = async () => {
+    setLoading(true);
+    try {
+      const response = await axios.get('/admin/integrations/checkbox/health');
+      setResult(response.data);
+      setCheckedAt(new Date().toISOString());
+      addToast(`CheckBox: ${response.data.status}`, response.data.status === 'ok' ? 'success' : 'warning');
+    } catch (err) {
+      const payload = err?.response?.data || { status: 'error', message: 'Request failed', details: [] };
+      setResult(payload);
+      setCheckedAt(new Date().toISOString());
+      addToast(`CheckBox: ${payload.message}`, 'error');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyDetails = async () => {
+    if (!result) return;
+    const text = JSON.stringify({ status: result.status, http_status: result.http_status, message: result.message, details: result.details }, null, 2);
+    await navigator.clipboard.writeText(text);
+    addToast('Детали скопированы', 'info');
+  };
+
+  const color = result?.status === 'ok' ? 'green' : (result?.status === 'warning' || result?.status === 'disabled') ? '#d4a000' : 'red';
+
+  return <div style={{ padding: '12px 16px', borderBottom: '1px solid #eee' }}>
+    <button className="btn btn--sm" onClick={runHealth} disabled={loading}>{loading ? 'Проверка...' : 'Проверить CheckBox'}</button>
+    {result && <div style={{ marginTop: 8 }}>
+      <strong style={{ color }}>Статус: {result.status}</strong> — {result.message}
+      {checkedAt && <div>Проверено: {checkedAt}</div>}
+      {(result.http_status === 401 || result.http_status === 403) && <div>Подсказка: проверьте логин/пароль/ключи CheckBox.</div>}
+      {String(result.message || '').toLowerCase().includes('network') && <div>Подсказка: проверьте интернет-доступ и CHECKBOX_API_URL.</div>}
+      <ul>{(result.details || []).map((d, i) => <li key={i}>{d}</li>)}</ul>
+      <button className="btn btn--ghost btn--sm" onClick={copyDetails}>Скопировать детали</button>
+    </div>}
+  </div>;
+}
+
+export default App;

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
 jest.mock('axios', () => ({ get: jest.fn(), post: jest.fn() }));
 import App from './App';
 
@@ -6,4 +7,33 @@ test('renders login', () => {
   render(<App />);
   const heading = screen.getByRole('heading', { name: /Login/i });
   expect(heading).toBeInTheDocument();
+});
+
+test('checkbox health loading and success render', async () => {
+  localStorage.setItem('token', 't');
+  axios.get.mockImplementation((url) => {
+    if (url === '/auth/verify') return Promise.resolve({ data: {} });
+    if (url === '/admin/integrations/checkbox/health') return Promise.resolve({ data: { status: 'ok', message: 'ok', details: [] } });
+    return Promise.resolve({ data: {} });
+  });
+
+  render(<App />);
+  const btn = await screen.findByRole('button', { name: /Проверить CheckBox/i });
+  fireEvent.click(btn);
+  expect(screen.getByRole('button', { name: /Проверка.../i })).toBeDisabled();
+  await waitFor(() => expect(screen.getByText(/Статус: ok/i)).toBeInTheDocument());
+});
+
+test('checkbox health error render', async () => {
+  localStorage.setItem('token', 't');
+  axios.get.mockImplementation((url) => {
+    if (url === '/auth/verify') return Promise.resolve({ data: {} });
+    if (url === '/admin/integrations/checkbox/health') return Promise.reject({ response: { data: { status: 'error', message: 'network', details: ['network'] } } });
+    return Promise.resolve({ data: {} });
+  });
+
+  render(<App />);
+  const btn = await screen.findByRole('button', { name: /Проверить CheckBox/i });
+  fireEvent.click(btn);
+  await waitFor(() => expect(screen.getByText(/Статус: error/i)).toBeInTheDocument());
 });

--- a/tests/test_admin_checkbox_health.py
+++ b/tests/test_admin_checkbox_health.py
@@ -1,0 +1,90 @@
+import importlib
+import os
+import sys
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+class DummyCursor:
+    def execute(self, *args, **kwargs):
+        pass
+    def fetchone(self):
+        return None
+    def fetchall(self):
+        return []
+    def close(self):
+        pass
+
+
+class DummyConn:
+    def cursor(self):
+        return DummyCursor()
+    def close(self):
+        pass
+    def commit(self):
+        pass
+    def rollback(self):
+        pass
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    monkeypatch.setattr('psycopg2.connect', lambda *a, **kw: DummyConn())
+    os.environ['CHECKBOX_ENABLED'] = 'true'
+    os.environ['CHECKBOX_CASHIER_LOGIN'] = 'login'
+    os.environ['CHECKBOX_CASHIER_PASSWORD'] = 'pwd'
+
+    if 'backend.main' in sys.modules:
+        importlib.reload(sys.modules['backend.main'])
+    else:
+        importlib.import_module('backend.main')
+
+    from backend.main import app
+    import backend.auth
+    app.dependency_overrides[backend.auth.require_admin_token] = lambda: {'role': 'admin'}
+    return TestClient(app)
+
+
+def test_checkbox_health_success(client, monkeypatch):
+    import backend.routers.integrations_admin as mod
+    monkeypatch.setattr(mod.checkbox, 'get_token_for_healthcheck', lambda: 'token')
+    monkeypatch.setattr(mod.checkbox, 'get_cashier_shift_status', lambda token: (200, {'status': 'OPENED'}))
+    r = client.get('/admin/integrations/checkbox/health')
+    assert r.status_code == 200
+    assert r.json()['status'] in ('ok', 'warning')
+
+
+def test_checkbox_health_disabled(client, monkeypatch):
+    import backend.routers.integrations_admin as mod
+    monkeypatch.setattr(mod.checkbox, 'is_enabled', lambda: False)
+    r = client.get('/admin/integrations/checkbox/health')
+    assert r.json()['status'] == 'disabled'
+
+
+def test_checkbox_health_missing_env(client, monkeypatch):
+    import backend.routers.integrations_admin as mod
+    monkeypatch.setattr(mod.checkbox, '_env', lambda k, d='': 'true' if k == 'CHECKBOX_ENABLED' else ('' if k == 'CHECKBOX_CASHIER_LOGIN' else 'x'))
+    r = client.get('/admin/integrations/checkbox/health')
+    assert r.json()['status'] == 'error'
+
+
+def test_checkbox_health_403(client, monkeypatch):
+    import backend.routers.integrations_admin as mod
+
+    req = httpx.Request('GET', 'https://api.checkbox.ua/api/v1/cashier/signin')
+    resp = httpx.Response(403, request=req)
+
+    def raise_403():
+        raise httpx.HTTPStatusError('forbidden', request=req, response=resp)
+
+    monkeypatch.setattr(mod.checkbox, 'get_token_for_healthcheck', raise_403)
+    r = client.get('/admin/integrations/checkbox/health')
+    assert r.json()['http_status'] == 403
+
+
+def test_checkbox_health_network_error(client, monkeypatch):
+    import backend.routers.integrations_admin as mod
+    monkeypatch.setattr(mod.checkbox, 'get_token_for_healthcheck', lambda: (_ for _ in ()).throw(httpx.ConnectTimeout('timeout')))
+    r = client.get('/admin/integrations/checkbox/health')
+    assert 'network' in r.json()['message'].lower()


### PR DESCRIPTION
### Motivation
- Provide an operational health-check for the CheckBox fiscal integration to make diagnostics and configuration issues visible to admins. 
- Surface authentication/shift status and useful diagnostics in the admin UI and documentation to reduce manual troubleshooting. 
- Ensure the new functionality is covered by automated tests and documented in the repository README.

### Description
- Add a new admin router `GET /admin/integrations/checkbox/health` with a typed `CheckBoxHealthResponse` model that validates env presence, performs signin and shift checks, and maps HTTP/network errors to clear statuses. 
- Extend `backend/services/checkbox.py` with `get_token_for_healthcheck` and `get_cashier_shift_status` wrappers used by the health endpoint and keep existing token logic intact. 
- Wire the new router into `backend/main.py`, add README documentation for the admin health-check and required env vars, and add a frontend `AdminCheckBoxHealth` component into `frontend/src/App.js` with a button, status display, copy-details action, and toast notifications. 
- Add automated tests: backend pytest tests in `tests/test_admin_checkbox_health.py` and frontend component tests updates in `frontend/src/App.test.js` to cover success, error and disabled scenarios.

### Testing
- Ran backend unit tests with `pytest` including `tests/test_admin_checkbox_health.py`, and they passed. 
- Ran frontend unit tests with the existing test runner (`npm test --prefix frontend`) covering `App.test.js` additions, and they passed. 
- Existing test suite (`pytest`) and frontend tests were executed to validate integration behavior and UI rendering after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61f7612748327839c5012217a64b9)