### PR TITLE
Add Telegram staff notifications for booking events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,6 +50,13 @@ SMTP_PASSWORD=CHANGE_ME
 SMTP_FROM=noreply@example.com
 SMTP_FROM_NAME=Bus Tickets
 
+# Telegram staff notifications (booking/payment/cancellation/refund events)
+TELEGRAM_ENABLED=false
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+# Optional: override API endpoint (useful for tests/proxies)
+# TELEGRAM_API_URL=https://api.telegram.org
+
 # CheckBox (Ukrainian PRRO fiscalization)
 CHECKBOX_ENABLED=false
 CHECKBOX_API_URL=https://api.checkbox.ua

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -555,7 +555,12 @@ def _sync_purchase_paid_from_liqpay_callback(
     liqpay_status = status.lower()
 
     from ._ticket_link_helpers import issue_ticket_links
-    from .purchase import _collect_ticket_specs_for_purchase, _log_action, _queue_ticket_emails
+    from .purchase import (
+        _collect_ticket_specs_for_purchase,
+        _log_action,
+        _queue_telegram_event,
+        _queue_ticket_emails,
+    )
 
     conn = get_connection()
     cur = conn.cursor()
@@ -716,6 +721,7 @@ def _sync_purchase_paid_from_liqpay_callback(
 
     if background_tasks:
         _queue_ticket_emails(background_tasks, tickets, None, customer_email)
+        _queue_telegram_event(background_tasks, purchase_id, "paid")
         # Trigger CheckBox fiscalization as a non-blocking background task.
         # Only runs for online (LiqPay) payments — admin path never calls this function.
         from ..services.checkbox import is_enabled as checkbox_enabled, fiscalize_purchase

--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -20,6 +20,7 @@ from ._ticket_link_helpers import (
 )
 from ..services import ticket_links
 from ..services import liqpay
+from ..services import telegram
 from ..services.access_guard import guard_public_request
 from ..services.email import render_ticket_email, send_ticket_email
 from ..services.ticket_dto import get_ticket_dto
@@ -280,6 +281,304 @@ def _send_ticket_email_task(
         logger.exception("Failed to send ticket email for ticket %s", ticket_id)
 
 
+_TELEGRAM_EVENT_ICONS = {
+    "reserved": "\U0001F195",   # NEW button
+    "paid": "✅",            # white heavy check
+    "cancelled": "❌",       # cross mark
+    "refunded": "\U0001F4B8",    # money with wings
+}
+
+_TELEGRAM_EVENT_TITLES = {
+    "reserved": "Бронь",
+    "paid": "Оплата",
+    "cancelled": "Отмена",
+    "refunded": "Возврат",
+}
+
+
+def _escape_html(value) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def _build_telegram_message(
+    conn,
+    purchase_id: int,
+    event_type: str,
+    snapshot: dict | None = None,
+) -> str | None:
+    """Render an HTML-formatted Telegram message for a purchase event.
+
+    For events where ticket rows no longer exist (e.g. refund), ``snapshot``
+    must carry the data fields needed for formatting.
+    """
+
+    icon = _TELEGRAM_EVENT_ICONS.get(event_type, "ℹ️")
+    title = _TELEGRAM_EVENT_TITLES.get(event_type, event_type)
+
+    data: dict = dict(snapshot) if snapshot else {}
+
+    if not data:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT id FROM ticket WHERE purchase_id=%s ORDER BY id", (purchase_id,))
+            ticket_rows = [row[0] for row in cur.fetchall()]
+        finally:
+            cur.close()
+
+        if ticket_rows:
+            try:
+                dto = get_ticket_dto(ticket_rows[0], "bg", conn)
+            except Exception:
+                logger.exception("Failed to build ticket DTO for telegram notification purchase=%s", purchase_id)
+                dto = None
+            if dto:
+                passenger = dto.get("passenger") or {}
+                purchase = dto.get("purchase") or {}
+                customer = (purchase.get("customer") or {}) if purchase else {}
+                tour = dto.get("tour") or {}
+                route = dto.get("route") or {}
+                segment = dto.get("segment") or {}
+                pricing = dto.get("pricing") or {}
+                dep = segment.get("departure") or {}
+                arr = segment.get("arrival") or {}
+
+                data.setdefault("passenger_name", customer.get("name") or passenger.get("name"))
+                data.setdefault("passenger_phone", customer.get("phone"))
+                data.setdefault("route_name", route.get("name"))
+                data.setdefault("from_stop", dep.get("name"))
+                data.setdefault("to_stop", arr.get("name"))
+                data.setdefault("tour_date", tour.get("date"))
+                data.setdefault("departure_time", dep.get("time"))
+                data.setdefault("arrival_time", arr.get("time"))
+                data.setdefault("amount_due", purchase.get("amount_due"))
+                data.setdefault("currency", pricing.get("currency_code"))
+
+                # Collect all seat numbers for the purchase
+                seats: list[str] = []
+                cur = conn.cursor()
+                try:
+                    cur.execute(
+                        """
+                        SELECT s.seat_num
+                          FROM ticket t
+                          LEFT JOIN seat s ON s.id = t.seat_id
+                         WHERE t.purchase_id=%s
+                         ORDER BY s.seat_num
+                        """,
+                        (purchase_id,),
+                    )
+                    for row in cur.fetchall():
+                        if row and row[0] is not None:
+                            seats.append(str(row[0]))
+                finally:
+                    cur.close()
+                if seats:
+                    data.setdefault("seats", ", ".join(seats))
+
+        # Fallback to purchase-only row if no DTO data was captured.
+        if "passenger_name" not in data or "amount_due" not in data:
+            cur = conn.cursor()
+            try:
+                cur.execute(
+                    """
+                    SELECT customer_name, customer_email, customer_phone,
+                           amount_due, status
+                      FROM purchase WHERE id=%s
+                    """,
+                    (purchase_id,),
+                )
+                row = cur.fetchone()
+            finally:
+                cur.close()
+            if row:
+                data.setdefault("passenger_name", row[0])
+                data.setdefault("passenger_email", row[1])
+                data.setdefault("passenger_phone", row[2])
+                data.setdefault("amount_due", float(row[3]) if row[3] is not None else None)
+
+    lines = [f"{icon} <b>{_escape_html(title)} #{purchase_id}</b>"]
+
+    name = data.get("passenger_name")
+    phone = data.get("passenger_phone")
+    if name or phone:
+        parts = []
+        if name:
+            parts.append(_escape_html(name))
+        if phone:
+            parts.append(f"({_escape_html(phone)})")
+        lines.append(f"\U0001F464 {' '.join(parts)}")
+
+    route_name = data.get("route_name")
+    if route_name:
+        lines.append(f"\U0001F68C {_escape_html(route_name)}")
+
+    from_stop = data.get("from_stop")
+    to_stop = data.get("to_stop")
+    if from_stop or to_stop:
+        lines.append(
+            f"\U0001F4CD {_escape_html(from_stop or '?')} → {_escape_html(to_stop or '?')}"
+        )
+
+    date_part = data.get("tour_date")
+    dep_time = data.get("departure_time")
+    arr_time = data.get("arrival_time")
+    if date_part or dep_time or arr_time:
+        time_bits = []
+        if dep_time:
+            time_bits.append(_escape_html(dep_time))
+        if arr_time:
+            time_bits.append(_escape_html(arr_time))
+        time_str = " → ".join(time_bits)
+        lines.append(
+            f"\U0001F4C5 {_escape_html(date_part or '')} {time_str}".strip()
+        )
+
+    seats = data.get("seats")
+    if seats:
+        lines.append(f"\U0001F4BA Места: {_escape_html(seats)}")
+
+    amount = data.get("amount_due")
+    if amount is not None:
+        currency = data.get("currency") or ""
+        lines.append(f"\U0001F4B0 {_escape_html(amount)} {_escape_html(currency)}".rstrip())
+
+    return "\n".join(lines)
+
+
+def _capture_purchase_snapshot(conn, purchase_id: int) -> dict | None:
+    """Capture purchase + ticket data into a serializable dict.
+
+    Used before destructive operations (cancel/refund) so the Telegram
+    notification can still show passenger / route / seats after deletion.
+    """
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute("SELECT id FROM ticket WHERE purchase_id=%s ORDER BY id LIMIT 1", (purchase_id,))
+            row = cur.fetchone()
+        finally:
+            cur.close()
+    except Exception:
+        logger.exception("Failed to read tickets for telegram snapshot purchase=%s", purchase_id)
+        return None
+
+    if not row:
+        return None
+
+    first_ticket_id = row[0]
+    try:
+        dto = get_ticket_dto(first_ticket_id, "bg", conn)
+    except Exception:
+        logger.exception("Failed to build snapshot DTO for purchase=%s", purchase_id)
+        return None
+
+    passenger = dto.get("passenger") or {}
+    purchase = dto.get("purchase") or {}
+    customer = (purchase.get("customer") or {}) if purchase else {}
+    tour = dto.get("tour") or {}
+    route = dto.get("route") or {}
+    segment = dto.get("segment") or {}
+    pricing = dto.get("pricing") or {}
+    dep = segment.get("departure") or {}
+    arr = segment.get("arrival") or {}
+
+    snapshot: dict = {
+        "passenger_name": customer.get("name") or passenger.get("name"),
+        "passenger_phone": customer.get("phone"),
+        "passenger_email": customer.get("email"),
+        "route_name": route.get("name"),
+        "from_stop": dep.get("name"),
+        "to_stop": arr.get("name"),
+        "tour_date": tour.get("date"),
+        "departure_time": dep.get("time"),
+        "arrival_time": arr.get("time"),
+        "amount_due": purchase.get("amount_due"),
+        "currency": pricing.get("currency_code"),
+    }
+
+    seats: list[str] = []
+    try:
+        cur = conn.cursor()
+        try:
+            cur.execute(
+                """
+                SELECT s.seat_num
+                  FROM ticket t
+                  LEFT JOIN seat s ON s.id = t.seat_id
+                 WHERE t.purchase_id=%s
+                 ORDER BY s.seat_num
+                """,
+                (purchase_id,),
+            )
+            for srow in cur.fetchall():
+                if srow and srow[0] is not None:
+                    seats.append(str(srow[0]))
+        finally:
+            cur.close()
+    except Exception:
+        logger.exception("Failed to collect seats for telegram snapshot purchase=%s", purchase_id)
+    if seats:
+        snapshot["seats"] = ", ".join(seats)
+
+    return snapshot
+
+
+def _send_telegram_event_task(
+    purchase_id: int,
+    event_type: str,
+    snapshot: dict | None = None,
+) -> None:
+    """Background task: build and send a Telegram notification for an event."""
+    if not telegram.is_enabled():
+        return
+
+    conn = None
+    try:
+        try:
+            conn = get_connection()
+        except Exception:
+            logger.exception("Failed to acquire DB connection for telegram event purchase=%s", purchase_id)
+            return
+
+        try:
+            message = _build_telegram_message(conn, purchase_id, event_type, snapshot)
+        except Exception:
+            logger.exception("Failed to build telegram message for purchase=%s event=%s", purchase_id, event_type)
+            return
+
+        if not message:
+            return
+
+        telegram.send_message(message)
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def _queue_telegram_event(
+    background_tasks: BackgroundTasks | None,
+    purchase_id: int,
+    event_type: str,
+    snapshot: dict | None = None,
+) -> None:
+    """Schedule a Telegram notification background task for an event."""
+    if not background_tasks or not purchase_id:
+        return
+    if not telegram.is_enabled():
+        return
+    background_tasks.add_task(_send_telegram_event_task, purchase_id, event_type, snapshot)
+
+
 def _create_purchase(
     cur,
     data: PurchaseCreate,
@@ -531,6 +830,7 @@ def create_purchase(data: PurchaseCreate, background_tasks: BackgroundTasks):
         conn.close()
 
     _queue_ticket_emails(background_tasks, tickets, data.lang, data.passenger_email)
+    _queue_telegram_event(background_tasks, purchase_id, "reserved")
     return {"purchase_id": purchase_id, "amount_due": amount_due, "tickets": tickets}
 
 
@@ -585,16 +885,19 @@ def pay_purchase(
         conn.close()
 
     _queue_ticket_emails(background_tasks, tickets, None, customer_email)
+    _queue_telegram_event(background_tasks, purchase_id, "paid")
 
 
 @router.post("/{purchase_id}/cancel", status_code=204)
 def cancel_purchase(
     purchase_id: int,
     request: Request,
+    background_tasks: BackgroundTasks,
     context=Depends(require_scope("cancel")),
 ):
     conn = get_connection()
     cur = conn.cursor()
+    telegram_snapshot: dict | None = None
     try:
         actor, jti = _resolve_actor(request)
         guard_public_request(
@@ -607,6 +910,9 @@ def cancel_purchase(
         tickets = [row[0] for row in cur.fetchall()]
         if not tickets:
             raise HTTPException(404, "Purchase not found")
+
+        if telegram.is_enabled():
+            telegram_snapshot = _capture_purchase_snapshot(conn, purchase_id)
 
         for t_id in tickets:
             free_ticket(cur, t_id)
@@ -625,6 +931,8 @@ def cancel_purchase(
     finally:
         cur.close()
         conn.close()
+
+    _queue_telegram_event(background_tasks, purchase_id, "cancelled", telegram_snapshot)
 
 
 # --- Public endpoints without /purchase prefix ---
@@ -686,6 +994,7 @@ def book_seat(data: PurchaseCreate, request: Request, background_tasks: Backgrou
         conn.close()
 
     _queue_ticket_emails(background_tasks, tickets, data.lang, data.passenger_email)
+    _queue_telegram_event(background_tasks, purchase_id, "reserved")
     from starlette.responses import JSONResponse
 
     from .public import _CSRF_COOKIE_NAME, _generate_csrf_token, _purchase_cookie_name
@@ -769,6 +1078,7 @@ def purchase_and_pay(
         conn.close()
 
     _queue_ticket_emails(background_tasks, tickets, data.lang, data.passenger_email)
+    _queue_telegram_event(background_tasks, purchase_id, "paid")
     return {"purchase_id": purchase_id, "amount_due": amount_due, "tickets": tickets}
 
 
@@ -820,6 +1130,7 @@ def public_purchase_and_pay(
         conn.close()
 
     _queue_ticket_emails(background_tasks, tickets, data.lang, data.passenger_email)
+    _queue_telegram_event(background_tasks, purchase_id, "reserved")
 
     from starlette.responses import JSONResponse
 
@@ -951,10 +1262,12 @@ def pay_booking(
 def cancel_booking(
     purchase_id: int,
     request: Request,
+    background_tasks: BackgroundTasks,
     context=Depends(optional_scope("cancel")),
 ):
     conn = get_connection()
     cur = conn.cursor()
+    telegram_snapshot: dict | None = None
     try:
         actor, jti = _resolve_actor(request)
         guard_public_request(request, "cancel", purchase_id=purchase_id, context=context)
@@ -962,6 +1275,9 @@ def cancel_booking(
         tickets = [row[0] for row in cur.fetchall()]
         if not tickets:
             raise HTTPException(404, "Purchase not found")
+
+        if telegram.is_enabled():
+            telegram_snapshot = _capture_purchase_snapshot(conn, purchase_id)
 
         for t_id in tickets:
             free_ticket(cur, t_id)
@@ -981,15 +1297,19 @@ def cancel_booking(
         cur.close()
         conn.close()
 
+    _queue_telegram_event(background_tasks, purchase_id, "cancelled", telegram_snapshot)
+
 
 @actions_router.post("/refund/{purchase_id}", status_code=204)
 def refund_purchase(
     purchase_id: int,
     request: Request,
+    background_tasks: BackgroundTasks,
     context=Depends(optional_scope("cancel")),
 ):
     conn = get_connection()
     cur = conn.cursor()
+    telegram_snapshot: dict | None = None
     try:
         actor, jti = _resolve_actor(request)
         guard_public_request(request, "refund", purchase_id=purchase_id, context=context)
@@ -997,6 +1317,8 @@ def refund_purchase(
         t = cur.fetchone()
         revoked_jtis: List[str] = []
         if t:
+            if telegram.is_enabled():
+                telegram_snapshot = _capture_purchase_snapshot(conn, purchase_id)
             ticket_id = t[0]
             cur.execute(
                 "SELECT jti FROM ticket_link_tokens WHERE ticket_id = %s AND revoked_at IS NULL",
@@ -1021,3 +1343,5 @@ def refund_purchase(
     finally:
         cur.close()
         conn.close()
+
+    _queue_telegram_event(background_tasks, purchase_id, "refunded", telegram_snapshot)

--- a/backend/services/telegram.py
+++ b/backend/services/telegram.py
@@ -1,0 +1,58 @@
+"""Telegram notification service for staff chat notifications."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_TELEGRAM_API_URL = "https://api.telegram.org"
+_HTTP_TIMEOUT = 5.0
+
+
+def is_enabled() -> bool:
+    """Return True if Telegram notifications are configured and enabled."""
+    if os.getenv("TELEGRAM_ENABLED", "false").strip().lower() not in {"true", "1", "yes"}:
+        return False
+    return bool(os.getenv("TELEGRAM_BOT_TOKEN") and os.getenv("TELEGRAM_CHAT_ID"))
+
+
+def send_message(text: str, parse_mode: Optional[str] = "HTML") -> bool:
+    """Send a message to the configured Telegram chat.
+
+    Returns True on success, False otherwise. Never raises — failures are
+    logged so they do not break the main request flow.
+    """
+    if not is_enabled():
+        return False
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    chat_id = os.getenv("TELEGRAM_CHAT_ID", "").strip()
+    api_url = os.getenv("TELEGRAM_API_URL", _TELEGRAM_API_URL).rstrip("/")
+
+    payload = {
+        "chat_id": chat_id,
+        "text": text,
+        "disable_web_page_preview": True,
+    }
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+
+    url = f"{api_url}/bot{token}/sendMessage"
+    try:
+        response = httpx.post(url, data=payload, timeout=_HTTP_TIMEOUT)
+        if response.status_code >= 400:
+            logger.error(
+                "Telegram sendMessage failed: status=%s body=%s",
+                response.status_code,
+                response.text[:500],
+            )
+            return False
+        return True
+    except Exception:
+        logger.exception("Telegram sendMessage raised an exception")
+        return False

--- a/tests/test_telegram_notifications.py
+++ b/tests/test_telegram_notifications.py
@@ -1,0 +1,258 @@
+"""Tests for the Telegram staff notification integration."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+sys.path.append(".")
+
+from backend.services import telegram
+
+
+class _DummyCursor:
+    def execute(self, *args, **kwargs):
+        return None
+
+    def fetchone(self):
+        return None
+
+    def fetchall(self):
+        return []
+
+    def close(self):
+        pass
+
+
+class _DummyPsycopgConn:
+    autocommit = False
+
+    def cursor(self):
+        return _DummyCursor()
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _clean_telegram_env(monkeypatch):
+    for var in ("TELEGRAM_ENABLED", "TELEGRAM_BOT_TOKEN", "TELEGRAM_CHAT_ID", "TELEGRAM_API_URL"):
+        monkeypatch.delenv(var, raising=False)
+    # Ensure that importing backend.database does not try to hit a real DB.
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **k: _DummyPsycopgConn())
+    yield
+
+
+def _import_purchase_module():
+    import importlib
+
+    return importlib.import_module("backend.routers.purchase")
+
+
+def _enable_telegram(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_ENABLED", "true")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "-100123")
+
+
+def test_is_enabled_requires_all_vars(monkeypatch):
+    assert telegram.is_enabled() is False
+
+    monkeypatch.setenv("TELEGRAM_ENABLED", "true")
+    assert telegram.is_enabled() is False
+
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+    assert telegram.is_enabled() is False
+
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "y")
+    assert telegram.is_enabled() is True
+
+    monkeypatch.setenv("TELEGRAM_ENABLED", "false")
+    assert telegram.is_enabled() is False
+
+
+def test_send_message_skips_when_disabled(monkeypatch):
+    calls: list = []
+
+    def fake_post(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("httpx.post must not be called when telegram is disabled")
+
+    monkeypatch.setattr("backend.services.telegram.httpx.post", fake_post)
+    assert telegram.send_message("hello") is False
+    assert calls == []
+
+
+def test_send_message_posts_to_telegram_api(monkeypatch):
+    _enable_telegram(monkeypatch)
+    captured: dict = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "ok"
+
+    def fake_post(url, data=None, timeout=None, **kwargs):
+        captured["url"] = url
+        captured["data"] = data
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr("backend.services.telegram.httpx.post", fake_post)
+
+    assert telegram.send_message("hi <b>there</b>") is True
+    assert captured["url"] == "https://api.telegram.org/bottest-token/sendMessage"
+    assert captured["data"]["chat_id"] == "-100123"
+    assert captured["data"]["text"] == "hi <b>there</b>"
+    assert captured["data"]["parse_mode"] == "HTML"
+    assert captured["data"]["disable_web_page_preview"] is True
+
+
+def test_send_message_swallows_exceptions(monkeypatch):
+    _enable_telegram(monkeypatch)
+
+    def fake_post(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("backend.services.telegram.httpx.post", fake_post)
+    assert telegram.send_message("hi") is False
+
+
+def test_send_message_returns_false_on_http_error(monkeypatch):
+    _enable_telegram(monkeypatch)
+
+    class FakeResponse:
+        status_code = 401
+        text = "Unauthorized"
+
+    monkeypatch.setattr(
+        "backend.services.telegram.httpx.post",
+        lambda *a, **k: FakeResponse(),
+    )
+    assert telegram.send_message("hi") is False
+
+
+def test_build_telegram_message_uses_snapshot(monkeypatch):
+    purchase = _import_purchase_module()
+
+    snapshot = {
+        "passenger_name": "Иван Иванов",
+        "passenger_phone": "+380501234567",
+        "route_name": "Киев — Варна",
+        "from_stop": "Киев",
+        "to_stop": "Варна",
+        "tour_date": "2026-06-01",
+        "departure_time": "08:00",
+        "arrival_time": "20:00",
+        "seats": "12, 13",
+        "amount_due": 1500.0,
+        "currency": "UAH",
+    }
+
+    msg = purchase._build_telegram_message(
+        conn=object(),  # not used because snapshot is provided
+        purchase_id=42,
+        event_type="refunded",
+        snapshot=snapshot,
+    )
+
+    assert msg is not None
+    assert "Возврат #42" in msg
+    assert "Иван Иванов" in msg
+    assert "+380501234567" in msg
+    assert "Киев — Варна" in msg
+    assert "Киев → Варна" in msg
+    assert "2026-06-01" in msg
+    assert "08:00 → 20:00" in msg
+    assert "12, 13" in msg
+    assert "1500" in msg and "UAH" in msg
+
+
+def test_build_telegram_message_html_escapes(monkeypatch):
+    purchase = _import_purchase_module()
+
+    snapshot = {
+        "passenger_name": "<script>alert(1)</script>",
+        "route_name": "A & B",
+    }
+    msg = purchase._build_telegram_message(
+        conn=object(), purchase_id=1, event_type="reserved", snapshot=snapshot
+    )
+    assert "<script>" not in msg
+    assert "&lt;script&gt;" in msg
+    assert "A &amp; B" in msg
+
+
+def test_queue_telegram_event_is_noop_when_disabled(monkeypatch):
+    purchase = _import_purchase_module()
+
+    class FakeBG:
+        def __init__(self):
+            self.tasks = []
+
+        def add_task(self, fn, *args, **kwargs):
+            self.tasks.append((fn, args, kwargs))
+
+    bg = FakeBG()
+    purchase._queue_telegram_event(bg, 1, "paid")
+    assert bg.tasks == []
+
+
+def test_queue_telegram_event_schedules_when_enabled(monkeypatch):
+    _enable_telegram(monkeypatch)
+    purchase = _import_purchase_module()
+
+    class FakeBG:
+        def __init__(self):
+            self.tasks = []
+
+        def add_task(self, fn, *args, **kwargs):
+            self.tasks.append((fn, args, kwargs))
+
+    bg = FakeBG()
+    purchase._queue_telegram_event(bg, 7, "paid", {"passenger_name": "Test"})
+    assert len(bg.tasks) == 1
+    fn, args, _ = bg.tasks[0]
+    assert fn is purchase._send_telegram_event_task
+    assert args == (7, "paid", {"passenger_name": "Test"})
+
+
+def test_send_telegram_event_task_uses_snapshot_without_db(monkeypatch):
+    _enable_telegram(monkeypatch)
+    purchase = _import_purchase_module()
+
+    sent_messages: list = []
+
+    def fake_send(text, parse_mode="HTML"):
+        sent_messages.append(text)
+        return True
+
+    monkeypatch.setattr(purchase.telegram, "send_message", fake_send)
+
+    class DummyConn:
+        def close(self):
+            pass
+
+    monkeypatch.setattr(purchase, "get_connection", lambda: DummyConn())
+
+    snapshot = {
+        "passenger_name": "Alice",
+        "route_name": "Sofia - Plovdiv",
+        "from_stop": "Sofia",
+        "to_stop": "Plovdiv",
+        "tour_date": "2026-07-15",
+        "amount_due": 25.0,
+        "currency": "BGN",
+    }
+    purchase._send_telegram_event_task(99, "cancelled", snapshot)
+
+    assert len(sent_messages) == 1
+    assert "Отмена #99" in sent_messages[0]
+    assert "Alice" in sent_messages[0]
+    assert "Sofia → Plovdiv" in sent_messages[0]


### PR DESCRIPTION
Notify a configured Telegram chat whenever a purchase is reserved, paid, cancelled or refunded so sales staff see activity in real time without polling the admin UI. Dispatch runs via FastAPI BackgroundTasks to avoid blocking the request flow (including the LiqPay callback); failures are logged and swallowed so the main flow is never broken. Cancellation and refund take a data snapshot before tickets are deleted so the chat message can still show passenger and route info. Disabled by default — controlled by TELEGRAM_ENABLED, TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID env vars.