### PR TITLE
Add explicit LiqPay→CheckBox fiscalization queue logging

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -699,6 +699,17 @@ def _sync_purchase_paid_from_liqpay_callback(
         from ..services.checkbox import is_enabled as checkbox_enabled, fiscalize_purchase
         if checkbox_enabled():
             background_tasks.add_task(fiscalize_purchase, purchase_id)
+            logger.info("Queued CheckBox fiscalization task for purchase=%s", purchase_id)
+        else:
+            logger.info(
+                "CheckBox fiscalization is disabled (CHECKBOX_ENABLED=false); skipping purchase=%s",
+                purchase_id,
+            )
+    else:
+        logger.warning(
+            "BackgroundTasks is unavailable for LiqPay callback; fiscalization queue skipped for purchase=%s",
+            purchase_id,
+        )
     return "paid", payment_id
 
 


### PR DESCRIPTION
### Motivation
- LiqPay callback flow queued CheckBox fiscalization in background with no explicit log markers, making it hard to tell from backend logs whether fiscalization was queued, skipped due to config, or skipped because `BackgroundTasks` was unavailable.

### Description
- Add explicit `INFO` logs when a CheckBox fiscalization task is queued and when it is skipped due to `CHECKBOX_ENABLED=false`, and add a `WARNING` log when `BackgroundTasks` is unavailable; change applied in `backend/routers/public.py`.

### Testing
- Ran `python -m py_compile backend/routers/public.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e38068408327943a6a77d7ab6dbd)