### PR TITLE
Add end-to-end CheckBox fiscalization progress/failure visibility

### DIFF
--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -39,6 +39,13 @@ _CSRF_COOKIE_NAME = "mc_csrf"
 _DEFAULT_LANG = "bg"
 
 logger = logging.getLogger(__name__)
+_uvicorn_error_logger = logging.getLogger("uvicorn.error")
+
+
+def _emit_fiscal_log(message: str, *args: Any) -> None:
+    """Emit fiscalization-critical logs to both module and container loggers."""
+    logger.warning(message, *args)
+    _uvicorn_error_logger.warning(message, *args)
 
 
 class RescheduleTicketSpec(BaseModel):
@@ -616,6 +623,12 @@ def _sync_purchase_paid_from_liqpay_callback(
             normalized,
         )
         if normalized != "paid":
+            _emit_fiscal_log(
+                "Skipping fiscalization flow for purchase=%s: LiqPay status is not paid (normalized=%s, raw=%s)",
+                purchase_id,
+                normalized,
+                liqpay_status or None,
+            )
             conn.commit()
             return normalized, payment_id
 
@@ -630,7 +643,16 @@ def _sync_purchase_paid_from_liqpay_callback(
             return "paid", payment_id
 
         if purchase_status != "reserved":
+            _emit_fiscal_log(
+                "Skipping fiscalization flow for purchase=%s: purchase status conflict (status=%s, expected=reserved)",
+                purchase_id,
+                purchase_status,
+            )
             raise HTTPException(status_code=409, detail="Purchase cannot be paid")
+        _emit_fiscal_log(
+            "Fiscalization flow will continue for purchase=%s: LiqPay paid and purchase status is reserved",
+            purchase_id,
+        )
 
         ticket_specs = _collect_ticket_specs_for_purchase(cur, purchase_id)
         from ..services.checkbox import is_enabled as checkbox_enabled
@@ -700,14 +722,23 @@ def _sync_purchase_paid_from_liqpay_callback(
         if checkbox_enabled():
             background_tasks.add_task(fiscalize_purchase, purchase_id)
             logger.info("Queued CheckBox fiscalization task for purchase=%s", purchase_id)
+            _emit_fiscal_log("Queued CheckBox fiscalization task for purchase=%s", purchase_id)
         else:
             logger.info(
                 "CheckBox fiscalization is disabled (CHECKBOX_ENABLED=false); skipping purchase=%s",
                 purchase_id,
             )
+            _emit_fiscal_log(
+                "Skipped CheckBox fiscalization for purchase=%s: CHECKBOX_ENABLED=false",
+                purchase_id,
+            )
     else:
         logger.warning(
             "BackgroundTasks is unavailable for LiqPay callback; fiscalization queue skipped for purchase=%s",
+            purchase_id,
+        )
+        _emit_fiscal_log(
+            "Skipped CheckBox fiscalization queue for purchase=%s: BackgroundTasks unavailable",
             purchase_id,
         )
     return "paid", payment_id

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -14,6 +14,12 @@ from typing import Any
 import httpx
 
 logger = logging.getLogger(__name__)
+_uvicorn_error_logger = logging.getLogger("uvicorn.error")
+
+
+def _emit_fiscal_log(message: str, *args: Any) -> None:
+    logger.warning(message, *args)
+    _uvicorn_error_logger.warning(message, *args)
 
 # ---------------------------------------------------------------------------
 # Configuration helpers
@@ -340,7 +346,12 @@ def fiscalize_purchase(purchase_id: int) -> None:
     are caught and persisted to the purchase row for later retry.
     """
     if not is_enabled():
+        _emit_fiscal_log(
+            "Skipping fiscalization for purchase=%s: CHECKBOX_ENABLED=false",
+            purchase_id,
+        )
         return
+    _emit_fiscal_log("Starting fiscalization for purchase=%s", purchase_id)
 
     from ..database import get_connection
 
@@ -394,7 +405,9 @@ def fiscalize_purchase(purchase_id: int) -> None:
         # instead of creating a duplicate
         receipt_id = existing_receipt_id
         if not receipt_id:
+            _emit_fiscal_log("Opening/ensuring CheckBox shift for purchase=%s", purchase_id)
             _ensure_shift()
+            _emit_fiscal_log("Creating CheckBox receipt for purchase=%s amount_kopecks=%s", purchase_id, total_kopecks)
             receipt_id = _create_receipt(items, total_kopecks)
             # Persist receipt_id immediately so we don't create duplicates on retry
             cur.execute(
@@ -426,11 +439,22 @@ def fiscalize_purchase(purchase_id: int) -> None:
             "Purchase %s fiscalized successfully: receipt=%s fiscal_code=%s",
             purchase_id, receipt_id, fiscal_code,
         )
+        _emit_fiscal_log(
+            "Fiscalization completed for purchase=%s receipt=%s fiscal_code=%s",
+            purchase_id,
+            receipt_id,
+            fiscal_code,
+        )
 
     except Exception as exc:
         conn.rollback()
         error_msg = str(exc)[:500]
         logger.exception("Fiscalization failed for purchase %s", purchase_id)
+        _emit_fiscal_log(
+            "Fiscalization failed for purchase=%s reason=%s",
+            purchase_id,
+            error_msg,
+        )
 
         # If auth-related, invalidate cached token for next attempt
         if "401" in error_msg or "403" in error_msg or "Unauthorized" in error_msg:


### PR DESCRIPTION
## Summary
- Extended `backend/services/checkbox.py` logging so fiscalization is observable from start to terminal outcome in container logs.
- Added `_emit_fiscal_log` warning messages for:
  - shift ensure/open phase before receipt creation,
  - receipt creation start with purchase amount,
  - successful fiscalization completion with receipt/fiscal code,
  - failure with explicit reason string.
- This preserves automatic retries and makes root cause visible without manual DB inspection.

## Validation
- `pytest -q tests/test_payment_resolve.py tests/test_liqpay_payload.py` passed (11 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6fb537f888327841d059b0c9a411c)