### PR TITLE
Add refund-request workflow end-to-end

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -36,6 +36,10 @@ from .routers import (
 )
 from .routers.ticket_admin import router as admin_tickets_router
 from .routers.purchase_admin import router as admin_purchases_router
+from .routers.refund_admin import (
+    router as admin_refund_requests_router,
+    purchase_router as admin_refund_purchase_router,
+)
 
 
 def _parse_cors_origins() -> list[str]:
@@ -104,6 +108,8 @@ app.include_router(public.session_router)
 app.include_router(public.router)
 app.include_router(admin_tickets_router)
 app.include_router(admin_purchases_router)
+app.include_router(admin_refund_requests_router)
+app.include_router(admin_refund_purchase_router)
 app.include_router(integrations_admin.router)
 app.include_router(auth.router)
 

--- a/backend/routers/public.py
+++ b/backend/routers/public.py
@@ -20,6 +20,7 @@ from ..services import link_sessions
 from ..services.link_sessions import get_or_create_view_session
 from ..services.access_guard import guard_public_request
 from ..services import liqpay
+from ..services import refund as refund_service
 from ..services.ticket_dto import get_ticket_dto
 from ..services.ticket_pdf import render_ticket_pdf
 from ..ticket_utils import free_ticket, recalc_available
@@ -79,6 +80,11 @@ class BaggageRequest(BaseModel):
 
 class CancelRequest(BaseModel):
     ticket_ids: list[int] = Field(..., min_length=1)
+
+
+class RefundRequestCreate(BaseModel):
+    ticket_ids: list[int] | None = None
+    reason: str | None = Field(default=None, max_length=2000)
 
 
 class PaymentResolveTicket(BaseModel):
@@ -953,6 +959,68 @@ async def _extract_liqpay_post_payload(request: Request) -> tuple[str | None, st
     return raw_data, raw_signature
 
 
+def _sync_refund_from_liqpay_callback(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Apply a LiqPay refund callback to the matching refund_request row.
+
+    LiqPay returns the original ``order_id`` plus a refund-specific identifier
+    (``payment_id`` or ``id``) for the refund operation itself. We persist the
+    final status against the row whose ``liqpay_refund_id`` matches.
+    """
+    liqpay_status = str(payload.get("status") or "").lower()
+    refund_id = (
+        payload.get("liqpay_refund_id")
+        or payload.get("refund_payment_id")
+        or payload.get("payment_id")
+        or payload.get("id")
+    )
+    if refund_id is None:
+        return {"matched": False, "reason": "no refund identifier"}
+
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        refund_service.ensure_schema(cur)
+        existing = refund_service.find_by_liqpay_refund_id(cur, str(refund_id))
+        if not existing:
+            return {"matched": False, "reason": "unknown refund id"}
+
+        if existing.get("status") in {"completed", "rejected"}:
+            return {"matched": True, "status": existing.get("status"), "noop": True}
+
+        if liqpay.is_refund_success(liqpay_status):
+            amount_refunded = (
+                existing.get("amount_refunded")
+                or existing.get("amount_requested")
+                or float(payload.get("refund_amount") or payload.get("amount") or 0)
+            )
+            refund_service.mark_completed(
+                cur,
+                int(existing["id"]),
+                amount_refunded=float(amount_refunded or 0),
+                liqpay_refund_id=str(refund_id),
+                liqpay_response=payload,
+                fiscal_receipt_id=existing.get("fiscal_receipt_id"),
+                fiscal_receipt_number=existing.get("fiscal_receipt_number"),
+                fiscal_status=existing.get("fiscal_status"),
+            )
+            conn.commit()
+            return {"matched": True, "status": "completed"}
+        refund_service.mark_failed(
+            cur,
+            int(existing["id"]),
+            failure_reason=f"LiqPay refund status: {liqpay_status or 'unknown'}",
+        )
+        conn.commit()
+        return {"matched": True, "status": "failed"}
+    except Exception as exc:
+        conn.rollback()
+        logger.exception("Failed to apply LiqPay refund callback")
+        return {"matched": False, "reason": str(exc)}
+    finally:
+        cur.close()
+        conn.close()
+
+
 @router.post("/payment/liqpay/callback")
 async def liqpay_callback(request: Request, background_tasks: BackgroundTasks) -> Mapping[str, Any]:
     data, signature = await _extract_liqpay_post_payload(request)
@@ -964,7 +1032,18 @@ async def liqpay_callback(request: Request, background_tasks: BackgroundTasks) -
         raise HTTPException(status_code=400, detail="Invalid LiqPay signature")
 
     payload = liqpay.decode_payload(data)
+    action = str(payload.get("action") or "").lower()
     order_id = str(payload.get("order_id") or "")
+
+    if action == "refund":
+        refund_result = _sync_refund_from_liqpay_callback(payload)
+        logger.info(
+            "LiqPay refund callback order_id=%s result=%s",
+            order_id,
+            refund_result,
+        )
+        return {"ok": True, "action": "refund", **refund_result}
+
     purchase_id = _extract_purchase_id_from_order(order_id)
     if purchase_id is None:
         raise HTTPException(status_code=400, detail="Unrecognized LiqPay order")
@@ -2220,6 +2299,20 @@ def public_baggage_quote(
     return jsonable_encoder(response)
 
 
+def _ensure_cancel_allowed(status: str) -> None:
+    """``/cancel`` and ``/cancel/preview`` only operate on reserved purchases.
+
+    Paid purchases must go through the refund-request workflow instead, so the
+    customer cannot bypass fiscal/refund accounting by reusing the legacy
+    cancel endpoint.
+    """
+    if status == "paid":
+        raise HTTPException(
+            status_code=409,
+            detail="Purchase is already paid; create a refund request instead",
+        )
+
+
 @router.post("/purchase/{purchase_id}/cancel/preview")
 def public_cancel_preview(
     purchase_id: int, data: CancelRequest, request: Request
@@ -2233,6 +2326,7 @@ def public_cancel_preview(
     try:
         amount_due, status = _load_purchase_state(cur, resolved_purchase_id)
         _ensure_purchase_active(status)
+        _ensure_cancel_allowed(status)
         plans, delta = _plan_cancel(
             cur,
             resolved_purchase_id,
@@ -2355,6 +2449,7 @@ def public_cancel(
             cur, resolved_purchase_id, for_update=True
         )
         _ensure_purchase_active(status)
+        _ensure_cancel_allowed(status)
         plans, delta = _plan_cancel(
             cur,
             resolved_purchase_id,
@@ -2433,6 +2528,174 @@ def public_cancel(
             path="/",
         )
     return response
+
+
+def _serialize_refund_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    """Public-facing view of a refund_request row."""
+    return {
+        "id": request.get("id"),
+        "purchase_id": request.get("purchase_id"),
+        "ticket_ids": list(request.get("ticket_ids") or []),
+        "amount_requested": (
+            float(request["amount_requested"])
+            if request.get("amount_requested") is not None
+            else None
+        ),
+        "amount_refunded": (
+            float(request["amount_refunded"])
+            if request.get("amount_refunded") is not None
+            else None
+        ),
+        "currency": request.get("currency") or "UAH",
+        "status": request.get("status"),
+        "requested_at": request.get("requested_at"),
+        "requested_by": request.get("requested_by"),
+        "reason": request.get("reason"),
+        "processed_at": request.get("processed_at"),
+        "failure_reason": request.get("failure_reason"),
+    }
+
+
+def _ticket_ids_for_purchase(cur, purchase_id: int) -> list[int]:
+    cur.execute(
+        "SELECT id FROM ticket WHERE purchase_id = %s ORDER BY id",
+        (purchase_id,),
+    )
+    return [int(r[0]) for r in cur.fetchall()]
+
+
+def _compute_refund_amount_for_tickets(
+    cur, purchase_id: int, ticket_ids: Sequence[int]
+) -> float:
+    """Sum the ticket value for the requested ticket subset.
+
+    Reuses :func:`_plan_cancel` so the pricing rules stay identical between the
+    cancel and refund-request flows (base fare + 10% baggage surcharge).
+    """
+    if not ticket_ids:
+        return 0.0
+    _plans, delta = _plan_cancel(cur, purchase_id, list(ticket_ids), lock_tickets=False)
+    # _plan_cancel returns a negative delta (money out of the purchase).
+    return round(abs(delta), 2)
+
+
+@router.post("/purchase/{purchase_id}/refund-request")
+def create_refund_request(
+    purchase_id: int,
+    data: RefundRequestCreate,
+    request: Request,
+    background_tasks: BackgroundTasks,
+) -> Mapping[str, Any]:
+    session, _ticket_id, resolved_purchase_id, _cookie = _require_purchase_context(
+        request, purchase_id, "refund_request"
+    )
+
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        refund_service.ensure_schema(cur)
+
+        cur.execute(
+            "SELECT status FROM purchase WHERE id = %s FOR UPDATE",
+            (resolved_purchase_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Purchase not found")
+        status = str(row[0] or "")
+
+        if status == "reserved":
+            raise HTTPException(
+                status_code=409,
+                detail="Purchase is reserved; use /cancel to release the booking",
+            )
+        if status != "paid":
+            raise HTTPException(
+                status_code=409,
+                detail=f"Refund requests require a paid purchase (current status: {status})",
+            )
+
+        # Idempotency: if an active request already exists, return it as-is.
+        existing = refund_service.find_active_request(cur, resolved_purchase_id)
+        if existing:
+            conn.commit()
+            return jsonable_encoder(_serialize_refund_request(existing))
+
+        available_ticket_ids = _ticket_ids_for_purchase(cur, resolved_purchase_id)
+        requested_ticket_ids = list(data.ticket_ids or [])
+
+        if requested_ticket_ids:
+            invalid = [t for t in requested_ticket_ids if t not in available_ticket_ids]
+            if invalid:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Tickets {invalid} do not belong to this purchase",
+                )
+        else:
+            requested_ticket_ids = list(available_ticket_ids)
+
+        if not requested_ticket_ids:
+            raise HTTPException(status_code=400, detail="Purchase has no tickets to refund")
+
+        amount_requested = _compute_refund_amount_for_tickets(
+            cur, resolved_purchase_id, requested_ticket_ids
+        )
+
+        currency = "UAH"
+        created = refund_service.create_request(
+            cur,
+            purchase_id=resolved_purchase_id,
+            ticket_ids=requested_ticket_ids,
+            amount_requested=amount_requested,
+            currency=currency,
+            requested_by="customer",
+            reason=data.reason,
+        )
+
+        _log_sale(
+            cur,
+            resolved_purchase_id,
+            "refund_requested",
+            0,
+            actor=session.jti,
+        )
+
+        refund_service.queue_requested_notification(
+            background_tasks, cur, resolved_purchase_id, created, "customer"
+        )
+
+        conn.commit()
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:  # pragma: no cover - defensive
+        conn.rollback()
+        raise HTTPException(status_code=500, detail=str(exc))
+    finally:
+        cur.close()
+        conn.close()
+
+    return jsonable_encoder(_serialize_refund_request(created))
+
+
+@router.get("/purchase/{purchase_id}/refund-request")
+def get_active_refund_request(purchase_id: int, request: Request) -> Mapping[str, Any]:
+    session, _ticket_id, resolved_purchase_id, _cookie = _require_purchase_context(
+        request, purchase_id, "refund_request_view"
+    )
+
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        refund_service.ensure_schema(cur)
+        active = refund_service.find_active_request(cur, resolved_purchase_id)
+    finally:
+        cur.close()
+        conn.close()
+
+    if not active:
+        return jsonable_encoder({"request": None})
+    return jsonable_encoder({"request": _serialize_refund_request(active)})
 
 
 __all__ = ["router", "session_router"]

--- a/backend/routers/refund_admin.py
+++ b/backend/routers/refund_admin.py
@@ -1,0 +1,662 @@
+"""Admin endpoints for the refund-request workflow.
+
+The public side only creates refund requests. All processing — calling LiqPay,
+issuing the CheckBox refund receipt, freeing seats and writing sales log
+entries — runs through here under admin auth.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Mapping, Optional, Sequence
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from ..auth import require_admin_token
+from ..database import get_connection
+from ..services import liqpay, refund as refund_service, telegram
+from ..services import checkbox as checkbox_service
+from ..services import link_sessions
+from ..ticket_utils import free_ticket
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/admin/refund-requests",
+    tags=["admin_refund_requests"],
+    dependencies=[Depends(require_admin_token)],
+)
+
+purchase_router = APIRouter(
+    prefix="/admin/purchases",
+    tags=["admin_refund_requests"],
+    dependencies=[Depends(require_admin_token)],
+)
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class RefundRequestRow(BaseModel):
+    id: int
+    purchase_id: int
+    ticket_ids: list[int]
+    amount_requested: Optional[float]
+    amount_refunded: Optional[float]
+    currency: str
+    status: str
+    requested_at: Optional[str]
+    requested_by: str
+    reason: Optional[str]
+    admin_actor: Optional[str]
+    processed_at: Optional[str]
+    failure_reason: Optional[str]
+    customer_name: Optional[str] = None
+    customer_email: Optional[str] = None
+
+
+class RefundRequestDetail(BaseModel):
+    request: RefundRequestRow
+    tickets: list[dict[str, Any]]
+    remaining: float
+    paid_amount: float
+    payment_method: Optional[str]
+    liqpay_order_id: Optional[str]
+
+
+class ProcessRequest(BaseModel):
+    ticket_ids: list[int] = Field(default_factory=list)
+    refund_amount: float = Field(..., gt=0)
+    void_fiscal: bool = True
+    comment: Optional[str] = Field(default=None, max_length=500)
+
+
+class RejectRequest(BaseModel):
+    reason: Optional[str] = Field(default=None, max_length=500)
+
+
+class PartialRefundRequest(BaseModel):
+    ticket_ids: list[int] = Field(..., min_length=1)
+    refund_amount: float = Field(..., gt=0)
+    void_fiscal: bool = True
+    reason: Optional[str] = Field(default=None, max_length=500)
+    comment: Optional[str] = Field(default=None, max_length=500)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _serialize_request(row: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "id": row.get("id"),
+        "purchase_id": row.get("purchase_id"),
+        "ticket_ids": list(row.get("ticket_ids") or []),
+        "amount_requested": (
+            float(row["amount_requested"]) if row.get("amount_requested") is not None else None
+        ),
+        "amount_refunded": (
+            float(row["amount_refunded"]) if row.get("amount_refunded") is not None else None
+        ),
+        "currency": row.get("currency") or "UAH",
+        "status": row.get("status"),
+        "requested_at": (
+            row["requested_at"].isoformat() if row.get("requested_at") else None
+        ),
+        "requested_by": row.get("requested_by"),
+        "reason": row.get("reason"),
+        "admin_actor": row.get("admin_actor"),
+        "processed_at": (
+            row["processed_at"].isoformat() if row.get("processed_at") else None
+        ),
+        "failure_reason": row.get("failure_reason"),
+    }
+
+
+def _resolve_admin_actor(request: Request) -> str:
+    """Best-effort actor label for audit fields."""
+    actor = getattr(request.state, "actor", None) or getattr(request.state, "jti", None)
+    return str(actor) if actor else "admin"
+
+
+def _load_purchase_for_refund(cur, purchase_id: int) -> dict[str, Any]:
+    cur.execute(
+        """
+        SELECT id, status, customer_name, customer_email, payment_method,
+               liqpay_order_id
+          FROM purchase
+         WHERE id = %s
+         FOR UPDATE
+        """,
+        (purchase_id,),
+    )
+    row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Purchase not found")
+    return {
+        "id": int(row[0]),
+        "status": row[1],
+        "customer_name": row[2],
+        "customer_email": row[3],
+        "payment_method": row[4],
+        "liqpay_order_id": row[5],
+    }
+
+
+def _active_ticket_ids(cur, purchase_id: int) -> list[int]:
+    cur.execute(
+        "SELECT id FROM ticket WHERE purchase_id = %s ORDER BY id",
+        (purchase_id,),
+    )
+    return [int(r[0]) for r in cur.fetchall()]
+
+
+def _log_sale(
+    cur,
+    purchase_id: int,
+    category: str,
+    amount: float,
+    *,
+    actor: str | None,
+    method: str | None,
+) -> None:
+    cur.execute(
+        "INSERT INTO sales (purchase_id, category, amount, actor, method) VALUES (%s,%s,%s,%s,%s)",
+        (purchase_id, category, amount, actor or "admin", method),
+    )
+
+
+# ---------------------------------------------------------------------------
+# List & detail
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=list[RefundRequestRow])
+@router.get("/", response_model=list[RefundRequestRow])
+def list_refund_requests(status: Optional[str] = Query(None)):
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        refund_service.ensure_schema(cur)
+        rows = refund_service.list_requests(cur, status=status)
+        out: list[dict[str, Any]] = []
+        for row in rows:
+            entry = _serialize_request(row)
+            # Attach customer info to make the list usable without a per-row join.
+            cur.execute(
+                "SELECT customer_name, customer_email FROM purchase WHERE id = %s",
+                (row.get("purchase_id"),),
+            )
+            cust_row = cur.fetchone()
+            if cust_row:
+                entry["customer_name"] = cust_row[0]
+                entry["customer_email"] = cust_row[1]
+            out.append(entry)
+        return out
+    finally:
+        cur.close()
+        conn.close()
+
+
+@router.get("/{request_id}", response_model=RefundRequestDetail)
+def get_refund_request(request_id: int):
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        refund_service.ensure_schema(cur)
+        row = refund_service.get_request(cur, request_id)
+        if not row:
+            raise HTTPException(status_code=404, detail="Refund request not found")
+
+        purchase_id = int(row["purchase_id"])
+        cur.execute(
+            """
+            SELECT id, status, customer_name, customer_email, payment_method,
+                   liqpay_order_id
+              FROM purchase
+             WHERE id = %s
+            """,
+            (purchase_id,),
+        )
+        purchase_row = cur.fetchone()
+        payment_method = purchase_row[4] if purchase_row else None
+        liqpay_order_id = purchase_row[5] if purchase_row else None
+
+        cur.execute(
+            """
+            SELECT t.id, s.seat_num, p.name, t.extra_baggage,
+                   COALESCE(dep.stop_ua, dep.stop_name),
+                   COALESCE(arr.stop_ua, arr.stop_name),
+                   tr.date
+              FROM ticket t
+              LEFT JOIN seat s ON s.id = t.seat_id
+              LEFT JOIN passenger p ON p.id = t.passenger_id
+              LEFT JOIN tour tr ON tr.id = t.tour_id
+              LEFT JOIN stop dep ON dep.id = t.departure_stop_id
+              LEFT JOIN stop arr ON arr.id = t.arrival_stop_id
+             WHERE t.purchase_id = %s
+             ORDER BY t.id
+            """,
+            (purchase_id,),
+        )
+        tickets = [
+            {
+                "id": int(t[0]),
+                "seat_num": t[1],
+                "passenger_name": t[2],
+                "extra_baggage": int(t[3] or 0),
+                "from_stop_name": t[4],
+                "to_stop_name": t[5],
+                "tour_date": t[6].isoformat() if t[6] else None,
+            }
+            for t in cur.fetchall()
+        ]
+
+        paid_amount = refund_service.compute_paid_amount(cur, purchase_id)
+        remaining = round(
+            paid_amount - refund_service.compute_completed_refunds(cur, purchase_id), 2
+        )
+
+        entry = _serialize_request(row)
+        if purchase_row:
+            entry["customer_name"] = purchase_row[2]
+            entry["customer_email"] = purchase_row[3]
+
+        return {
+            "request": entry,
+            "tickets": tickets,
+            "remaining": remaining,
+            "paid_amount": round(paid_amount, 2),
+            "payment_method": payment_method,
+            "liqpay_order_id": liqpay_order_id,
+        }
+    finally:
+        cur.close()
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Core refund processing
+# ---------------------------------------------------------------------------
+
+
+def _execute_refund(
+    request_id: int,
+    *,
+    actor: str,
+    ticket_ids: Sequence[int],
+    refund_amount: float,
+    void_fiscal: bool,
+    comment: str | None,
+    background_tasks: BackgroundTasks | None,
+) -> dict[str, Any]:
+    """Execute the full refund flow for an existing pending request.
+
+    Steps (in order):
+      1. mark request as processing
+      2. call LiqPay refund_payment (online refund)
+      3. optionally create CheckBox refund receipt
+      4. release seats, void open returns, write sales log
+      5. close purchase status if fully refunded
+      6. mark request completed; schedule Telegram completion notification
+    """
+    conn = get_connection()
+    cur = conn.cursor()
+    purchase_snapshot: dict[str, Any] = {}
+    completed_request: dict[str, Any] = {}
+    try:
+        refund_service.ensure_schema(cur)
+        request_row = refund_service.get_request(cur, request_id, for_update=True)
+        if not request_row:
+            raise HTTPException(status_code=404, detail="Refund request not found")
+
+        if request_row.get("status") not in {"pending"}:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Refund request is not pending (status={request_row.get('status')})",
+            )
+
+        purchase = _load_purchase_for_refund(cur, int(request_row["purchase_id"]))
+        if purchase["status"] not in {"paid"}:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Purchase is not paid (status={purchase['status']})",
+            )
+
+        if not purchase.get("liqpay_order_id"):
+            raise HTTPException(
+                status_code=409,
+                detail="Purchase has no LiqPay order id; offline payments must use the manual refund flow",
+            )
+
+        active_tickets = set(_active_ticket_ids(cur, purchase["id"]))
+        ticket_ids_list = list(ticket_ids)
+        invalid = [t for t in ticket_ids_list if t not in active_tickets]
+        if invalid:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Tickets {invalid} are not active on this purchase",
+            )
+
+        remaining = refund_service.compute_remaining(cur, purchase["id"])
+        if refund_amount - remaining > 0.005:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Refund amount {refund_amount} exceeds remaining {remaining}",
+            )
+
+        refund_service.mark_processing(cur, request_id)
+        # Commit the processing flip immediately so the row is visibly locked
+        # even if the external API hangs.
+        conn.commit()
+
+        purchase_snapshot = {
+            "id": purchase["id"],
+            "customer_name": purchase["customer_name"],
+            "customer_email": purchase["customer_email"],
+        }
+
+        # ---- LiqPay refund call (outside any DB transaction) ----
+        try:
+            liqpay_result = liqpay.refund_payment(
+                purchase["liqpay_order_id"],
+                refund_amount,
+                comment or f"Refund for purchase #{purchase['id']}",
+            )
+        except Exception as exc:
+            error = f"LiqPay refund failed: {exc}"
+            logger.exception("LiqPay refund failed for request=%s", request_id)
+            _record_failure(request_id, error)
+            refund_service.queue_failed_notification(
+                background_tasks, purchase_snapshot, request_row, error
+            )
+            raise HTTPException(status_code=502, detail=error) from exc
+
+        if not liqpay.is_refund_success(liqpay_result.get("status")):
+            error = f"LiqPay refund rejected: status={liqpay_result.get('status')}"
+            _record_failure(request_id, error, liqpay_response=liqpay_result.get("raw"))
+            refund_service.queue_failed_notification(
+                background_tasks, purchase_snapshot, request_row, error
+            )
+            raise HTTPException(status_code=502, detail=error)
+
+        # ---- Fiscal refund receipt (optional) ----
+        fiscal_receipt_id: str | None = None
+        fiscal_receipt_number: str | None = None
+        fiscal_status: str | None = None
+        if void_fiscal and checkbox_service.is_enabled():
+            try:
+                fiscal = checkbox_service.create_refund_receipt(
+                    purchase["id"], ticket_ids_list or None, refund_amount
+                )
+                fiscal_receipt_id = fiscal.get("receipt_id")
+                fiscal_receipt_number = fiscal.get("fiscal_number")
+                fiscal_status = fiscal.get("status") or "done"
+            except Exception as exc:
+                error = f"CheckBox refund failed: {exc}"
+                logger.exception("CheckBox refund failed for request=%s", request_id)
+                _record_failure(
+                    request_id,
+                    error,
+                    liqpay_refund_id=liqpay_result.get("payment_id"),
+                    liqpay_response=liqpay_result.get("raw"),
+                )
+                refund_service.queue_failed_notification(
+                    background_tasks, purchase_snapshot, request_row, error
+                )
+                raise HTTPException(status_code=502, detail=error) from exc
+
+        # ---- Apply seat & purchase changes inside a fresh DB transaction ----
+        cur2 = conn.cursor()
+        try:
+            for ticket_id in ticket_ids_list:
+                free_ticket(cur2, ticket_id)
+                link_sessions.revoke_ticket_sessions(ticket_id, conn=conn)
+
+            # Did we wipe out all remaining tickets?
+            cur2.execute(
+                "SELECT COUNT(*) FROM ticket WHERE purchase_id = %s",
+                (purchase["id"],),
+            )
+            count_row = cur2.fetchone()
+            remaining_tickets = int(count_row[0]) if count_row else 0
+
+            new_total_refunded = round(
+                refund_service.compute_completed_refunds(cur2, purchase["id"])
+                + refund_amount,
+                2,
+            )
+            paid_total = round(refund_service.compute_paid_amount(cur2, purchase["id"]), 2)
+            is_full_refund = (
+                remaining_tickets == 0
+                and abs(new_total_refunded - paid_total) <= 0.005
+            )
+
+            sale_category = "refunded" if is_full_refund else "part_refund"
+            _log_sale(
+                cur2,
+                purchase["id"],
+                sale_category,
+                -refund_amount,
+                actor=actor,
+                method="liqpay",
+            )
+
+            if is_full_refund:
+                cur2.execute(
+                    "UPDATE purchase SET status='refunded', update_at=NOW() WHERE id=%s",
+                    (purchase["id"],),
+                )
+                cur2.execute(
+                    "UPDATE open_ticket SET status='cancelled' "
+                    "WHERE purchase_id=%s AND status='open'",
+                    (purchase["id"],),
+                )
+
+            refund_service.mark_completed(
+                cur2,
+                request_id,
+                amount_refunded=refund_amount,
+                liqpay_refund_id=liqpay_result.get("payment_id"),
+                liqpay_response=liqpay_result.get("raw"),
+                fiscal_receipt_id=fiscal_receipt_id,
+                fiscal_receipt_number=fiscal_receipt_number,
+                fiscal_status=fiscal_status,
+            )
+            conn.commit()
+        finally:
+            cur2.close()
+
+        completed_request = refund_service.get_request(cur, request_id) or {}
+        refund_service.queue_completed_notification(
+            background_tasks, purchase_snapshot, completed_request
+        )
+
+        return _serialize_request(completed_request)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        conn.rollback()
+        logger.exception("Unhandled error processing refund request=%s", request_id)
+        raise HTTPException(status_code=500, detail=str(exc))
+    finally:
+        cur.close()
+        conn.close()
+
+
+def _record_failure(
+    request_id: int,
+    error: str,
+    *,
+    liqpay_refund_id: str | None = None,
+    liqpay_response: Mapping[str, Any] | None = None,
+) -> None:
+    """Persist a failure on a dedicated connection so it survives rollbacks."""
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        if liqpay_refund_id or liqpay_response is not None:
+            import json
+
+            cur.execute(
+                """
+                UPDATE refund_request
+                   SET liqpay_refund_id = COALESCE(%s, liqpay_refund_id),
+                       liqpay_response  = COALESCE(%s::jsonb, liqpay_response)
+                 WHERE id = %s
+                """,
+                (
+                    liqpay_refund_id,
+                    json.dumps(dict(liqpay_response)) if liqpay_response else None,
+                    request_id,
+                ),
+            )
+        refund_service.mark_failed(cur, request_id, error)
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        logger.exception("Failed to persist refund failure for request=%s", request_id)
+    finally:
+        cur.close()
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{request_id}/process")
+def process_refund_request(
+    request_id: int,
+    data: ProcessRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
+):
+    actor = _resolve_admin_actor(request)
+    return _execute_refund(
+        request_id,
+        actor=actor,
+        ticket_ids=data.ticket_ids,
+        refund_amount=round(float(data.refund_amount), 2),
+        void_fiscal=data.void_fiscal,
+        comment=data.comment,
+        background_tasks=background_tasks,
+    )
+
+
+@router.post("/{request_id}/reject")
+def reject_refund_request(
+    request_id: int,
+    data: RejectRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
+):
+    actor = _resolve_admin_actor(request)
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        refund_service.ensure_schema(cur)
+        row = refund_service.get_request(cur, request_id, for_update=True)
+        if not row:
+            raise HTTPException(status_code=404, detail="Refund request not found")
+        if row.get("status") != "pending":
+            raise HTTPException(
+                status_code=409,
+                detail=f"Cannot reject a {row.get('status')} request",
+            )
+        refund_service.mark_rejected(
+            cur, request_id, admin_actor=actor, reason=data.reason
+        )
+        conn.commit()
+        rejected = refund_service.get_request(cur, request_id) or {}
+        return _serialize_request(rejected)
+    except HTTPException:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+
+@purchase_router.post("/{purchase_id}/partial-refund")
+def admin_initiated_partial_refund(
+    purchase_id: int,
+    data: PartialRefundRequest,
+    request: Request,
+    background_tasks: BackgroundTasks,
+):
+    """Admin shortcut: create a refund request and immediately process it.
+
+    Used when the customer didn't open a request themselves — e.g. when a call
+    centre operator initiates the refund manually.
+    """
+    actor = _resolve_admin_actor(request)
+    conn = get_connection()
+    cur = conn.cursor()
+    request_id: int | None = None
+    try:
+        refund_service.ensure_schema(cur)
+        cur.execute(
+            "SELECT status FROM purchase WHERE id = %s FOR UPDATE",
+            (purchase_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Purchase not found")
+        if str(row[0] or "") != "paid":
+            raise HTTPException(
+                status_code=409,
+                detail=f"Only paid purchases can be refunded (status={row[0]})",
+            )
+
+        existing = refund_service.find_active_request(cur, purchase_id)
+        if existing:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Active refund request already exists (id={existing['id']})",
+            )
+
+        created = refund_service.create_request(
+            cur,
+            purchase_id=purchase_id,
+            ticket_ids=data.ticket_ids,
+            amount_requested=round(float(data.refund_amount), 2),
+            currency="UAH",
+            requested_by="admin",
+            reason=data.reason,
+            admin_actor=actor,
+        )
+        request_id = int(created["id"])
+        _log_sale(cur, purchase_id, "refund_requested", 0, actor=actor, method=None)
+
+        refund_service.queue_requested_notification(
+            background_tasks, cur, purchase_id, created, "admin"
+        )
+        conn.commit()
+    except HTTPException:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+        conn.close()
+
+    if request_id is None:  # pragma: no cover - safeguarded above
+        raise HTTPException(status_code=500, detail="Failed to create refund request")
+
+    return _execute_refund(
+        request_id,
+        actor=actor,
+        ticket_ids=data.ticket_ids,
+        refund_amount=round(float(data.refund_amount), 2),
+        void_fiscal=data.void_fiscal,
+        comment=data.comment,
+        background_tasks=background_tasks,
+    )
+
+
+__all__ = ["router", "purchase_router"]

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -9,6 +9,7 @@ import logging
 import os
 import time
 import threading
+from decimal import Decimal
 from typing import Any
 
 import httpx
@@ -269,6 +270,211 @@ def _poll_receipt(receipt_id: str) -> dict[str, Any]:
 def get_receipt_png_url(receipt_id: str) -> str:
     """Return URL for the receipt PNG image."""
     return f"{_api_url()}/api/v1/receipts/{receipt_id}/png"
+
+
+# ---------------------------------------------------------------------------
+# Refund receipts
+# ---------------------------------------------------------------------------
+
+def _load_refund_items_for_tickets(
+    cur, purchase_id: int, ticket_ids: list[int]
+) -> tuple[list[dict[str, Any]], int]:
+    """Build CheckBox refund goods entries from the listed tickets.
+
+    Mirrors the structure of ``_load_purchase_receipt_items`` but limited to a
+    subset of tickets — used when an admin issues a partial refund.
+    """
+    if not ticket_ids:
+        return [], 0
+
+    cur.execute(
+        """
+        SELECT
+            t.id,
+            t.extra_baggage,
+            COALESCE(dep.stop_ua, dep.stop_name) AS departure_name,
+            COALESCE(arr.stop_ua, arr.stop_name) AS arrival_name,
+            p.price
+        FROM ticket t
+        JOIN tour tr ON tr.id = t.tour_id
+        JOIN stop dep ON dep.id = t.departure_stop_id
+        JOIN stop arr ON arr.id = t.arrival_stop_id
+        JOIN prices p ON p.departure_stop_id = t.departure_stop_id
+                     AND p.arrival_stop_id = t.arrival_stop_id
+                     AND p.pricelist_id = tr.pricelist_id
+        WHERE t.purchase_id = %s
+          AND t.id = ANY(%s)
+        ORDER BY t.id
+        """,
+        (purchase_id, list(ticket_ids)),
+    )
+    rows = cur.fetchall() or []
+
+    items: list[dict[str, Any]] = []
+    total_kopecks = 0
+    for ticket_id, extra_baggage, dep_name, arr_name, base_price in rows:
+        price_kopecks = int(round(float(base_price) * 100))
+        items.append({
+            "good": {
+                "code": str(ticket_id),
+                "name": f"Повернення: квиток {dep_name} – {arr_name}",
+                "price": price_kopecks,
+            },
+            "quantity": 1000,
+        })
+        total_kopecks += price_kopecks
+
+        extra_bag = int(extra_baggage or 0)
+        if extra_bag > 0:
+            baggage_price_kopecks = int(round(float(base_price) * 0.1 * extra_bag * 100))
+            items.append({
+                "good": {
+                    "code": f"{ticket_id}-bag",
+                    "name": "Повернення: додатковий багаж",
+                    "price": baggage_price_kopecks,
+                },
+                "quantity": 1000,
+            })
+            total_kopecks += baggage_price_kopecks
+
+    return items, total_kopecks
+
+
+def _flat_refund_items(purchase_id: int, amount_kopecks: int) -> list[dict[str, Any]]:
+    """Single-line refund position used when no ticket list is supplied."""
+    return [
+        {
+            "good": {
+                "code": f"refund-{purchase_id}",
+                "name": f"Повернення коштів за замовлення #{purchase_id}",
+                "price": amount_kopecks,
+            },
+            "quantity": 1000,
+        }
+    ]
+
+
+def _create_refund_receipt_request(
+    items: list[dict[str, Any]],
+    amount_kopecks: int,
+    *,
+    related_receipt_id: str | None = None,
+) -> str:
+    """Post a refund (return) receipt to CheckBox and return the receipt id."""
+    license_key = _env("CHECKBOX_LICENSE_KEY")
+    headers = {**_auth_headers()}
+    if license_key:
+        headers["X-License-Key"] = license_key
+
+    body: dict[str, Any] = {
+        "goods": items,
+        "payments": [
+            {
+                "type": "CASHLESS",
+                "value": amount_kopecks,
+            }
+        ],
+    }
+    if related_receipt_id:
+        body["related_receipt_id"] = related_receipt_id
+
+    resp = httpx.post(
+        f"{_api_url()}/api/v1/receipts/service",
+        json=body,
+        headers=headers,
+        timeout=30.0,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    receipt_id = data.get("id")
+    if not receipt_id:
+        raise RuntimeError("CheckBox refund receipt creation did not return id")
+    logger.info("CheckBox refund receipt %s created", receipt_id)
+    return receipt_id
+
+
+def create_refund_receipt(
+    purchase_id: int,
+    ticket_ids: list[int] | None,
+    amount: Decimal | float,
+) -> dict[str, Any]:
+    """Create a fiscal refund receipt for the given purchase/tickets.
+
+    Each call produces a fresh fiscal document with its own number — partial
+    refunds therefore get an independent receipt per call. When ``ticket_ids``
+    is empty/None the receipt carries a single aggregate refund line for the
+    requested amount.
+
+    Returns ``{receipt_id, fiscal_number, status}``.
+    """
+    amount_kopecks = int(round(float(amount) * 100))
+    if amount_kopecks <= 0:
+        raise ValueError("refund amount must be positive")
+
+    if not is_enabled():
+        raise RuntimeError("CheckBox is disabled")
+
+    from ..database import get_connection
+
+    related_receipt_id: str | None = None
+    items: list[dict[str, Any]]
+
+    conn = get_connection()
+    cur = conn.cursor()
+    try:
+        if _purchase_has_column(cur, "checkbox_receipt_id"):
+            cur.execute(
+                "SELECT checkbox_receipt_id FROM purchase WHERE id = %s",
+                (purchase_id,),
+            )
+            row = cur.fetchone()
+            if row and row[0]:
+                related_receipt_id = str(row[0])
+
+        if ticket_ids:
+            items, items_kopecks = _load_refund_items_for_tickets(cur, purchase_id, list(ticket_ids))
+            if not items:
+                items = _flat_refund_items(purchase_id, amount_kopecks)
+                items_kopecks = amount_kopecks
+        else:
+            items = _flat_refund_items(purchase_id, amount_kopecks)
+            items_kopecks = amount_kopecks
+    finally:
+        cur.close()
+        conn.close()
+
+    # Use the explicit amount as the source of truth (admin can override the
+    # ticket-aggregate). Items are informational; payments line drives the
+    # fiscal total.
+    _ensure_shift()
+    receipt_id = _create_refund_receipt_request(
+        items,
+        amount_kopecks,
+        related_receipt_id=related_receipt_id,
+    )
+
+    try:
+        receipt_data = _poll_receipt(receipt_id)
+    except Exception:
+        # The receipt was accepted but did not reach DONE in time. Surface the
+        # id so the caller can persist it and retry status polling later.
+        return {
+            "receipt_id": receipt_id,
+            "fiscal_number": None,
+            "status": "pending",
+        }
+
+    fiscal_number = (
+        receipt_data.get("fiscal_code")
+        or receipt_data.get("fiscal_number")
+        or receipt_data.get("number")
+    )
+
+    return {
+        "receipt_id": receipt_id,
+        "fiscal_number": str(fiscal_number) if fiscal_number else None,
+        "status": "done",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/liqpay.py
+++ b/backend/services/liqpay.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import os
 from datetime import date
+from decimal import Decimal
 from typing import Any, Mapping, Sequence
 
 import httpx
@@ -11,6 +12,7 @@ from ..utils.client_app import build_liqpay_result_url, build_liqpay_server_url
 
 
 LIQPAY_CHECKOUT_URL = "https://www.liqpay.ua/api/3/checkout"
+LIQPAY_API_URL = "https://www.liqpay.ua/api/request"
 
 
 def _env(key: str, default: str) -> str:
@@ -142,6 +144,76 @@ def build_purchase_description(cur, purchase_id: int) -> str | None:
 def verify_signature(data: str, signature: str) -> bool:
     expected_signature = sign(data)
     return expected_signature == signature
+
+
+def refund_payment(
+    order_id: str,
+    amount: Decimal | float,
+    comment: str | None = None,
+) -> dict[str, Any]:
+    """Issue a (partial or full) refund through LiqPay.
+
+    Returns a normalized dict ``{status, payment_id, refund_amount, raw}``.
+    The LiqPay endpoint expects action=refund and the same order_id used at
+    payment time. Partial refunds are supported by passing a smaller amount.
+    """
+
+    order_value = (order_id or "").strip()
+    if not order_value:
+        raise ValueError("order_id is required")
+
+    amount_value = round(float(amount), 2)
+    if amount_value <= 0:
+        raise ValueError("refund amount must be positive")
+
+    payload: dict[str, Any] = {
+        "version": "3",
+        "public_key": _env("LIQPAY_PUBLIC_KEY", "sandbox"),
+        "action": "refund",
+        "amount": amount_value,
+        "order_id": order_value,
+    }
+    if comment:
+        payload["description"] = comment[:255]
+
+    data, signature = encode_payload(payload)
+
+    timeout = float(os.getenv("LIQPAY_REFUND_TIMEOUT_S", "15"))
+    response = httpx.post(
+        LIQPAY_API_URL,
+        data={"data": data, "signature": signature},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+
+    body = response.json()
+    if not isinstance(body, Mapping):
+        raise ValueError("Unexpected LiqPay refund response")
+
+    raw_status = str(body.get("status") or "").lower()
+    payment_id = body.get("payment_id")
+    refund_amount_raw = (
+        body.get("refund_amount")
+        or body.get("amount_refund")
+        or body.get("amount")
+        or amount_value
+    )
+    try:
+        refund_amount = float(refund_amount_raw)
+    except (TypeError, ValueError):
+        refund_amount = amount_value
+
+    return {
+        "status": raw_status,
+        "payment_id": str(payment_id) if payment_id is not None else None,
+        "refund_amount": refund_amount,
+        "raw": dict(body),
+    }
+
+
+def is_refund_success(status: str | None) -> bool:
+    """LiqPay statuses that mean the refund landed at the bank side."""
+    return (status or "").lower() in {"success", "ok", "sandbox", "reversed"}
 
 
 def verify_order(order_id: str) -> Mapping[str, Any]:

--- a/backend/services/refund.py
+++ b/backend/services/refund.py
@@ -1,0 +1,388 @@
+"""Shared helpers for the refund-request workflow.
+
+Both the public router (where customers create requests) and the admin router
+(where staff process them) need consistent rules around:
+  * locating the active pending request for a purchase
+  * computing the remaining refundable balance
+  * scheduling Telegram notifications
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Mapping, Sequence
+
+from fastapi import BackgroundTasks
+
+from . import telegram
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema bootstrap (mirrors what 025_refund_requests.sql declares — included
+# here so the table is present when the migration has not been applied yet
+# and so tests using fresh dbs don't need to apply migrations manually).
+# ---------------------------------------------------------------------------
+
+def ensure_schema(cur) -> None:
+    """Create the refund_request table on demand. Safe to call repeatedly."""
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS refund_request (
+            id                     SERIAL PRIMARY KEY,
+            purchase_id            INTEGER NOT NULL REFERENCES purchase(id),
+            ticket_ids             INTEGER[] NOT NULL DEFAULT '{}',
+            amount_requested       NUMERIC(12,2),
+            amount_refunded        NUMERIC(12,2),
+            currency               TEXT DEFAULT 'UAH',
+            status                 TEXT NOT NULL DEFAULT 'pending',
+            requested_at           TIMESTAMP NOT NULL DEFAULT NOW(),
+            requested_by           TEXT NOT NULL,
+            reason                 TEXT,
+            admin_actor            TEXT,
+            processed_at           TIMESTAMP,
+            liqpay_refund_id       TEXT,
+            liqpay_response        JSONB,
+            fiscal_receipt_id      TEXT,
+            fiscal_receipt_number  TEXT,
+            fiscal_status          TEXT,
+            failure_reason         TEXT
+        )
+        """
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_refund_request_status ON refund_request(status)"
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_refund_request_purchase ON refund_request(purchase_id)"
+    )
+    cur.execute(
+        "ALTER TABLE purchase ADD COLUMN IF NOT EXISTS refund_requested_at TIMESTAMP"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Read helpers
+# ---------------------------------------------------------------------------
+
+_REQUEST_COLUMNS = (
+    "id, purchase_id, ticket_ids, amount_requested, amount_refunded, currency, "
+    "status, requested_at, requested_by, reason, admin_actor, processed_at, "
+    "liqpay_refund_id, liqpay_response, fiscal_receipt_id, fiscal_receipt_number, "
+    "fiscal_status, failure_reason"
+)
+
+
+def _row_to_request(row: Sequence[Any]) -> dict[str, Any]:
+    keys = [
+        "id",
+        "purchase_id",
+        "ticket_ids",
+        "amount_requested",
+        "amount_refunded",
+        "currency",
+        "status",
+        "requested_at",
+        "requested_by",
+        "reason",
+        "admin_actor",
+        "processed_at",
+        "liqpay_refund_id",
+        "liqpay_response",
+        "fiscal_receipt_id",
+        "fiscal_receipt_number",
+        "fiscal_status",
+        "failure_reason",
+    ]
+    return dict(zip(keys, row))
+
+
+def find_active_request(cur, purchase_id: int) -> dict[str, Any] | None:
+    """Return the most recent pending/processing request for a purchase, if any."""
+    cur.execute(
+        f"""
+        SELECT {_REQUEST_COLUMNS}
+          FROM refund_request
+         WHERE purchase_id = %s AND status IN ('pending', 'processing')
+         ORDER BY requested_at DESC, id DESC
+         LIMIT 1
+        """,
+        (purchase_id,),
+    )
+    row = cur.fetchone()
+    return _row_to_request(row) if row else None
+
+
+def get_request(cur, request_id: int, *, for_update: bool = False) -> dict[str, Any] | None:
+    query = f"SELECT {_REQUEST_COLUMNS} FROM refund_request WHERE id = %s"
+    if for_update:
+        query += " FOR UPDATE"
+    cur.execute(query, (request_id,))
+    row = cur.fetchone()
+    return _row_to_request(row) if row else None
+
+
+def list_requests(cur, *, status: str | None = None) -> list[dict[str, Any]]:
+    if status:
+        cur.execute(
+            f"""
+            SELECT {_REQUEST_COLUMNS}
+              FROM refund_request
+             WHERE status = %s
+             ORDER BY requested_at DESC, id DESC
+            """,
+            (status,),
+        )
+    else:
+        cur.execute(
+            f"""
+            SELECT {_REQUEST_COLUMNS}
+              FROM refund_request
+             ORDER BY requested_at DESC, id DESC
+            """,
+        )
+    return [_row_to_request(row) for row in cur.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# Money helpers
+# ---------------------------------------------------------------------------
+
+def compute_paid_amount(cur, purchase_id: int) -> float:
+    """Total amount the customer has paid for the purchase.
+
+    Derived from the sales log because the purchase row has no dedicated
+    ``paid_amount`` column. We sum positive ``paid`` entries.
+    """
+    cur.execute(
+        """
+        SELECT COALESCE(SUM(amount), 0)
+          FROM sales
+         WHERE purchase_id = %s AND category = 'paid'
+        """,
+        (purchase_id,),
+    )
+    row = cur.fetchone()
+    return float(row[0]) if row and row[0] is not None else 0.0
+
+
+def compute_completed_refunds(cur, purchase_id: int) -> float:
+    """Total amount already refunded for the purchase (completed requests)."""
+    cur.execute(
+        """
+        SELECT COALESCE(SUM(amount_refunded), 0)
+          FROM refund_request
+         WHERE purchase_id = %s AND status = 'completed'
+        """,
+        (purchase_id,),
+    )
+    row = cur.fetchone()
+    return float(row[0]) if row and row[0] is not None else 0.0
+
+
+def compute_remaining(cur, purchase_id: int) -> float:
+    """Amount still refundable: paid − already-refunded."""
+    return round(compute_paid_amount(cur, purchase_id) - compute_completed_refunds(cur, purchase_id), 2)
+
+
+# ---------------------------------------------------------------------------
+# Request lifecycle
+# ---------------------------------------------------------------------------
+
+def create_request(
+    cur,
+    *,
+    purchase_id: int,
+    ticket_ids: Sequence[int],
+    amount_requested: float | None,
+    currency: str,
+    requested_by: str,
+    reason: str | None,
+    admin_actor: str | None = None,
+) -> dict[str, Any]:
+    cur.execute(
+        """
+        INSERT INTO refund_request (
+            purchase_id, ticket_ids, amount_requested, currency,
+            requested_by, reason, admin_actor, status
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s, 'pending')
+        RETURNING id, requested_at
+        """,
+        (
+            purchase_id,
+            list(ticket_ids),
+            amount_requested,
+            currency,
+            requested_by,
+            reason,
+            admin_actor,
+        ),
+    )
+    row = cur.fetchone()
+    request_id = int(row[0]) if row else 0
+    requested_at = row[1] if row else None
+    cur.execute(
+        "UPDATE purchase SET refund_requested_at = NOW(), update_at = NOW() WHERE id = %s",
+        (purchase_id,),
+    )
+    return {
+        "id": request_id,
+        "purchase_id": purchase_id,
+        "ticket_ids": list(ticket_ids),
+        "amount_requested": amount_requested,
+        "currency": currency,
+        "status": "pending",
+        "requested_at": requested_at,
+        "requested_by": requested_by,
+        "reason": reason,
+        "admin_actor": admin_actor,
+    }
+
+
+def mark_processing(cur, request_id: int) -> None:
+    cur.execute(
+        "UPDATE refund_request SET status='processing' WHERE id=%s",
+        (request_id,),
+    )
+
+
+def mark_completed(
+    cur,
+    request_id: int,
+    *,
+    amount_refunded: float,
+    liqpay_refund_id: str | None,
+    liqpay_response: Mapping[str, Any] | None,
+    fiscal_receipt_id: str | None,
+    fiscal_receipt_number: str | None,
+    fiscal_status: str | None,
+) -> None:
+    cur.execute(
+        """
+        UPDATE refund_request
+           SET status = 'completed',
+               amount_refunded = %s,
+               liqpay_refund_id = %s,
+               liqpay_response = %s,
+               fiscal_receipt_id = %s,
+               fiscal_receipt_number = %s,
+               fiscal_status = %s,
+               processed_at = NOW(),
+               failure_reason = NULL
+         WHERE id = %s
+        """,
+        (
+            amount_refunded,
+            liqpay_refund_id,
+            json.dumps(dict(liqpay_response)) if liqpay_response else None,
+            fiscal_receipt_id,
+            fiscal_receipt_number,
+            fiscal_status,
+            request_id,
+        ),
+    )
+
+
+def mark_failed(cur, request_id: int, failure_reason: str) -> None:
+    cur.execute(
+        """
+        UPDATE refund_request
+           SET status = 'failed',
+               failure_reason = %s,
+               processed_at = NOW()
+         WHERE id = %s
+        """,
+        (failure_reason[:500], request_id),
+    )
+
+
+def mark_rejected(cur, request_id: int, *, admin_actor: str | None, reason: str | None) -> None:
+    cur.execute(
+        """
+        UPDATE refund_request
+           SET status = 'rejected',
+               admin_actor = COALESCE(%s, admin_actor),
+               failure_reason = %s,
+               processed_at = NOW()
+         WHERE id = %s
+        """,
+        (admin_actor, reason, request_id),
+    )
+
+
+def find_by_liqpay_refund_id(cur, liqpay_refund_id: str) -> dict[str, Any] | None:
+    cur.execute(
+        f"SELECT {_REQUEST_COLUMNS} FROM refund_request WHERE liqpay_refund_id = %s LIMIT 1",
+        (liqpay_refund_id,),
+    )
+    row = cur.fetchone()
+    return _row_to_request(row) if row else None
+
+
+# ---------------------------------------------------------------------------
+# Notification scheduling
+# ---------------------------------------------------------------------------
+
+def _load_purchase_snapshot(cur, purchase_id: int) -> dict[str, Any]:
+    cur.execute(
+        """
+        SELECT id, customer_name, customer_email, customer_phone, amount_due, status
+          FROM purchase
+         WHERE id = %s
+        """,
+        (purchase_id,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return {"id": purchase_id}
+    return {
+        "id": int(row[0]),
+        "customer_name": row[1],
+        "customer_email": row[2],
+        "customer_phone": row[3],
+        "amount_due": float(row[4]) if row[4] is not None else None,
+        "status": row[5],
+    }
+
+
+def queue_requested_notification(
+    background_tasks: BackgroundTasks | None,
+    cur,
+    purchase_id: int,
+    request: Mapping[str, Any],
+    requester: str,
+) -> None:
+    if not background_tasks or not telegram.is_enabled():
+        return
+    snapshot = _load_purchase_snapshot(cur, purchase_id)
+    request_snapshot = dict(request)
+    background_tasks.add_task(
+        telegram.notify_refund_requested, snapshot, request_snapshot, requester
+    )
+
+
+def queue_completed_notification(
+    background_tasks: BackgroundTasks | None,
+    purchase_snapshot: Mapping[str, Any],
+    request: Mapping[str, Any],
+) -> None:
+    if not background_tasks or not telegram.is_enabled():
+        return
+    background_tasks.add_task(
+        telegram.notify_refund_completed, dict(purchase_snapshot), dict(request)
+    )
+
+
+def queue_failed_notification(
+    background_tasks: BackgroundTasks | None,
+    purchase_snapshot: Mapping[str, Any],
+    request: Mapping[str, Any],
+    error: str,
+) -> None:
+    if not background_tasks or not telegram.is_enabled():
+        return
+    background_tasks.add_task(
+        telegram.notify_refund_failed, dict(purchase_snapshot), dict(request), error
+    )

--- a/backend/services/telegram.py
+++ b/backend/services/telegram.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import html
 import logging
 import os
 import time
-from typing import Optional
+from typing import Any, Mapping, Optional
 
 import httpx
 
@@ -86,3 +87,106 @@ def send_message(text: str, parse_mode: Optional[str] = "HTML") -> bool:
         return False
 
     return False
+
+
+# ---------------------------------------------------------------------------
+# Refund event notifications
+# ---------------------------------------------------------------------------
+
+def _escape(value: Any) -> str:
+    if value is None:
+        return ""
+    return html.escape(str(value), quote=False)
+
+
+def _format_amount(amount: Any, currency: str = "UAH") -> str:
+    try:
+        return f"{float(amount):.2f} {currency}"
+    except (TypeError, ValueError):
+        return f"{amount} {currency}"
+
+
+def _purchase_summary(purchase: Mapping[str, Any]) -> str:
+    pid = purchase.get("id") or purchase.get("purchase_id")
+    name = purchase.get("customer_name") or "—"
+    email = purchase.get("customer_email") or "—"
+    parts = [
+        f"Замовлення: <b>#{_escape(pid)}</b>",
+        f"Клієнт: {_escape(name)} ({_escape(email)})",
+    ]
+    return "\n".join(parts)
+
+
+def _request_summary(request: Mapping[str, Any]) -> list[str]:
+    lines: list[str] = []
+    ticket_ids = request.get("ticket_ids") or []
+    if ticket_ids:
+        lines.append(f"Квитки: {', '.join(str(t) for t in ticket_ids)}")
+    amount_requested = request.get("amount_requested")
+    if amount_requested is not None:
+        currency = request.get("currency") or "UAH"
+        lines.append(f"Сума заявки: {_format_amount(amount_requested, currency)}")
+    reason = request.get("reason")
+    if reason:
+        lines.append(f"Причина: {_escape(reason)}")
+    return lines
+
+
+def notify_refund_requested(
+    purchase: Mapping[str, Any],
+    request: Mapping[str, Any],
+    requester: str,
+) -> bool:
+    """Notify staff that a refund request was created (by customer or admin)."""
+    if not is_enabled():
+        return False
+    header = (
+        "🔁 <b>Нова заявка на повернення</b>"
+        if (requester or "").lower() != "admin"
+        else "🔁 <b>Адміністратор створив заявку на повернення</b>"
+    )
+    lines = [header, _purchase_summary(purchase), *_request_summary(request)]
+    return send_message("\n".join(lines))
+
+
+def notify_refund_completed(
+    purchase: Mapping[str, Any],
+    request: Mapping[str, Any],
+) -> bool:
+    """Notify staff that a refund was processed end-to-end (LiqPay + fiscal)."""
+    if not is_enabled():
+        return False
+    currency = request.get("currency") or "UAH"
+    amount_refunded = request.get("amount_refunded") or request.get("amount_requested")
+    lines = [
+        "✅ <b>Повернення завершено</b>",
+        _purchase_summary(purchase),
+        f"Повернуто: <b>{_format_amount(amount_refunded, currency)}</b>",
+    ]
+    liqpay_id = request.get("liqpay_refund_id")
+    if liqpay_id:
+        lines.append(f"LiqPay: {_escape(liqpay_id)}")
+    fiscal = request.get("fiscal_receipt_number") or request.get("fiscal_receipt_id")
+    if fiscal:
+        lines.append(f"Фіскальний чек: {_escape(fiscal)}")
+    return send_message("\n".join(lines))
+
+
+def notify_refund_failed(
+    purchase: Mapping[str, Any],
+    request: Mapping[str, Any],
+    error: str | None,
+) -> bool:
+    """Notify staff that a refund processing attempt failed."""
+    if not is_enabled():
+        return False
+    lines = [
+        "❌ <b>Помилка повернення</b>",
+        _purchase_summary(purchase),
+    ]
+    request_id = request.get("id")
+    if request_id is not None:
+        lines.append(f"Заявка: #{_escape(request_id)}")
+    if error:
+        lines.append(f"Причина: {_escape(error)[:500]}")
+    return send_message("\n".join(lines))

--- a/db/migrations/025_refund_requests.sql
+++ b/db/migrations/025_refund_requests.sql
@@ -1,0 +1,36 @@
+-- Refund requests: tracks customer- or admin-initiated refunds against paid
+-- purchases. One row per refund event (partial or full) capturing LiqPay
+-- processing state and the linked CheckBox refund receipt.
+
+-- Extend sales_category enum with 'refund_requested' so we can log the moment
+-- a customer/admin creates a refund request (amount=0, audit entry only).
+ALTER TYPE sales_category ADD VALUE IF NOT EXISTS 'refund_requested';
+
+CREATE TABLE IF NOT EXISTS public.refund_request (
+    id                     SERIAL PRIMARY KEY,
+    purchase_id            INTEGER NOT NULL REFERENCES public.purchase(id),
+    ticket_ids             INTEGER[] NOT NULL DEFAULT '{}',
+    amount_requested       NUMERIC(12,2),
+    amount_refunded        NUMERIC(12,2),
+    currency               TEXT DEFAULT 'UAH',
+    -- pending | processing | completed | failed | rejected
+    status                 TEXT NOT NULL DEFAULT 'pending',
+    requested_at           TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- 'customer' | 'admin'
+    requested_by           TEXT NOT NULL,
+    reason                 TEXT,
+    admin_actor            TEXT,
+    processed_at           TIMESTAMP,
+    liqpay_refund_id       TEXT,
+    liqpay_response        JSONB,
+    fiscal_receipt_id      TEXT,
+    fiscal_receipt_number  TEXT,
+    -- pending | sent | done | failed
+    fiscal_status          TEXT,
+    failure_reason         TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_refund_request_status   ON public.refund_request(status);
+CREATE INDEX IF NOT EXISTS idx_refund_request_purchase ON public.refund_request(purchase_id);
+
+ALTER TABLE public.purchase ADD COLUMN IF NOT EXISTS refund_requested_at TIMESTAMP;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,6 +9,7 @@ import ToursPage from "./pages/ToursPage";
 import ReportPage from "./pages/ReportPage";
 import LoginPage from "./pages/LoginPage";
 import PurchasesPage from "./pages/PurchasesPage";
+import RefundRequestsPage from "./pages/RefundRequestsPage";
 import { ToastProvider } from "./components/Toast";
 import { useToast } from "./components/Toast";
 
@@ -85,6 +86,9 @@ function App() {
             </NavLink>
           </li>
           <li>
+            <RefundRequestsNavLink />
+          </li>
+          <li>
             <button className="btn btn--ghost btn--sm" onClick={handleLogout}>Logout</button>
           </li>
         </ul>
@@ -98,10 +102,58 @@ function App() {
           <Route path="/report" element={<ReportPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/purchases" element={<PurchasesPage />} />
+          <Route path="/refund-requests" element={<RefundRequestsPage />} />
         </Routes>
       </div>
     </Router>
     </ToastProvider>
+  );
+}
+
+function RefundRequestsNavLink() {
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      axios
+        .get("/admin/refund-requests/", { params: { status: "pending" } })
+        .then((res) => {
+          if (!cancelled) setPendingCount((res.data || []).length);
+        })
+        .catch(() => {
+          if (!cancelled) setPendingCount(0);
+        });
+    };
+    load();
+    const id = setInterval(load, 60000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  return (
+    <NavLink
+      to="/refund-requests"
+      className={({ isActive }) => (isActive ? "active" : undefined)}
+    >
+      Refunds
+      {pendingCount > 0 && (
+        <span
+          style={{
+            marginLeft: 6,
+            background: "#d4a000",
+            color: "#fff",
+            borderRadius: 10,
+            padding: "1px 7px",
+            fontSize: 12,
+          }}
+        >
+          {pendingCount}
+        </span>
+      )}
+    </NavLink>
   );
 }
 

--- a/frontend/src/pages/RefundRequestsPage.js
+++ b/frontend/src/pages/RefundRequestsPage.js
@@ -1,0 +1,393 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import { API } from "../config";
+
+const formatDateTime = (date) => {
+  if (!date) return "—";
+  const d = new Date(date);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString("ru-RU", { timeZone: "Europe/Sofia", hour12: false });
+};
+
+const formatMoney = (amount, currency = "UAH") => {
+  if (amount === null || amount === undefined) return "—";
+  const num = Number(amount);
+  if (Number.isNaN(num)) return "—";
+  return `${num.toFixed(2)} ${currency}`;
+};
+
+const statusLabel = {
+  pending: "Ожидает",
+  processing: "В обработке",
+  completed: "Завершено",
+  failed: "Ошибка",
+  rejected: "Отклонено",
+};
+
+export default function RefundRequestsPage() {
+  useEffect(() => {
+    document.title = "Заявки на возврат";
+  }, []);
+
+  const [requests, setRequests] = useState([]);
+  const [filter, setFilter] = useState("pending");
+  const [selectedId, setSelectedId] = useState(null);
+  const [detail, setDetail] = useState(null);
+  const [detailError, setDetailError] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(null);
+  const [selectedTickets, setSelectedTickets] = useState({});
+  const [refundAmount, setRefundAmount] = useState("");
+  const [voidFiscal, setVoidFiscal] = useState(true);
+  const [comment, setComment] = useState("");
+  const [rejectReason, setRejectReason] = useState("");
+
+  const loadList = useCallback(() => {
+    const params = {};
+    if (filter) params.status = filter;
+    axios
+      .get(`${API}/admin/refund-requests/`, { params })
+      .then((res) => {
+        setRequests(res.data || []);
+        setError(null);
+      })
+      .catch((err) => {
+        console.error(err);
+        setError("Не удалось загрузить заявки");
+      });
+  }, [filter]);
+
+  useEffect(() => {
+    loadList();
+  }, [loadList]);
+
+  const loadDetail = useCallback((id) => {
+    if (id == null) {
+      setDetail(null);
+      return;
+    }
+    setDetailError(null);
+    axios
+      .get(`${API}/admin/refund-requests/${id}`)
+      .then((res) => {
+        setDetail(res.data);
+        const ticketIds = (res.data?.request?.ticket_ids || []);
+        const sel = {};
+        (res.data?.tickets || []).forEach((t) => {
+          sel[t.id] = ticketIds.includes(t.id);
+        });
+        setSelectedTickets(sel);
+        setRefundAmount(
+          res.data?.request?.amount_requested != null
+            ? String(res.data.request.amount_requested)
+            : ""
+        );
+        setVoidFiscal(true);
+        setComment("");
+        setRejectReason("");
+      })
+      .catch((err) => {
+        console.error(err);
+        setDetailError("Не удалось загрузить детали заявки");
+        setDetail(null);
+      });
+  }, []);
+
+  useEffect(() => {
+    loadDetail(selectedId);
+  }, [selectedId, loadDetail]);
+
+  const handleToggleTicket = (ticketId) => {
+    setSelectedTickets((prev) => ({ ...prev, [ticketId]: !prev[ticketId] }));
+  };
+
+  const selectedTicketIds = useMemo(
+    () => Object.entries(selectedTickets).filter(([, v]) => v).map(([k]) => Number(k)),
+    [selectedTickets]
+  );
+
+  useEffect(() => {
+    // Auto-recompute refund amount from selected tickets when admin toggles.
+    if (!detail) return;
+    const tickets = detail.tickets || [];
+    if (selectedTicketIds.length === 0) return;
+    if (
+      detail.request?.amount_requested != null
+      && selectedTicketIds.length === (detail.request.ticket_ids || []).length
+      && selectedTicketIds.every((id) => (detail.request.ticket_ids || []).includes(id))
+    ) {
+      // Match original request — leave the field as-is.
+      return;
+    }
+    const total = tickets
+      .filter((t) => selectedTicketIds.includes(t.id))
+      .reduce((acc, t) => {
+        const extra = Number(t.extra_baggage || 0);
+        return acc + 0; // server is the source of truth; admin can override
+      }, 0);
+    if (total > 0) {
+      setRefundAmount(String(total.toFixed(2)));
+    }
+  }, [selectedTicketIds, detail]);
+
+  const handleProcess = () => {
+    if (!selectedId) return;
+    if (!refundAmount || Number(refundAmount) <= 0) {
+      setError("Введите сумму возврата");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    axios
+      .post(`${API}/admin/refund-requests/${selectedId}/process`, {
+        ticket_ids: selectedTicketIds,
+        refund_amount: Number(refundAmount),
+        void_fiscal: voidFiscal,
+        comment: comment || null,
+      })
+      .then(() => {
+        loadList();
+        loadDetail(selectedId);
+      })
+      .catch((err) => {
+        console.error(err);
+        const msg = err?.response?.data?.detail || "Не удалось обработать возврат";
+        setError(String(msg));
+      })
+      .finally(() => setBusy(false));
+  };
+
+  const handleReject = () => {
+    if (!selectedId) return;
+    setBusy(true);
+    setError(null);
+    axios
+      .post(`${API}/admin/refund-requests/${selectedId}/reject`, {
+        reason: rejectReason || null,
+      })
+      .then(() => {
+        loadList();
+        loadDetail(selectedId);
+      })
+      .catch((err) => {
+        console.error(err);
+        const msg = err?.response?.data?.detail || "Не удалось отклонить заявку";
+        setError(String(msg));
+      })
+      .finally(() => setBusy(false));
+  };
+
+  const pendingCount = requests.filter((r) => r.status === "pending").length;
+  const request = detail?.request;
+  const isPending = request?.status === "pending";
+
+  return (
+    <div style={{ padding: 16 }}>
+      <h2>Заявки на возврат {pendingCount > 0 && <span style={{ background: "#d4a000", color: "#fff", borderRadius: 12, padding: "2px 8px", fontSize: 14 }}>{pendingCount}</span>}</h2>
+
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        {["pending", "processing", "completed", "failed", "rejected", ""].map((s) => (
+          <button
+            key={s || "all"}
+            className="btn btn--sm"
+            onClick={() => { setFilter(s); setSelectedId(null); }}
+            style={{
+              fontWeight: filter === s ? 700 : 400,
+              textDecoration: filter === s ? "underline" : "none",
+            }}
+          >
+            {s ? (statusLabel[s] || s) : "Все"}
+          </button>
+        ))}
+      </div>
+
+      {error && <div style={{ color: "red", marginBottom: 8 }}>{error}</div>}
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
+        <div>
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>#</th>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Заказ</th>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Клиент</th>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Билеты</th>
+                <th style={{ textAlign: "right", borderBottom: "1px solid #ccc" }}>Сумма</th>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Статус</th>
+                <th style={{ textAlign: "left", borderBottom: "1px solid #ccc" }}>Дата</th>
+              </tr>
+            </thead>
+            <tbody>
+              {requests.length === 0 && (
+                <tr>
+                  <td colSpan="7" style={{ padding: 16, textAlign: "center", color: "#888" }}>
+                    Нет заявок
+                  </td>
+                </tr>
+              )}
+              {requests.map((r) => (
+                <tr
+                  key={r.id}
+                  onClick={() => setSelectedId(r.id)}
+                  style={{
+                    cursor: "pointer",
+                    background: r.id === selectedId ? "#f0f7ff" : "transparent",
+                  }}
+                >
+                  <td>{r.id}</td>
+                  <td>#{r.purchase_id}</td>
+                  <td>
+                    {r.customer_name || "—"}
+                    <br />
+                    <small style={{ color: "#666" }}>{r.customer_email || ""}</small>
+                  </td>
+                  <td>{(r.ticket_ids || []).join(", ") || "все"}</td>
+                  <td style={{ textAlign: "right" }}>
+                    {formatMoney(r.amount_requested, r.currency)}
+                  </td>
+                  <td>{statusLabel[r.status] || r.status}</td>
+                  <td>{formatDateTime(r.requested_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div>
+          {!detail && (
+            <div style={{ color: "#888" }}>
+              {detailError || "Выберите заявку слева"}
+            </div>
+          )}
+          {detail && (
+            <div>
+              <h3>Заявка #{request.id}</h3>
+              <div>Заказ: #{detail.request.purchase_id}</div>
+              <div>Клиент: {request.customer_name || "—"} ({request.customer_email || "—"})</div>
+              <div>Способ оплаты: {detail.payment_method || "—"}</div>
+              <div>Оплачено всего: {formatMoney(detail.paid_amount)}</div>
+              <div>
+                <strong>Осталось доступно к возврату: {formatMoney(detail.remaining)}</strong>
+              </div>
+              {request.reason && (
+                <div style={{ marginTop: 8 }}>
+                  <em>Причина клиента:</em> {request.reason}
+                </div>
+              )}
+
+              <h4 style={{ marginTop: 16 }}>Билеты</h4>
+              <table style={{ width: "100%", borderCollapse: "collapse" }}>
+                <thead>
+                  <tr>
+                    <th></th>
+                    <th>#</th>
+                    <th>Пассажир</th>
+                    <th>Откуда</th>
+                    <th>Куда</th>
+                    <th>Дата</th>
+                    <th>Место</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(detail.tickets || []).map((t) => (
+                    <tr key={t.id}>
+                      <td>
+                        <input
+                          type="checkbox"
+                          checked={!!selectedTickets[t.id]}
+                          disabled={!isPending}
+                          onChange={() => handleToggleTicket(t.id)}
+                        />
+                      </td>
+                      <td>{t.id}</td>
+                      <td>{t.passenger_name || "—"}</td>
+                      <td>{t.from_stop_name || "—"}</td>
+                      <td>{t.to_stop_name || "—"}</td>
+                      <td>{t.tour_date || "—"}</td>
+                      <td>{t.seat_num ?? "—"}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              {isPending ? (
+                <div style={{ marginTop: 16, display: "grid", gap: 8 }}>
+                  <label>
+                    Сумма возврата:&nbsp;
+                    <input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={refundAmount}
+                      onChange={(e) => setRefundAmount(e.target.value)}
+                      style={{ width: 120 }}
+                    />
+                  </label>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={voidFiscal}
+                      onChange={(e) => setVoidFiscal(e.target.checked)}
+                    />
+                    &nbsp;Оформить фискальный возврат (CheckBox)
+                  </label>
+                  <label>
+                    Комментарий:&nbsp;
+                    <input
+                      type="text"
+                      value={comment}
+                      onChange={(e) => setComment(e.target.value)}
+                      style={{ width: 320 }}
+                    />
+                  </label>
+                  <div style={{ display: "flex", gap: 8 }}>
+                    <button
+                      className="btn btn--primary"
+                      onClick={handleProcess}
+                      disabled={
+                        busy
+                        || !detail.liqpay_order_id
+                        || selectedTicketIds.length === 0
+                      }
+                      title={!detail.liqpay_order_id ? "Только для оплат через LiqPay" : ""}
+                    >
+                      {busy ? "Обработка..." : "Вернуть через LiqPay"}
+                    </button>
+                    {request.requested_by === "customer" && (
+                      <>
+                        <input
+                          type="text"
+                          placeholder="Причина отказа"
+                          value={rejectReason}
+                          onChange={(e) => setRejectReason(e.target.value)}
+                          style={{ width: 220 }}
+                        />
+                        <button
+                          className="btn btn--ghost"
+                          onClick={handleReject}
+                          disabled={busy}
+                        >
+                          Отклонить заявку
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div style={{ marginTop: 16, color: "#666" }}>
+                  Заявка в статусе <strong>{statusLabel[request.status] || request.status}</strong>.
+                  {request.amount_refunded != null && (
+                    <div>Возвращено: {formatMoney(request.amount_refunded, request.currency)}</div>
+                  )}
+                  {request.failure_reason && (
+                    <div style={{ color: "red" }}>Ошибка: {request.failure_reason}</div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/test_checkbox_refund.py
+++ b/tests/test_checkbox_refund.py
@@ -1,0 +1,136 @@
+"""Tests for CheckBox refund-receipt creation."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Mapping
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.services import checkbox
+
+
+class _FakeResponse:
+    def __init__(self, body: Mapping[str, Any], status_code: int = 200) -> None:
+        self._body = body
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> Mapping[str, Any]:
+        return self._body
+
+
+class _DummyCursor:
+    def __init__(self) -> None:
+        self.last_query: str = ""
+        self.last_params: Any = None
+
+    def execute(self, query: str, params: Any = None) -> None:
+        self.last_query = query
+        self.last_params = params
+
+    def fetchone(self):
+        if "checkbox_receipt_id" in self.last_query:
+            return ("RECEIPT-PREV",)
+        if "information_schema" in self.last_query:
+            return (1,)
+        return None
+
+    def fetchall(self):
+        return []
+
+    def close(self) -> None:
+        pass
+
+
+class _DummyConn:
+    autocommit = False
+
+    def cursor(self):
+        return _DummyCursor()
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("CHECKBOX_ENABLED", "true")
+    monkeypatch.setenv("CHECKBOX_CASHIER_PIN", "1234")
+    # Block the real DB driver before backend.database is first imported.
+    monkeypatch.setattr("psycopg2.connect", lambda *a, **k: _DummyConn())
+
+    # The refund function does ``from ..database import get_connection`` lazily,
+    # so once that module is loaded we can swap the helper itself.
+    import importlib
+    db_module = importlib.import_module("backend.database")
+    monkeypatch.setattr(db_module, "get_connection", lambda: _DummyConn())
+
+    # Bypass token/shift orchestration so we can focus on the refund call.
+    monkeypatch.setattr(
+        "backend.services.checkbox._auth_headers", lambda: {"Authorization": "Bearer test"}
+    )
+    monkeypatch.setattr("backend.services.checkbox._ensure_shift", lambda: "SHIFT-1")
+    yield
+
+
+def _install_post(monkeypatch, body):
+    calls: list[dict[str, Any]] = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append({"url": url, "json": json, "headers": headers})
+        return _FakeResponse(body)
+
+    monkeypatch.setattr("backend.services.checkbox.httpx.post", fake_post)
+    return calls
+
+
+def _install_get(monkeypatch, body):
+    def fake_get(url, headers=None, timeout=None):
+        return _FakeResponse(body)
+
+    monkeypatch.setattr("backend.services.checkbox.httpx.get", fake_get)
+
+
+def test_create_refund_receipt_for_flat_amount(monkeypatch):
+    calls = _install_post(monkeypatch, {"id": "RFND-1"})
+    _install_get(monkeypatch, {"status": "DONE", "fiscal_code": "FC-RFND-1"})
+
+    result = checkbox.create_refund_receipt(100, None, 150.0)
+
+    assert result == {
+        "receipt_id": "RFND-1",
+        "fiscal_number": "FC-RFND-1",
+        "status": "done",
+    }
+    assert calls and calls[0]["url"].endswith("/receipts/service")
+    body = calls[0]["json"]
+    assert body["payments"][0]["value"] == 15000  # 150.00 -> kopecks
+    # Single flat refund position
+    assert len(body["goods"]) == 1
+    assert "Повернення" in body["goods"][0]["good"]["name"]
+    # Should reference the original purchase receipt when one is on file.
+    assert body.get("related_receipt_id") == "RECEIPT-PREV"
+
+
+def test_create_refund_receipt_rejects_disabled(monkeypatch):
+    monkeypatch.setenv("CHECKBOX_ENABLED", "false")
+    with pytest.raises(RuntimeError):
+        checkbox.create_refund_receipt(1, None, 10.0)
+
+
+def test_create_refund_receipt_rejects_zero_amount():
+    with pytest.raises(ValueError):
+        checkbox.create_refund_receipt(1, None, 0)

--- a/tests/test_liqpay_refund.py
+++ b/tests/test_liqpay_refund.py
@@ -1,0 +1,92 @@
+"""Tests for the LiqPay refund helper."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Mapping
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.services import liqpay
+
+
+class _FakeResponse:
+    def __init__(self, body: Mapping[str, Any], status_code: int = 200) -> None:
+        self._body = body
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> Mapping[str, Any]:
+        return self._body
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("LIQPAY_PUBLIC_KEY", "pub")
+    monkeypatch.setenv("LIQPAY_PRIVATE_KEY", "priv")
+    yield
+
+
+def test_refund_payment_partial_amount_posts_action_refund(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_post(url, data=None, timeout=None):
+        captured["url"] = url
+        captured["data"] = data
+        captured["timeout"] = timeout
+        return _FakeResponse(
+            {
+                "status": "success",
+                "payment_id": "999",
+                "refund_amount": 250.0,
+            }
+        )
+
+    monkeypatch.setattr("backend.services.liqpay.httpx.post", fake_post)
+
+    result = liqpay.refund_payment("purchase-42", 250.0, "Partial refund")
+
+    assert result["status"] == "success"
+    assert result["payment_id"] == "999"
+    assert result["refund_amount"] == 250.0
+    assert isinstance(result["raw"], dict)
+
+    assert captured["url"] == liqpay.LIQPAY_API_URL
+    assert "data" in captured["data"] and "signature" in captured["data"]
+
+
+def test_refund_payment_full_amount_decodes_payload(monkeypatch):
+    decoded_payloads = []
+
+    def fake_post(url, data=None, timeout=None):
+        decoded_payloads.append(liqpay.decode_payload(data["data"]))
+        return _FakeResponse({"status": "success", "payment_id": "1", "amount": 1500.0})
+
+    monkeypatch.setattr("backend.services.liqpay.httpx.post", fake_post)
+
+    liqpay.refund_payment("purchase-7", 1500.00)
+
+    assert decoded_payloads[0]["action"] == "refund"
+    assert decoded_payloads[0]["amount"] == 1500.0
+    assert decoded_payloads[0]["order_id"] == "purchase-7"
+
+
+def test_refund_payment_rejects_invalid_amount():
+    with pytest.raises(ValueError):
+        liqpay.refund_payment("purchase-1", 0)
+    with pytest.raises(ValueError):
+        liqpay.refund_payment("", 50.0)
+
+
+def test_is_refund_success_recognizes_known_statuses():
+    assert liqpay.is_refund_success("success")
+    assert liqpay.is_refund_success("ok")
+    assert liqpay.is_refund_success("sandbox")
+    assert not liqpay.is_refund_success("failure")
+    assert not liqpay.is_refund_success(None)

--- a/tests/test_refund_flow.py
+++ b/tests/test_refund_flow.py
@@ -1,0 +1,310 @@
+"""Integration-style tests for the refund-request workflow.
+
+These exercise the helper layer in ``backend.services.refund`` with a small
+in-memory cursor that emulates just enough SQL behaviour to drive the
+state machine: paid amount → multiple partial refunds → completion.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime
+from typing import Any, Sequence
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.services import refund
+
+
+class FakeDB:
+    """Minimal in-memory store keyed by purchase_id, sales rows, refund rows."""
+
+    def __init__(self) -> None:
+        self.purchases: dict[int, dict[str, Any]] = {}
+        self.sales: list[dict[str, Any]] = []
+        self.refunds: list[dict[str, Any]] = []
+        self._next_refund_id = 1
+
+    def seed_purchase(self, purchase_id: int, *, paid_amount: float) -> None:
+        self.purchases[purchase_id] = {
+            "id": purchase_id,
+            "status": "paid",
+            "customer_name": "Test User",
+            "customer_email": "test@example.com",
+            "amount_due": 0.0,
+        }
+        self.sales.append({
+            "purchase_id": purchase_id,
+            "category": "paid",
+            "amount": paid_amount,
+        })
+
+
+class FakeCursor:
+    def __init__(self, db: FakeDB) -> None:
+        self.db = db
+        self._last_query = ""
+        self._last_params: Any = None
+        self._results: list[Any] = []
+
+    def execute(self, query: str, params: Any = None) -> None:
+        self._last_query = " ".join(query.split())
+        self._last_params = params or ()
+        q = self._last_query.lower()
+        self._results = []
+
+        if q.startswith("create table") or q.startswith("create index") or q.startswith("alter table"):
+            return
+
+        if q.startswith("select coalesce(sum(amount), 0) from sales"):
+            purchase_id = params[0]
+            total = sum(
+                float(s["amount"])
+                for s in self.db.sales
+                if s["purchase_id"] == purchase_id and s["category"] == "paid"
+            )
+            self._results = [(total,)]
+            return
+
+        if q.startswith("select coalesce(sum(amount_refunded), 0) from refund_request"):
+            purchase_id = params[0]
+            total = sum(
+                float(r.get("amount_refunded") or 0)
+                for r in self.db.refunds
+                if r["purchase_id"] == purchase_id and r["status"] == "completed"
+            )
+            self._results = [(total,)]
+            return
+
+        if q.startswith("insert into refund_request"):
+            (
+                purchase_id,
+                ticket_ids,
+                amount_requested,
+                currency,
+                requested_by,
+                reason,
+                admin_actor,
+            ) = params
+            row = {
+                "id": self.db._next_refund_id,
+                "purchase_id": purchase_id,
+                "ticket_ids": list(ticket_ids),
+                "amount_requested": amount_requested,
+                "amount_refunded": None,
+                "currency": currency,
+                "status": "pending",
+                "requested_at": datetime.utcnow(),
+                "requested_by": requested_by,
+                "reason": reason,
+                "admin_actor": admin_actor,
+                "processed_at": None,
+                "liqpay_refund_id": None,
+                "liqpay_response": None,
+                "fiscal_receipt_id": None,
+                "fiscal_receipt_number": None,
+                "fiscal_status": None,
+                "failure_reason": None,
+            }
+            self.db.refunds.append(row)
+            self.db._next_refund_id += 1
+            self._results = [(row["id"], row["requested_at"])]
+            return
+
+        if q.startswith("update purchase set refund_requested_at"):
+            return
+
+        if q.startswith("select id, purchase_id, ticket_ids") and "where purchase_id" in q and "status in" in q:
+            purchase_id = params[0]
+            candidates = [
+                r for r in self.db.refunds
+                if r["purchase_id"] == purchase_id and r["status"] in {"pending", "processing"}
+            ]
+            self._results = [_row_tuple(c) for c in candidates]
+            return
+
+        if q.startswith("select id, purchase_id, ticket_ids") and "where id =" in q:
+            request_id = params[0]
+            matches = [r for r in self.db.refunds if r["id"] == request_id]
+            self._results = [_row_tuple(m) for m in matches]
+            return
+
+        if q.startswith("update refund_request set status='processing'"):
+            request_id = params[0]
+            for r in self.db.refunds:
+                if r["id"] == request_id:
+                    r["status"] = "processing"
+            return
+
+        if q.startswith("update refund_request set status = 'completed'"):
+            (
+                amount_refunded,
+                liqpay_refund_id,
+                liqpay_response,
+                fiscal_receipt_id,
+                fiscal_receipt_number,
+                fiscal_status,
+                request_id,
+            ) = params
+            for r in self.db.refunds:
+                if r["id"] == request_id:
+                    r["status"] = "completed"
+                    r["amount_refunded"] = amount_refunded
+                    r["liqpay_refund_id"] = liqpay_refund_id
+                    r["liqpay_response"] = liqpay_response
+                    r["fiscal_receipt_id"] = fiscal_receipt_id
+                    r["fiscal_receipt_number"] = fiscal_receipt_number
+                    r["fiscal_status"] = fiscal_status
+                    r["processed_at"] = datetime.utcnow()
+                    r["failure_reason"] = None
+            return
+
+        if q.startswith("update refund_request set status = 'failed'"):
+            failure_reason, request_id = params
+            for r in self.db.refunds:
+                if r["id"] == request_id:
+                    r["status"] = "failed"
+                    r["failure_reason"] = failure_reason
+                    r["processed_at"] = datetime.utcnow()
+            return
+
+        if q.startswith("update refund_request set status = 'rejected'"):
+            admin_actor, reason, request_id = params
+            for r in self.db.refunds:
+                if r["id"] == request_id:
+                    r["status"] = "rejected"
+                    if admin_actor:
+                        r["admin_actor"] = admin_actor
+                    r["failure_reason"] = reason
+                    r["processed_at"] = datetime.utcnow()
+            return
+
+        # Anything else: noop, no results.
+        return
+
+    def fetchone(self):
+        return self._results[0] if self._results else None
+
+    def fetchall(self):
+        return list(self._results)
+
+    def close(self) -> None:
+        pass
+
+
+def _row_tuple(r: dict[str, Any]) -> tuple:
+    return (
+        r["id"], r["purchase_id"], r["ticket_ids"], r["amount_requested"],
+        r["amount_refunded"], r["currency"], r["status"], r["requested_at"],
+        r["requested_by"], r["reason"], r["admin_actor"], r["processed_at"],
+        r["liqpay_refund_id"], r["liqpay_response"], r["fiscal_receipt_id"],
+        r["fiscal_receipt_number"], r["fiscal_status"], r["failure_reason"],
+    )
+
+
+def test_remaining_after_partial_refund_then_completion():
+    db = FakeDB()
+    db.seed_purchase(42, paid_amount=1500.0)
+    cur = FakeCursor(db)
+
+    assert refund.compute_paid_amount(cur, 42) == 1500.0
+    assert refund.compute_remaining(cur, 42) == 1500.0
+
+    # Customer creates a request for 1 ticket worth 500
+    req1 = refund.create_request(
+        cur,
+        purchase_id=42,
+        ticket_ids=[101],
+        amount_requested=500.0,
+        currency="UAH",
+        requested_by="customer",
+        reason="want refund",
+    )
+    assert req1["id"] >= 1
+    assert refund.find_active_request(cur, 42)["id"] == req1["id"]
+
+    # Admin processes it — mark completed
+    refund.mark_processing(cur, req1["id"])
+    refund.mark_completed(
+        cur,
+        req1["id"],
+        amount_refunded=500.0,
+        liqpay_refund_id="LIQP-1",
+        liqpay_response={"status": "success"},
+        fiscal_receipt_id="R-1",
+        fiscal_receipt_number="FN-1",
+        fiscal_status="done",
+    )
+    assert refund.compute_completed_refunds(cur, 42) == 500.0
+    assert refund.compute_remaining(cur, 42) == 1000.0
+    assert refund.find_active_request(cur, 42) is None
+
+    # Second refund for remaining 1000
+    req2 = refund.create_request(
+        cur,
+        purchase_id=42,
+        ticket_ids=[102, 103],
+        amount_requested=1000.0,
+        currency="UAH",
+        requested_by="admin",
+        reason=None,
+        admin_actor="alice",
+    )
+    refund.mark_processing(cur, req2["id"])
+    refund.mark_completed(
+        cur,
+        req2["id"],
+        amount_refunded=1000.0,
+        liqpay_refund_id="LIQP-2",
+        liqpay_response={"status": "success"},
+        fiscal_receipt_id="R-2",
+        fiscal_receipt_number="FN-2",
+        fiscal_status="done",
+    )
+    assert refund.compute_remaining(cur, 42) == 0.0
+
+
+def test_rejected_request_does_not_count_towards_refunds():
+    db = FakeDB()
+    db.seed_purchase(7, paid_amount=200.0)
+    cur = FakeCursor(db)
+
+    req = refund.create_request(
+        cur,
+        purchase_id=7,
+        ticket_ids=[1],
+        amount_requested=200.0,
+        currency="UAH",
+        requested_by="customer",
+        reason=None,
+    )
+    refund.mark_rejected(cur, req["id"], admin_actor="bob", reason="duplicate")
+
+    assert refund.compute_completed_refunds(cur, 7) == 0.0
+    assert refund.compute_remaining(cur, 7) == 200.0
+    assert refund.find_active_request(cur, 7) is None
+
+
+def test_failed_request_keeps_remaining_intact():
+    db = FakeDB()
+    db.seed_purchase(8, paid_amount=300.0)
+    cur = FakeCursor(db)
+
+    req = refund.create_request(
+        cur,
+        purchase_id=8,
+        ticket_ids=[],
+        amount_requested=100.0,
+        currency="UAH",
+        requested_by="admin",
+        reason=None,
+        admin_actor="ops",
+    )
+    refund.mark_processing(cur, req["id"])
+    refund.mark_failed(cur, req["id"], "LiqPay timeout")
+
+    assert refund.compute_completed_refunds(cur, 8) == 0.0
+    assert refund.compute_remaining(cur, 8) == 300.0


### PR DESCRIPTION
Public side:
* New POST/GET /public/purchase/{id}/refund-request endpoints for paid purchases (idempotent on pending requests, defaults to all tickets).
* /cancel and /cancel/preview now reject paid purchases with 409 so customers go through the refund workflow.
* LiqPay callback handler now branches on action=refund and updates the matching refund_request row.

Admin side:
* New /admin/refund-requests router: list/detail/process/reject and a /admin/purchases/{id}/partial-refund shortcut for admin-initiated refunds. process step calls LiqPay, optionally creates a CheckBox refund receipt, frees seats via free_ticket, writes part_refund or refunded sales rows, and flips purchase.status when fully refunded.

Services:
* liqpay.refund_payment posts action=refund with normalized response.
* checkbox.create_refund_receipt produces one fiscal refund document per call (partial refunds get their own number).
* telegram gains notify_refund_requested/completed/failed.
* New refund service module owns the request lifecycle, remaining balance calculation (paid - completed refunds), and Telegram queueing.

Schema:
* Migration 025 adds refund_request table, indexes, refund_requested enum value, and purchase.refund_requested_at column.
* Helper ensure_schema bootstraps the table at runtime for environments that haven't applied migration 025 yet.

Frontend:
* New RefundRequestsPage with status filter, request list, ticket selection, refund amount field, void_fiscal toggle, LiqPay process button (disabled for non-LiqPay payments), and reject flow.
* Nav link with pending-count badge polled every 60s.

Tests:
* Unit tests for liqpay.refund_payment (partial/full/validation).
* Unit tests for checkbox.create_refund_receipt (flat amount path, disabled guard, validation).
* Integration test for the refund_service state machine: paid 1500 ->
  partial refund 500 -> remaining 1000 -> full refund -> remaining 0. Also covers rejected/failed branches.

https://claude.ai/code/session_01L8ySbRNbiMuALQcHGdD8yv