### PR TITLE
Add detailed logging for LiqPay callback fiscalization and CheckBox service

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -616,6 +616,11 @@ def _sync_purchase_paid_from_liqpay_callback(
             normalized,
         )
         if normalized != "paid":
+            logger.info(
+                "Skipping fiscalization flow for purchase=%s because LiqPay status is not paid (normalized=%s)",
+                purchase_id,
+                normalized,
+            )
             conn.commit()
             return normalized, payment_id
 
@@ -630,6 +635,11 @@ def _sync_purchase_paid_from_liqpay_callback(
             return "paid", payment_id
 
         if purchase_status != "reserved":
+            logger.warning(
+                "Skipping fiscalization flow for purchase=%s because purchase status is %s (expected reserved)",
+                purchase_id,
+                purchase_status,
+            )
             raise HTTPException(status_code=409, detail="Purchase cannot be paid")
 
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
@@ -699,6 +709,17 @@ def _sync_purchase_paid_from_liqpay_callback(
         from ..services.checkbox import is_enabled as checkbox_enabled, fiscalize_purchase
         if checkbox_enabled():
             background_tasks.add_task(fiscalize_purchase, purchase_id)
+            logger.info("Queued CheckBox fiscalization task for purchase=%s", purchase_id)
+        else:
+            logger.info(
+                "CheckBox fiscalization is disabled (CHECKBOX_ENABLED=false); skipping purchase=%s",
+                purchase_id,
+            )
+    else:
+        logger.warning(
+            "BackgroundTasks is unavailable for LiqPay callback; fiscalization queue skipped for purchase=%s",
+            purchase_id,
+        )
     return "paid", payment_id
 
 

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -340,7 +340,13 @@ def fiscalize_purchase(purchase_id: int) -> None:
     are caught and persisted to the purchase row for later retry.
     """
     if not is_enabled():
+        logger.info(
+            "Skipping fiscalize_purchase for purchase=%s because CHECKBOX_ENABLED=false",
+            purchase_id,
+        )
         return
+
+    logger.info("Starting CheckBox fiscalization for purchase=%s", purchase_id)
 
     from ..database import get_connection
 


### PR DESCRIPTION
### Motivation
- Improve observability of the fiscalization flow triggered from LiqPay callbacks and the CheckBox service to make failures and decision points easier to diagnose.

### Description
- Log when a LiqPay callback is skipped because the normalized status is not `paid` or when the purchase status is not the expected `reserved` instead of silently returning or raising.
- Add logging around enqueueing of CheckBox fiscalization tasks and explicit messages when CheckBox is disabled or `BackgroundTasks` is unavailable in the callback path.
- Add entry/exit informational logs in `fiscalize_purchase` to indicate early return when `CHECKBOX_ENABLED=false` and when fiscalization is starting.

### Testing
- Ran the backend automated test suite with `pytest` and verified no regressions in existing tests.
- Verified that the new logging statements do not change control flow and that existing fiscalization/invocation paths remain covered by the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e38068408327943a6a77d7ab6dbd)