### PR TITLE
Duplicate fiscalization logs to container logger and add `_emit_fiscal_log` utilities

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -39,6 +39,13 @@ _CSRF_COOKIE_NAME = "mc_csrf"
 _DEFAULT_LANG = "bg"
 
 logger = logging.getLogger(__name__)
+_uvicorn_error_logger = logging.getLogger("uvicorn.error")
+
+
+def _emit_fiscal_log(message: str, *args: Any) -> None:
+    """Emit fiscalization-critical logs to both module and container loggers."""
+    logger.warning(message, *args)
+    _uvicorn_error_logger.warning(message, *args)
 
 
 class RescheduleTicketSpec(BaseModel):
@@ -616,6 +623,12 @@ def _sync_purchase_paid_from_liqpay_callback(
             normalized,
         )
         if normalized != "paid":
+            _emit_fiscal_log(
+                "Skipping fiscalization flow for purchase=%s: LiqPay status is not paid (normalized=%s, raw=%s)",
+                purchase_id,
+                normalized,
+                liqpay_status or None,
+            )
             conn.commit()
             return normalized, payment_id
 
@@ -630,7 +643,16 @@ def _sync_purchase_paid_from_liqpay_callback(
             return "paid", payment_id
 
         if purchase_status != "reserved":
+            _emit_fiscal_log(
+                "Skipping fiscalization flow for purchase=%s: purchase status conflict (status=%s, expected=reserved)",
+                purchase_id,
+                purchase_status,
+            )
             raise HTTPException(status_code=409, detail="Purchase cannot be paid")
+        _emit_fiscal_log(
+            "Fiscalization flow will continue for purchase=%s: LiqPay paid and purchase status is reserved",
+            purchase_id,
+        )
 
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
         from ..services.checkbox import is_enabled as checkbox_enabled
@@ -700,14 +722,23 @@ def _sync_purchase_paid_from_liqpay_callback(
         if checkbox_enabled():
             background_tasks.add_task(fiscalize_purchase, purchase_id)
             logger.info("Queued CheckBox fiscalization task for purchase=%s", purchase_id)
+            _emit_fiscal_log("Queued CheckBox fiscalization task for purchase=%s", purchase_id)
         else:
             logger.info(
                 "CheckBox fiscalization is disabled (CHECKBOX_ENABLED=false); skipping purchase=%s",
                 purchase_id,
             )
+            _emit_fiscal_log(
+                "Skipped CheckBox fiscalization for purchase=%s: CHECKBOX_ENABLED=false",
+                purchase_id,
+            )
     else:
         logger.warning(
             "BackgroundTasks is unavailable for LiqPay callback; fiscalization queue skipped for purchase=%s",
+            purchase_id,
+        )
+        _emit_fiscal_log(
+            "Skipped CheckBox fiscalization queue for purchase=%s: BackgroundTasks unavailable",
             purchase_id,
         )
     return "paid", payment_id

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -14,6 +14,12 @@ from typing import Any
 import httpx
 
 logger = logging.getLogger(__name__)
+_uvicorn_error_logger = logging.getLogger("uvicorn.error")
+
+
+def _emit_fiscal_log(message: str, *args: Any) -> None:
+    logger.warning(message, *args)
+    _uvicorn_error_logger.warning(message, *args)
 
 # ---------------------------------------------------------------------------
 # Configuration helpers
@@ -340,7 +346,12 @@ def fiscalize_purchase(purchase_id: int) -> None:
     are caught and persisted to the purchase row for later retry.
     """
     if not is_enabled():
+        _emit_fiscal_log(
+            "Skipping fiscalization for purchase=%s: CHECKBOX_ENABLED=false",
+            purchase_id,
+        )
         return
+    _emit_fiscal_log("Starting fiscalization for purchase=%s", purchase_id)
 
     from ..database import get_connection
 


### PR DESCRIPTION
### Motivation

- Ensure fiscalization-related events are recorded both in the module logger and the container (`uvicorn.error`) logger for better observability and compliance auditing.
- Make fiscalization decision points and queueing/skipping behavior more visible in centralized logs so operators can trace fiscal flows for online payments.

### Description

- Added a module-level `_uvicorn_error_logger` and an `_emit_fiscal_log` helper to `backend/routers/public.py` and `backend/services/checkbox.py` to emit fiscalization-critical messages to both the module logger and `uvicorn.error`.
- Instrumented the LiqPay callback flow in `_sync_purchase_paid_from_liqpay_callback` to call `_emit_fiscal_log` at key decision points including when LiqPay status is not paid, when purchase status conflicts, when fiscalization will continue, when CheckBox fiscalization is queued, and when it is skipped due to config or missing `BackgroundTasks`.
- Added logging calls in `fiscalize_purchase` to emit messages when `CHECKBOX_ENABLED` is false and when fiscalization starts.

### Testing

- Ran the existing automated backend unit test suite against the modified modules and all tests passed.
- Ran linting/static checks on the modified files with no new warnings or errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6fb537f888327841d059b0c9a411c)