### PR TITLE
Fix CheckBox refund endpoint and make refund processing idempotent

### DIFF
--- a/backend/routers/refund_admin.py
+++ b/backend/routers/refund_admin.py
@@ -7,6 +7,7 @@ entries — runs through here under admin auth.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any, Mapping, Optional, Sequence
 
@@ -360,35 +361,82 @@ def _execute_refund(
             "customer_email": purchase["customer_email"],
         }
 
-        # ---- LiqPay refund call (outside any DB transaction) ----
-        try:
-            liqpay_result = liqpay.refund_payment(
-                purchase["liqpay_order_id"],
-                refund_amount,
-                comment or f"Refund for purchase #{purchase['id']}",
-            )
-        except Exception as exc:
-            error = f"LiqPay refund failed: {exc}"
-            logger.exception("LiqPay refund failed for request=%s", request_id)
-            _record_failure(request_id, error)
-            refund_service.queue_failed_notification(
-                background_tasks, purchase_snapshot, request_row, error
-            )
-            raise HTTPException(status_code=502, detail=error) from exc
+        # Idempotency guards: a previous attempt may have completed some
+        # steps before failing (e.g. LiqPay refunded but CheckBox errored).
+        # A money-moving step with a persisted id must never run twice.
+        existing_liqpay_refund_id = request_row.get("liqpay_refund_id")
+        existing_fiscal_receipt_id = request_row.get("fiscal_receipt_id")
 
-        if not liqpay.is_refund_success(liqpay_result.get("status")):
-            error = f"LiqPay refund rejected: status={liqpay_result.get('status')}"
-            _record_failure(request_id, error, liqpay_response=liqpay_result.get("raw"))
-            refund_service.queue_failed_notification(
-                background_tasks, purchase_snapshot, request_row, error
+        # ---- LiqPay refund call (outside any DB transaction) ----
+        if existing_liqpay_refund_id:
+            logger.info(
+                "LiqPay refund %s already done for request=%s, skipping",
+                existing_liqpay_refund_id,
+                request_id,
             )
-            raise HTTPException(status_code=502, detail=error)
+            liqpay_result = {
+                "status": "success",
+                "payment_id": existing_liqpay_refund_id,
+                "raw": request_row.get("liqpay_response"),
+            }
+        else:
+            try:
+                liqpay_result = liqpay.refund_payment(
+                    purchase["liqpay_order_id"],
+                    refund_amount,
+                    comment or f"Refund for purchase #{purchase['id']}",
+                )
+            except Exception as exc:
+                error = f"LiqPay refund failed: {exc}"
+                logger.exception("LiqPay refund failed for request=%s", request_id)
+                _record_failure(request_id, error)
+                refund_service.queue_failed_notification(
+                    background_tasks, purchase_snapshot, request_row, error
+                )
+                raise HTTPException(status_code=502, detail=error) from exc
+
+            if not liqpay.is_refund_success(liqpay_result.get("status")):
+                error = f"LiqPay refund rejected: status={liqpay_result.get('status')}"
+                _record_failure(request_id, error, liqpay_response=liqpay_result.get("raw"))
+                refund_service.queue_failed_notification(
+                    background_tasks, purchase_snapshot, request_row, error
+                )
+                raise HTTPException(status_code=502, detail=error)
+
+            # Persist the refund id immediately, before touching CheckBox, so
+            # a fiscal failure below cannot lead to a second LiqPay refund on
+            # retry.
+            cur.execute(
+                """
+                UPDATE refund_request
+                   SET liqpay_refund_id = %s,
+                       liqpay_response = %s
+                 WHERE id = %s
+                """,
+                (
+                    liqpay_result.get("payment_id"),
+                    json.dumps(dict(liqpay_result["raw"]))
+                    if liqpay_result.get("raw")
+                    else None,
+                    request_id,
+                ),
+            )
+            conn.commit()
 
         # ---- Fiscal refund receipt (optional) ----
         fiscal_receipt_id: str | None = None
         fiscal_receipt_number: str | None = None
         fiscal_status: str | None = None
-        if void_fiscal and checkbox_service.is_enabled():
+        if existing_fiscal_receipt_id:
+            logger.info(
+                "CheckBox refund receipt %s already created for request=%s, skipping",
+                existing_fiscal_receipt_id,
+                request_id,
+            )
+            fiscal_receipt_id = existing_fiscal_receipt_id
+            fiscal_receipt_number = request_row.get("fiscal_receipt_number")
+            fiscal_status = request_row.get("fiscal_status")
+        elif void_fiscal and checkbox_service.is_enabled():
             try:
                 fiscal = checkbox_service.create_refund_receipt(
                     purchase["id"], ticket_ids_list or None, refund_amount

--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -378,12 +378,20 @@ def _create_refund_receipt_request(
     if related_receipt_id:
         body["related_receipt_id"] = related_receipt_id
 
+    # A sell receipt with ``related_receipt_id`` is treated by CheckBox as a
+    # return receipt ("чек повернення"). The /receipts/service endpoint is for
+    # cash-drawer operations only and rejects goods/CASHLESS payments with 422.
     resp = httpx.post(
-        f"{_api_url()}/api/v1/receipts/service",
+        f"{_api_url()}/api/v1/receipts/sell",
         json=body,
         headers=headers,
         timeout=30.0,
     )
+    if resp.status_code >= 400:
+        logger.error(
+            "CheckBox refund receipt error: status=%s body=%s payload=%s",
+            resp.status_code, resp.text, body,
+        )
     resp.raise_for_status()
     data = resp.json()
     receipt_id = data.get("id")
@@ -405,7 +413,10 @@ def create_refund_receipt(
     is empty/None the receipt carries a single aggregate refund line for the
     requested amount.
 
-    Returns ``{receipt_id, fiscal_number, status}``.
+    Returns ``{receipt_id, fiscal_number, status}``. When the original sale
+    was never fiscalized (no ``checkbox_receipt_id`` on the purchase, e.g.
+    offline/admin payments) CheckBox is not called at all and the status is
+    ``not_applicable``.
     """
     amount_kopecks = int(round(float(amount) * 100))
     if amount_kopecks <= 0:
@@ -442,6 +453,16 @@ def create_refund_receipt(
     finally:
         cur.close()
         conn.close()
+
+    if not related_receipt_id:
+        # A return receipt requires the original sale receipt; without it
+        # CheckBox rejects the request, so skip fiscalization entirely.
+        logger.info(
+            "Skipping CheckBox refund receipt for purchase=%s: "
+            "original sale was not fiscalized",
+            purchase_id,
+        )
+        return {"receipt_id": None, "fiscal_number": None, "status": "not_applicable"}
 
     # Use the explicit amount as the source of truth (admin can override the
     # ticket-aggregate). Items are informational; payments line drives the

--- a/docs/runbooks/refund-request-1-recovery.md
+++ b/docs/runbooks/refund-request-1-recovery.md
@@ -1,0 +1,57 @@
+# Recovery: refund_request id=1 (purchase 64)
+
+## Background
+
+First production refund attempt (2026-06) half-completed:
+
+* LiqPay refund **succeeded** — `liqpay_refund_id=2870201631`, 3500 ₴,
+  confirmed by callback.
+* CheckBox returned **422** on `POST /api/v1/receipts/service` (wrong
+  endpoint for a return receipt), the backend answered 502 and the request
+  went to `failed`.
+* The row was manually flipped to `status=completed` via SQL as a stopgap so
+  the admin "Refund" button could not trigger a second LiqPay refund.
+
+The code fix (refund endpoint switched to `/api/v1/receipts/sell` with
+`related_receipt_id`, plus idempotent processing that skips steps with
+already-persisted ids) must be **deployed before** running this recovery.
+
+## Steps (run after deploy)
+
+```sql
+-- 1) Reset the request to pending, keeping liqpay_refund_id
+UPDATE refund_request
+SET status = 'pending',
+    processed_at = NULL,
+    failure_reason = NULL
+WHERE id = 1;
+
+-- 2) Verify liqpay_refund_id is still present
+SELECT id, status, liqpay_refund_id, fiscal_receipt_id
+FROM refund_request
+WHERE id = 1;
+```
+
+```bash
+# 3) Trigger processing — the LiqPay step is skipped thanks to the
+#    idempotency guard, CheckBox issues the return receipt ("чек повернення")
+curl -X POST http://localhost:8000/admin/refund-requests/1/process \
+  -H "Authorization: Bearer <ADMIN_JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"refund_amount": 3500, "void_fiscal": true}'
+```
+
+## Expected result
+
+* `refund_request.status = 'completed'`
+* `liqpay_refund_id = 2870201631` (unchanged — no second refund)
+* `fiscal_receipt_id` filled with the new return-receipt id
+* `fiscal_status = 'done'`
+* Backend log contains:
+  `LiqPay refund 2870201631 already done for request=1, skipping`
+
+## If CheckBox returns 422 again
+
+Do **not** tweak the request schema blindly. The response body is now logged
+(`CheckBox refund receipt error: status=... body=... payload=...`) — capture
+the `body` from the log and escalate with that exact message.

--- a/tests/test_checkbox_refund.py
+++ b/tests/test_checkbox_refund.py
@@ -115,7 +115,7 @@ def test_create_refund_receipt_for_flat_amount(monkeypatch):
         "fiscal_number": "FC-RFND-1",
         "status": "done",
     }
-    assert calls and calls[0]["url"].endswith("/receipts/service")
+    assert calls and calls[0]["url"].endswith("/receipts/sell")
     body = calls[0]["json"]
     assert body["payments"][0]["value"] == 15000  # 150.00 -> kopecks
     # Single flat refund position
@@ -123,6 +123,38 @@ def test_create_refund_receipt_for_flat_amount(monkeypatch):
     assert "Повернення" in body["goods"][0]["good"]["name"]
     # Should reference the original purchase receipt when one is on file.
     assert body.get("related_receipt_id") == "RECEIPT-PREV"
+
+
+class _DummyCursorNoReceipt(_DummyCursor):
+    def fetchone(self):
+        if "checkbox_receipt_id" in self.last_query:
+            return (None,)
+        if "information_schema" in self.last_query:
+            return (1,)
+        return None
+
+
+class _DummyConnNoReceipt(_DummyConn):
+    def cursor(self):
+        return _DummyCursorNoReceipt()
+
+
+def test_create_refund_receipt_without_original_is_not_applicable(monkeypatch):
+    """No fiscalized sale receipt → CheckBox must not be called at all."""
+    import importlib
+
+    db_module = importlib.import_module("backend.database")
+    monkeypatch.setattr(db_module, "get_connection", lambda: _DummyConnNoReceipt())
+    calls = _install_post(monkeypatch, {"id": "SHOULD-NOT-BE-CREATED"})
+
+    result = checkbox.create_refund_receipt(100, None, 150.0)
+
+    assert result == {
+        "receipt_id": None,
+        "fiscal_number": None,
+        "status": "not_applicable",
+    }
+    assert calls == []
 
 
 def test_create_refund_receipt_rejects_disabled(monkeypatch):

--- a/tests/test_refund_admin_idempotency.py
+++ b/tests/test_refund_admin_idempotency.py
@@ -1,0 +1,408 @@
+"""Idempotency tests for the admin refund processing flow.
+
+Covers the double-charge scenario observed on refund_request id=1 /
+purchase 64: LiqPay refunded the money but the CheckBox fiscal receipt
+failed, the request went to ``failed``, and a retry must NOT trigger a
+second LiqPay refund.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime
+from typing import Any
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import psycopg2
+
+
+class _BootstrapCursor:
+    """No-op cursor so importing backend.database needs no live Postgres."""
+
+    def execute(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def fetchone(self):
+        return None
+
+    def fetchall(self):
+        return []
+
+    def close(self) -> None:
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args: Any) -> bool:
+        return False
+
+
+class _BootstrapConn:
+    autocommit = False
+
+    def cursor(self) -> _BootstrapCursor:
+        return _BootstrapCursor()
+
+    def commit(self) -> None:
+        pass
+
+    def rollback(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+_original_connect = psycopg2.connect
+psycopg2.connect = lambda *a, **k: _BootstrapConn()
+try:
+    from backend.routers import refund_admin
+finally:
+    psycopg2.connect = _original_connect
+
+
+class FakeDB:
+    def __init__(self) -> None:
+        self.purchases: dict[int, dict[str, Any]] = {}
+        self.tickets: dict[int, list[int]] = {}
+        self.sales: list[dict[str, Any]] = []
+        self.refunds: list[dict[str, Any]] = []
+
+    def seed(
+        self,
+        purchase_id: int,
+        *,
+        paid_amount: float,
+        ticket_ids: list[int],
+        request_amount: float,
+    ) -> dict[str, Any]:
+        self.purchases[purchase_id] = {
+            "id": purchase_id,
+            "status": "paid",
+            "customer_name": "Test User",
+            "customer_email": "test@example.com",
+            "payment_method": "online",
+            "liqpay_order_id": f"ORDER-{purchase_id}",
+        }
+        self.tickets[purchase_id] = list(ticket_ids)
+        self.sales.append({
+            "purchase_id": purchase_id,
+            "category": "paid",
+            "amount": paid_amount,
+        })
+        row = {
+            "id": len(self.refunds) + 1,
+            "purchase_id": purchase_id,
+            "ticket_ids": [],
+            "amount_requested": request_amount,
+            "amount_refunded": None,
+            "currency": "UAH",
+            "status": "pending",
+            "requested_at": datetime.utcnow(),
+            "requested_by": "customer",
+            "reason": None,
+            "admin_actor": None,
+            "processed_at": None,
+            "liqpay_refund_id": None,
+            "liqpay_response": None,
+            "fiscal_receipt_id": None,
+            "fiscal_receipt_number": None,
+            "fiscal_status": None,
+            "failure_reason": None,
+        }
+        self.refunds.append(row)
+        return row
+
+
+def _request_tuple(r: dict[str, Any]) -> tuple:
+    return (
+        r["id"], r["purchase_id"], r["ticket_ids"], r["amount_requested"],
+        r["amount_refunded"], r["currency"], r["status"], r["requested_at"],
+        r["requested_by"], r["reason"], r["admin_actor"], r["processed_at"],
+        r["liqpay_refund_id"], r["liqpay_response"], r["fiscal_receipt_id"],
+        r["fiscal_receipt_number"], r["fiscal_status"], r["failure_reason"],
+    )
+
+
+class FakeCursor:
+    def __init__(self, db: FakeDB) -> None:
+        self.db = db
+        self._results: list[Any] = []
+
+    def _refund(self, request_id: int) -> dict[str, Any]:
+        return next(r for r in self.db.refunds if r["id"] == request_id)
+
+    def execute(self, query: str, params: Any = None) -> None:
+        q = " ".join(query.split()).lower()
+        p = params or ()
+        self._results = []
+
+        if q.startswith(("create table", "create index", "alter table")):
+            return
+
+        if q.startswith("select id, purchase_id, ticket_ids"):
+            self._results = [
+                _request_tuple(r) for r in self.db.refunds if r["id"] == p[0]
+            ]
+            return
+
+        if q.startswith("select id, status, customer_name"):
+            purchase = self.db.purchases.get(p[0])
+            if purchase:
+                self._results = [(
+                    purchase["id"], purchase["status"], purchase["customer_name"],
+                    purchase["customer_email"], purchase["payment_method"],
+                    purchase["liqpay_order_id"],
+                )]
+            return
+
+        if q.startswith("select id from ticket"):
+            self._results = [(tid,) for tid in self.db.tickets.get(p[0], [])]
+            return
+
+        if q.startswith("select count(*) from ticket"):
+            self._results = [(len(self.db.tickets.get(p[0], [])),)]
+            return
+
+        if q.startswith("select coalesce(sum(amount), 0) from sales"):
+            total = sum(
+                float(s["amount"])
+                for s in self.db.sales
+                if s["purchase_id"] == p[0] and s["category"] == "paid"
+            )
+            self._results = [(total,)]
+            return
+
+        if q.startswith("select coalesce(sum(amount_refunded), 0) from refund_request"):
+            total = sum(
+                float(r["amount_refunded"] or 0)
+                for r in self.db.refunds
+                if r["purchase_id"] == p[0] and r["status"] == "completed"
+            )
+            self._results = [(total,)]
+            return
+
+        if q.startswith("update refund_request set status='processing'"):
+            self._refund(p[0])["status"] = "processing"
+            return
+
+        if "set liqpay_refund_id = coalesce" in q:
+            lp_id, lp_resp, request_id = p
+            row = self._refund(request_id)
+            if lp_id:
+                row["liqpay_refund_id"] = lp_id
+            if lp_resp is not None:
+                # jsonb round-trip: stored payload comes back as a dict
+                row["liqpay_response"] = json.loads(lp_resp)
+            return
+
+        if "set liqpay_refund_id = %s" in q:
+            lp_id, lp_resp, request_id = p
+            row = self._refund(request_id)
+            row["liqpay_refund_id"] = lp_id
+            row["liqpay_response"] = json.loads(lp_resp) if lp_resp else None
+            return
+
+        if q.startswith("update refund_request set status = 'completed'"):
+            (
+                amount_refunded, lp_id, lp_resp,
+                f_id, f_num, f_status, request_id,
+            ) = p
+            row = self._refund(request_id)
+            row.update(
+                status="completed",
+                amount_refunded=amount_refunded,
+                liqpay_refund_id=lp_id,
+                liqpay_response=json.loads(lp_resp) if lp_resp else None,
+                fiscal_receipt_id=f_id,
+                fiscal_receipt_number=f_num,
+                fiscal_status=f_status,
+                processed_at=datetime.utcnow(),
+                failure_reason=None,
+            )
+            return
+
+        if q.startswith("update refund_request set status = 'failed'"):
+            failure_reason, request_id = p
+            row = self._refund(request_id)
+            row.update(
+                status="failed",
+                failure_reason=failure_reason,
+                processed_at=datetime.utcnow(),
+            )
+            return
+
+        if q.startswith("insert into sales"):
+            purchase_id, category, amount, _actor, _method = p
+            self.db.sales.append({
+                "purchase_id": purchase_id,
+                "category": category,
+                "amount": amount,
+            })
+            return
+
+        # purchase/open_ticket status flips are irrelevant to these tests
+        return
+
+    def fetchone(self):
+        return self._results[0] if self._results else None
+
+    def fetchall(self):
+        return list(self._results)
+
+    def close(self) -> None:
+        pass
+
+
+class FakeConn:
+    def __init__(self, db: FakeDB) -> None:
+        self.db = db
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self.db)
+
+    def commit(self) -> None:
+        pass
+
+    def rollback(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class LiqPayStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, float]] = []
+        self.result: dict[str, Any] = {
+            "status": "success",
+            "payment_id": "2870201631",
+            "refund_amount": 3500.0,
+            "raw": {"status": "success"},
+        }
+
+    def refund_payment(self, order_id, amount, comment=None):
+        self.calls.append((order_id, amount))
+        return dict(self.result)
+
+    @staticmethod
+    def is_refund_success(status):
+        return (status or "").lower() in {"success", "ok", "sandbox", "reversed"}
+
+
+class CheckboxStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, Any, float]] = []
+        self.result: dict[str, Any] = {
+            "receipt_id": "RFND-NEW",
+            "fiscal_number": "FN-NEW",
+            "status": "done",
+        }
+        self.error: Exception | None = None
+
+    def is_enabled(self) -> bool:
+        return True
+
+    def create_refund_receipt(self, purchase_id, ticket_ids, amount):
+        self.calls.append((purchase_id, ticket_ids, amount))
+        if self.error:
+            raise self.error
+        return dict(self.result)
+
+
+@pytest.fixture
+def env(monkeypatch):
+    db = FakeDB()
+    liqpay_stub = LiqPayStub()
+    checkbox_stub = CheckboxStub()
+    monkeypatch.setattr(refund_admin, "get_connection", lambda: FakeConn(db))
+    monkeypatch.setattr(refund_admin, "liqpay", liqpay_stub)
+    monkeypatch.setattr(refund_admin, "checkbox_service", checkbox_stub)
+    monkeypatch.setattr(refund_admin, "free_ticket", lambda cur, tid: None)
+    monkeypatch.setattr(
+        refund_admin.link_sessions,
+        "revoke_ticket_sessions",
+        lambda tid, conn=None: None,
+    )
+    return db, liqpay_stub, checkbox_stub
+
+
+def _process(request_id: int, amount: float):
+    return refund_admin._execute_refund(
+        request_id,
+        actor="admin",
+        ticket_ids=[],
+        refund_amount=amount,
+        void_fiscal=True,
+        comment=None,
+        background_tasks=None,
+    )
+
+
+def test_retry_after_checkbox_failure_skips_liqpay(env, caplog):
+    db, liqpay_stub, checkbox_stub = env
+    req = db.seed(64, paid_amount=3500.0, ticket_ids=[1, 2], request_amount=3500.0)
+
+    # First attempt: LiqPay succeeds, CheckBox returns 422 → request fails
+    # with 502, but the LiqPay refund id must already be persisted.
+    checkbox_stub.error = RuntimeError("422 Unprocessable Entity")
+    with pytest.raises(HTTPException) as exc_info:
+        _process(req["id"], 3500.0)
+    assert exc_info.value.status_code == 502
+
+    row = db.refunds[0]
+    assert row["status"] == "failed"
+    assert row["liqpay_refund_id"] == "2870201631"
+    assert len(liqpay_stub.calls) == 1
+
+    # Manual recovery (runbook step 1): reset the request to pending while
+    # keeping liqpay_refund_id.
+    row["status"] = "pending"
+    row["processed_at"] = None
+    row["failure_reason"] = None
+
+    # Retry: LiqPay must be skipped, CheckBox now succeeds.
+    checkbox_stub.error = None
+    with caplog.at_level(logging.INFO, logger="backend.routers.refund_admin"):
+        result = _process(req["id"], 3500.0)
+
+    assert result["status"] == "completed"
+    assert len(liqpay_stub.calls) == 1  # no second LiqPay refund
+    assert len(checkbox_stub.calls) == 2
+    assert row["liqpay_refund_id"] == "2870201631"
+    assert row["fiscal_receipt_id"] == "RFND-NEW"
+    assert row["fiscal_status"] == "done"
+    assert any(
+        "already done for request" in message for message in caplog.messages
+    )
+
+
+def test_refund_without_original_receipt_is_not_applicable(env):
+    db, liqpay_stub, checkbox_stub = env
+    req = db.seed(70, paid_amount=500.0, ticket_ids=[5], request_amount=500.0)
+
+    # checkbox.create_refund_receipt skips the API when the purchase has no
+    # checkbox_receipt_id and reports not_applicable (covered separately in
+    # test_checkbox_refund.py); the admin flow must treat that as success.
+    checkbox_stub.result = {
+        "receipt_id": None,
+        "fiscal_number": None,
+        "status": "not_applicable",
+    }
+
+    result = _process(req["id"], 500.0)
+
+    assert result["status"] == "completed"
+    row = db.refunds[0]
+    assert row["fiscal_status"] == "not_applicable"
+    assert row["fiscal_receipt_id"] is None
+    assert row["failure_reason"] is None
+    assert len(liqpay_stub.calls) == 1


### PR DESCRIPTION
The first production refund (request id=1, purchase 64) double-charge hazard: LiqPay refunded successfully but CheckBox returned 422 because refund receipts were posted to /api/v1/receipts/service (a cash-drawer service endpoint that rejects goods/CASHLESS payments). The request went to 'failed' with no persisted LiqPay id, so a retry would have refunded the customer twice.

checkbox.py:
- Post refund receipts to /api/v1/receipts/sell; with related_receipt_id CheckBox treats them as return receipts.
- Log the CheckBox response body and payload on HTTP errors so 4xx causes are diagnosable.
- When the purchase has no original fiscal receipt, skip CheckBox entirely and report status 'not_applicable' instead of failing.

refund_admin.py (_execute_refund):
- Skip the LiqPay call when liqpay_refund_id is already persisted on the request; reuse the stored id/response.
- Skip the CheckBox call when fiscal_receipt_id is already persisted.
- Persist liqpay_refund_id/liqpay_response immediately after a successful LiqPay refund, before calling CheckBox, so a fiscal failure can never cause a second LiqPay refund on retry.
- Treat fiscal status 'not_applicable' as success.

Add tests for the retry-after-CheckBox-failure and no-original-receipt scenarios, and a recovery runbook for refund_request id=1.

https://claude.ai/code/session_01Jg4eWMieokzj4iomMLUHZZ