### PR TITLE
Add unavoidable fiscalization logs for Liqpay callback and CheckBox worker

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -39,6 +39,13 @@ _CSRF_COOKIE_NAME = "mc_csrf"
 _DEFAULT_LANG = "bg"
 
 logger = logging.getLogger(__name__)
+_uvicorn_error_logger = logging.getLogger("uvicorn.error")
+
+
+def _emit_fiscal_log(message: str, *args: Any) -> None:
+    """Emit fiscalization-critical logs to both module and container loggers."""
+    logger.warning(message, *args)
+    _uvicorn_error_logger.warning(message, *args)
 
 
 class RescheduleTicketSpec(BaseModel):
@@ -616,6 +623,12 @@ def _sync_purchase_paid_from_liqpay_callback(
             normalized,
         )
         if normalized != "paid":
+            _emit_fiscal_log(
+                "Skipping fiscalization flow for purchase=%s: LiqPay status is not paid (normalized=%s, raw=%s)",
+                purchase_id,
+                normalized,
+                liqpay_status or None,
+            )
             conn.commit()
             return normalized, payment_id
 
@@ -630,6 +643,11 @@ def _sync_purchase_paid_from_liqpay_callback(
             return "paid", payment_id
 
         if purchase_status != "reserved":
+            _emit_fiscal_log(
+                "Skipping fiscalization flow for purchase=%s: purchase status conflict (status=%s, expected=reserved)",
+                purchase_id,
+                purchase_status,
+            )
             raise HTTPException(status_code=409, detail="Purchase cannot be paid")
 
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
@@ -700,14 +718,23 @@ def _sync_purchase_paid_from_liqpay_callback(
         if checkbox_enabled():
             background_tasks.add_task(fiscalize_purchase, purchase_id)
             logger.info("Queued CheckBox fiscalization task for purchase=%s", purchase_id)
+            _emit_fiscal_log("Queued CheckBox fiscalization task for purchase=%s", purchase_id)
         else:
             logger.info(
                 "CheckBox fiscalization is disabled (CHECKBOX_ENABLED=false); skipping purchase=%s",
                 purchase_id,
             )
+            _emit_fiscal_log(
+                "Skipped CheckBox fiscalization for purchase=%s: CHECKBOX_ENABLED=false",
+                purchase_id,
+            )
     else:
         logger.warning(
             "BackgroundTasks is unavailable for LiqPay callback; fiscalization queue skipped for purchase=%s",
+            purchase_id,
+        )
+        _emit_fiscal_log(
+            "Skipped CheckBox fiscalization queue for purchase=%s: BackgroundTasks unavailable",
             purchase_id,
         )
     return "paid", payment_id

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -340,7 +340,12 @@ def fiscalize_purchase(purchase_id: int) -> None:
     are caught and persisted to the purchase row for later retry.
     """
     if not is_enabled():
+        logger.warning(
+            "Skipping fiscalization for purchase=%s: CHECKBOX_ENABLED=false",
+            purchase_id,
+        )
         return
+    logger.warning("Starting fiscalization for purchase=%s", purchase_id)
 
     from ..database import get_connection
 


### PR DESCRIPTION
### Motivation
- Ensure that after `POST /public/payment/liqpay/callback` returns 200 the reason why CheckBox fiscalization ran or was skipped is always visible in backend container logs. 
- Duplicate critical fiscal branch messages to the container-visible `uvicorn.error` logger so platform log aggregation reliably captures them. 
- Surface explicit start/skip reasons inside the background `fiscalize_purchase` worker so operators can see progress immediately after the callback handler enqueues the job.

### Description
- Added `_emit_fiscal_log` helper to `backend/routers/public.py` which emits the same warning to the module logger and `uvicorn.error`. 
- Emitted warning-level fiscal logs via `_emit_fiscal_log` in `_sync_purchase_paid_from_liqpay_callback` for the branches: non-`paid` normalized status, purchase status conflict (`!= reserved`), queued fiscalization task, skip due to `CHECKBOX_ENABLED=false`, and skip due to missing `BackgroundTasks`. 
- Added warning logs inside `backend/services/checkbox.py::fiscalize_purchase` to record an explicit skip when `CHECKBOX_ENABLED=false` and to log the start of fiscalization. 
- Kept existing `queue`/`skip` logs and only added duplicated/container-visible warning logs for guaranteed visibility.

### Testing
- Ran `pytest -q tests/test_payment_resolve.py tests/test_liqpay_payload.py` which completed successfully with all tests passing (11 passed, several warnings reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6fb537f888327841d059b0c9a411c)