### PR TITLE
Switch CheckBox authentication to cashier PIN flow

### DIFF
--- a/backend/routers/integrations_admin.py
+++ b/backend/routers/integrations_admin.py
@@ -31,7 +31,7 @@ def checkbox_health() -> CheckBoxHealthResponse:
         )
 
     missing_required: list[str] = []
-    for key in ("CHECKBOX_CASHIER_LOGIN", "CHECKBOX_CASHIER_PASSWORD"):
+    for key in ("CHECKBOX_CASHIER_PIN",):
         if not checkbox._env(key):
             missing_required.append(key)
 

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -50,17 +50,20 @@ def _get_token() -> str:
         if _cached_token and time.time() < _token_expires_at:
             return _cached_token
 
-    login = _env("CHECKBOX_CASHIER_LOGIN")
-    password = _env("CHECKBOX_CASHIER_PASSWORD")
-    access_key = _env("CHECKBOX_ACCESS_KEY")
+    pin_code = _env("CHECKBOX_CASHIER_PIN")
+    license_key = _env("CHECKBOX_LICENSE_KEY")
 
-    if not login or not password:
-        raise RuntimeError("CHECKBOX_CASHIER_LOGIN and CHECKBOX_CASHIER_PASSWORD are required")
+    if not pin_code:
+        raise RuntimeError("CHECKBOX_CASHIER_PIN is required")
+
+    headers: dict[str, str] = {}
+    if license_key:
+        headers["X-License-Key"] = license_key
 
     resp = httpx.post(
-        f"{_api_url()}/api/v1/cashier/signin",
-        json={"login": login, "password": password},
-        headers={"X-Access-Key": access_key} if access_key else {},
+        f"{_api_url()}/api/v1/cashier/signinPinCode",
+        json={"pin_code": pin_code},
+        headers=headers,
         timeout=15.0,
     )
     resp.raise_for_status()


### PR DESCRIPTION
### Motivation
- Replace the previous cashier login/password flow with PIN-based authentication to match updated CheckBox API and `.env` usage.
- Ensure the integration can use the already-present license key by sending it during signin when available.

### Description
- `backend/services/checkbox.py`: `_get_token()` now reads `CHECKBOX_CASHIER_PIN`, validates its presence, and calls `POST /api/v1/cashier/signinPinCode` with `{"pin_code": ...}` to obtain the bearer token.
- `backend/services/checkbox.py`: when provided, `CHECKBOX_LICENSE_KEY` is sent as `X-License-Key` header during signin.
- `backend/routers/integrations_admin.py`: health-check now requires `CHECKBOX_CASHIER_PIN` instead of `CHECKBOX_CASHIER_LOGIN`/`CHECKBOX_CASHIER_PASSWORD`.

### Testing
- Ran `python -m compileall backend/services/checkbox.py backend/routers/integrations_admin.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62e2e246c832799772e27c1e2d2bb)