### PR TITLE
Duplicate fiscal logs to ops logger and add explicit fiscalization logging

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -39,6 +39,14 @@ _CSRF_COOKIE_NAME = "mc_csrf"
 _DEFAULT_LANG = "bg"
 
 logger = logging.getLogger(__name__)
+ops_logger = logging.getLogger("uvicorn.error")
+
+
+def _emit_fiscal_log(level: str, message: str, *args: object) -> None:
+    log_fn = getattr(logger, level, logger.info)
+    ops_fn = getattr(ops_logger, level, ops_logger.info)
+    log_fn(message, *args)
+    ops_fn(message, *args)
 
 
 class RescheduleTicketSpec(BaseModel):
@@ -616,6 +624,12 @@ def _sync_purchase_paid_from_liqpay_callback(
             normalized,
         )
         if normalized != "paid":
+            _emit_fiscal_log(
+                "warning",
+                "Skipping fiscalization flow for purchase=%s because LiqPay status is not paid (normalized=%s)",
+                purchase_id,
+                normalized,
+            )
             conn.commit()
             return normalized, payment_id
 
@@ -630,6 +644,12 @@ def _sync_purchase_paid_from_liqpay_callback(
             return "paid", payment_id
 
         if purchase_status != "reserved":
+            _emit_fiscal_log(
+                "warning",
+                "Skipping fiscalization flow for purchase=%s because purchase status is %s (expected reserved)",
+                purchase_id,
+                purchase_status,
+            )
             raise HTTPException(status_code=409, detail="Purchase cannot be paid")
 
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
@@ -699,6 +719,19 @@ def _sync_purchase_paid_from_liqpay_callback(
         from ..services.checkbox import is_enabled as checkbox_enabled, fiscalize_purchase
         if checkbox_enabled():
             background_tasks.add_task(fiscalize_purchase, purchase_id)
+            _emit_fiscal_log("warning", "Queued CheckBox fiscalization task for purchase=%s", purchase_id)
+        else:
+            _emit_fiscal_log(
+                "warning",
+                "CheckBox fiscalization is disabled (CHECKBOX_ENABLED=false); skipping purchase=%s",
+                purchase_id,
+            )
+    else:
+        _emit_fiscal_log(
+            "warning",
+            "BackgroundTasks is unavailable for LiqPay callback; fiscalization queue skipped for purchase=%s",
+            purchase_id,
+        )
     return "paid", payment_id
 
 

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -14,6 +14,14 @@ from typing import Any
 import httpx
 
 logger = logging.getLogger(__name__)
+ops_logger = logging.getLogger("uvicorn.error")
+
+
+def _emit_fiscal_log(level: str, message: str, *args: object) -> None:
+    log_fn = getattr(logger, level, logger.info)
+    ops_fn = getattr(ops_logger, level, ops_logger.info)
+    log_fn(message, *args)
+    ops_fn(message, *args)
 
 # ---------------------------------------------------------------------------
 # Configuration helpers
@@ -340,7 +348,14 @@ def fiscalize_purchase(purchase_id: int) -> None:
     are caught and persisted to the purchase row for later retry.
     """
     if not is_enabled():
+        _emit_fiscal_log(
+            "warning",
+            "Skipping fiscalize_purchase for purchase=%s because CHECKBOX_ENABLED=false",
+            purchase_id,
+        )
         return
+
+    _emit_fiscal_log("warning", "Starting CheckBox fiscalization for purchase=%s", purchase_id)
 
     from ..database import get_connection
 


### PR DESCRIPTION
### Motivation

- Improve observability for fiscalization and payment flows by ensuring key fiscal events are also emitted to the ops log stream (`uvicorn.error`).

### Description

- Added an `ops_logger = logging.getLogger("uvicorn.error")` and helper `_emit_fiscal_log(level, message, *args)` in `backend/routers/public.py` and `backend/services/checkbox.py` to mirror important fiscal messages to both the module logger and the ops logger.
- Inserted `_emit_fiscal_log` calls in the LiqPay callback flow to record cases where fiscalization is skipped due to non-paid LiqPay status, unexpected purchase status, disabled CheckBox integration, or missing `BackgroundTasks`, and to note when a CheckBox fiscalization task is queued.
- Added `_emit_fiscal_log` calls in `fiscalize_purchase` to explicitly log when `CHECKBOX_ENABLED` is false and when fiscalization starts.
- No functional change to fiscalization logic besides additional logging; existing logger calls are preserved.

### Testing

- Ran the test suite with `pytest` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6e38068408327943a6a77d7ab6dbd)