### PR TITLE
Price open-date return from outbound pricelist

### DIFF
--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -727,22 +727,13 @@ def _create_purchase(
         roundtrip=roundtrip,
     )
 
-    # Prepaid open-date return: reverse-direction fare (same pricelist) minus 15%.
+    # Prepaid open-date return fare, minus 15%. The return tour isn't chosen yet,
+    # so it's priced off the outbound segment price from the same pricelist rather
+    # than a reverse-direction row the outbound pricelist doesn't contain.
     open_return_unit: tuple[float, float] | None = None
     if data.open_return:
-        cur.execute(
-            """
-            SELECT price FROM prices
-             WHERE pricelist_id=%s AND departure_stop_id=%s AND arrival_stop_id=%s
-            """,
-            (pricelist_id, data.arrival_stop_id, data.departure_stop_id),
-        )
-        reverse_row = cur.fetchone()
-        if not reverse_row:
-            raise HTTPException(404, "Return price not found")
-        reverse_base = float(reverse_row[0])
-        adult_open_fare = round(reverse_base * _passenger_multiplier(False, True), 2)
-        discount_open_fare = round(reverse_base * _passenger_multiplier(True, True), 2)
+        adult_open_fare = round(base_price * _passenger_multiplier(False, True), 2)
+        discount_open_fare = round(base_price * _passenger_multiplier(True, True), 2)
         open_return_unit = (adult_open_fare, discount_open_fare)
         total_price = round(
             total_price
@@ -1237,21 +1228,12 @@ def quote_purchase(data: PurchaseQuote, request: Request):
         )
 
         if data.open_return:
-            cur.execute(
-                """
-                SELECT price FROM prices
-                 WHERE pricelist_id=%s AND departure_stop_id=%s AND arrival_stop_id=%s
-                """,
-                (pricelist_id, data.arrival_stop_id, data.departure_stop_id),
-            )
-            reverse_row = cur.fetchone()
-            if not reverse_row:
-                raise HTTPException(404, "Return price not found")
-            reverse_base = float(reverse_row[0])
+            # Open-date return: priced off the outbound segment price from the
+            # same pricelist (the return tour isn't selected yet).
             amount_due = round(
                 amount_due
-                + data.adult_count * round(reverse_base * _passenger_multiplier(False, True), 2)
-                + data.discount_count * round(reverse_base * _passenger_multiplier(True, True), 2),
+                + data.adult_count * round(base_price * _passenger_multiplier(False, True), 2)
+                + data.discount_count * round(base_price * _passenger_multiplier(True, True), 2),
                 2,
             )
 

--- a/tests/test_open_return.py
+++ b/tests/test_open_return.py
@@ -143,13 +143,14 @@ def test_open_return_creates_voucher_and_adds_to_amount(monkeypatch):
     open_inserts = [q for q, p in cur.queries if "insert into open_ticket" in q.lower()]
     assert len(open_inserts) == 1
 
-    # Reverse-direction price lookup uses swapped stops on the same pricelist.
+    # Open-date return reuses the outbound segment price from the same pricelist;
+    # it must NOT query a reverse-direction row (arrival, departure).
     reverse_lookups = [
         p
         for q, p in cur.queries
         if "select price from prices" in q.lower() and p == (1, 2, 1)
     ]
-    assert reverse_lookups, "expected a reverse-direction price lookup (arrival, departure)"
+    assert not reverse_lookups, "open-date return should not do a reverse-direction price lookup"
 
 
 def test_open_return_discount_passenger_price(monkeypatch):
@@ -232,8 +233,10 @@ def test_quote_return_leg_discount(monkeypatch):
     assert result["amount_due"] == 8.5
 
 
-def test_quote_open_return_adds_reverse_leg(monkeypatch):
-    cur = FakeQuoteCursor(forward=10, reverse=10)
+def test_quote_open_return_uses_outbound_price(monkeypatch):
+    # reverse=999 would blow up the total if it were ever used; the open-date
+    # return must be priced off the outbound segment price instead.
+    cur = FakeQuoteCursor(forward=10, reverse=999)
     _patch_quote(monkeypatch, cur)
     data = PurchaseQuote(
         tour_id=1,


### PR DESCRIPTION
The open-date return leg looked up a reverse-direction price (arrival -> departure) in the outbound tour's pricelist, which only contains forward- direction rows. This raised 404 "Return price not found" for both the public quote and checkout. Price the open return off the outbound segment price from the same pricelist, since the return tour isn't chosen yet.

https://claude.ai/code/session_01MquznfVnnSNWxBfBVTvjA5