### PR TITLE
Handle all CheckBox shift states in _ensure_shift and log 4xx bodies

### DIFF
--- a/backend/services/checkbox.py
+++ b/backend/services/checkbox.py
@@ -39,6 +39,28 @@ def _api_url() -> str:
     return _env("CHECKBOX_API_URL", "https://api.checkbox.ua").rstrip("/")
 
 
+def _log_http_error(resp: httpx.Response, payload: Any = None) -> None:
+    """Log the body of every CheckBox 4xx/5xx response before it gets raised.
+
+    ``raise_for_status`` swallows the response body, which made every CheckBox
+    failure undiagnosable — call this right before it.
+    """
+    if resp.status_code < 400:
+        return
+    if payload is not None:
+        logger.error(
+            "CheckBox %s %s -> %s body=%s payload=%s",
+            resp.request.method, str(resp.request.url),
+            resp.status_code, resp.text, payload,
+        )
+    else:
+        logger.error(
+            "CheckBox %s %s -> %s body=%s",
+            resp.request.method, str(resp.request.url),
+            resp.status_code, resp.text,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Token cache (module-level, thread-safe)
 # ---------------------------------------------------------------------------
@@ -73,6 +95,7 @@ def _get_token() -> str:
         headers=headers,
         timeout=15.0,
     )
+    _log_http_error(resp)
     resp.raise_for_status()
     token = resp.json().get("access_token")
     if not token:
@@ -114,6 +137,7 @@ def get_cashier_shift_status(token: str) -> tuple[int, dict[str, Any] | None]:
         headers=headers,
         timeout=10.0,
     )
+    _log_http_error(resp)
     resp.raise_for_status()
     return resp.status_code, resp.json()
 
@@ -153,61 +177,145 @@ def _has_required_fiscal_columns(cur) -> tuple[bool, list[str]]:
 _shift_lock = threading.Lock()
 _active_shift_id: str | None = None
 
+_SHIFT_WAIT_TIMEOUT = 30  # seconds to wait for OPENED/CLOSED transitions
 
-def _ensure_shift() -> str:
-    """Ensure an OPENED shift exists, opening one if needed. Returns shift id."""
-    global _active_shift_id
 
-    license_key = _env("CHECKBOX_LICENSE_KEY")
+def _shift_headers() -> dict[str, str]:
     headers = {**_auth_headers()}
+    license_key = _env("CHECKBOX_LICENSE_KEY")
     if license_key:
         headers["X-License-Key"] = license_key
+    return headers
 
-    # Check if there's already an active shift for this cashier
-    try:
-        resp = httpx.get(
-            f"{_api_url()}/api/v1/cashier/shift",
-            headers=headers,
-            timeout=10.0,
-        )
-        if resp.status_code == 200:
-            shift = resp.json()
-            if shift and shift.get("status") == "OPENED":
-                shift_id = shift["id"]
-                with _shift_lock:
-                    _active_shift_id = shift_id
-                return shift_id
-    except Exception:
-        logger.debug("Could not check existing shift, will try to open new one")
 
-    # Open a new shift
+def _get_current_shift(headers: dict[str, str]) -> dict[str, Any] | None:
+    """Return the cashier's current shift, or None when there is none.
+
+    CheckBox answers ``GET /api/v1/cashier/shift`` with a JSON ``null`` body
+    when the cashier has no shift at all.
+    """
+    resp = httpx.get(
+        f"{_api_url()}/api/v1/cashier/shift",
+        headers=headers,
+        timeout=10.0,
+    )
+    _log_http_error(resp)
+    resp.raise_for_status()
+    data = resp.json()
+    return data if isinstance(data, dict) else None
+
+
+def _fetch_shift(shift_id: str, headers: dict[str, str]) -> dict[str, Any]:
+    resp = httpx.get(
+        f"{_api_url()}/api/v1/shifts/{shift_id}",
+        headers=headers,
+        timeout=10.0,
+    )
+    _log_http_error(resp)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _remember_shift(shift_id: str) -> str:
+    global _active_shift_id
+    with _shift_lock:
+        _active_shift_id = shift_id
+    return shift_id
+
+
+def _wait_until_opened(shift_id: str, headers: dict[str, str]) -> str:
+    """Poll a CREATED/OPENING shift until it reaches OPENED."""
+    deadline = time.time() + _SHIFT_WAIT_TIMEOUT
+    while True:
+        status = _fetch_shift(shift_id, headers).get("status")
+        if status == "OPENED":
+            logger.info("CheckBox shift %s OPENED", shift_id)
+            return _remember_shift(shift_id)
+        if status in ("CLOSING", "CLOSED"):
+            raise RuntimeError(
+                f"CheckBox shift {shift_id} moved to {status} while waiting for OPENED"
+            )
+        if time.time() >= deadline:
+            raise RuntimeError(
+                f"CheckBox shift {shift_id} did not reach OPENED within "
+                f"{_SHIFT_WAIT_TIMEOUT}s (last status={status})"
+            )
+        logger.info("CheckBox shift %s status=%s, waiting for OPENED", shift_id, status)
+        time.sleep(2)
+
+
+def _wait_until_closed(shift_id: str, headers: dict[str, str]) -> None:
+    """Poll a CLOSING shift until it is fully CLOSED."""
+    deadline = time.time() + _SHIFT_WAIT_TIMEOUT
+    while True:
+        status = _fetch_shift(shift_id, headers).get("status")
+        if status == "CLOSED":
+            logger.info("CheckBox shift %s fully CLOSED", shift_id)
+            return
+        if time.time() >= deadline:
+            raise RuntimeError(
+                f"CheckBox shift {shift_id} did not finish closing within "
+                f"{_SHIFT_WAIT_TIMEOUT}s (last status={status})"
+            )
+        logger.info("CheckBox shift %s status=%s, waiting for CLOSED", shift_id, status)
+        time.sleep(2)
+
+
+def _open_new_shift(headers: dict[str, str]) -> str:
     resp = httpx.post(
         f"{_api_url()}/api/v1/shifts",
         headers=headers,
         timeout=15.0,
     )
+    _log_http_error(resp)
+    if resp.status_code == 400:
+        # CheckBox answers 400 when the cashier already has an active shift
+        # (e.g. one stuck in CREATED/OPENING that appeared between our check
+        # and this call). Re-read the cashier's shift and reuse it.
+        current = _get_current_shift(headers)
+        if current and current.get("id") and current.get("status") in (
+            "OPENED", "CREATED", "OPENING",
+        ):
+            logger.info(
+                "POST /shifts returned 400 but cashier already has shift %s "
+                "(status=%s), reusing it",
+                current.get("id"), current.get("status"),
+            )
+            return _wait_until_opened(str(current["id"]), headers)
     resp.raise_for_status()
-    shift = resp.json()
-    shift_id = shift["id"]
+    shift_id = resp.json()["id"]
+    logger.info("CheckBox shift %s created, waiting for OPENED", shift_id)
+    return _wait_until_opened(shift_id, headers)
 
-    # Poll until OPENED (max 30s)
-    deadline = time.time() + 30
-    while time.time() < deadline:
-        poll = httpx.get(
-            f"{_api_url()}/api/v1/shifts/{shift_id}",
-            headers=headers,
-            timeout=10.0,
-        )
-        poll.raise_for_status()
-        data = poll.json()
-        if data.get("status") == "OPENED":
-            with _shift_lock:
-                _active_shift_id = shift_id
-            logger.info("CheckBox shift %s opened", shift_id)
-            return shift_id
-        time.sleep(2)
 
-    raise RuntimeError(f"CheckBox shift {shift_id} did not reach OPENED status within 30s")
+def _ensure_shift() -> str:
+    """Ensure an OPENED shift exists, opening one if needed. Returns shift id.
+
+    Covers every CheckBox shift status: OPENED is reused as-is, a
+    CREATED/OPENING shift is awaited, a CLOSING one is awaited until CLOSED
+    and then replaced, CLOSED or no shift at all means opening a new one.
+    """
+    headers = _shift_headers()
+
+    shift = _get_current_shift(headers)
+    status = shift.get("status") if shift else None
+    shift_id = str(shift["id"]) if shift and shift.get("id") else None
+
+    if status == "OPENED" and shift_id:
+        logger.info("Using existing OPENED shift %s", shift_id)
+        return _remember_shift(shift_id)
+
+    if status in ("CREATED", "OPENING") and shift_id:
+        logger.info("Shift %s is %s, waiting for it to open", shift_id, status)
+        return _wait_until_opened(shift_id, headers)
+
+    if status == "CLOSING" and shift_id:
+        logger.info("Shift %s is CLOSING, waiting before opening a new one", shift_id)
+        _wait_until_closed(shift_id, headers)
+        status = "CLOSED"
+
+    logger.info("No usable shift (status=%s), opening a new one", status)
+    return _open_new_shift(headers)
 
 
 # ---------------------------------------------------------------------------
@@ -237,6 +345,7 @@ def _create_receipt(items: list[dict[str, Any]], payment_amount_kopecks: int) ->
         headers=headers,
         timeout=30.0,
     )
+    _log_http_error(resp, payload=body)
     resp.raise_for_status()
     data = resp.json()
     receipt_id = data.get("id")
@@ -256,10 +365,12 @@ def _poll_receipt(receipt_id: str) -> dict[str, Any]:
             headers=headers,
             timeout=10.0,
         )
+        _log_http_error(resp)
         resp.raise_for_status()
         data = resp.json()
         status = data.get("status", "")
         if status == "DONE":
+            logger.info("CheckBox receipt %s DONE", receipt_id)
             return data
         if status in ("ERROR", "CANCELLED"):
             raise RuntimeError(f"CheckBox receipt {receipt_id} ended with status {status}")
@@ -387,11 +498,7 @@ def _create_refund_receipt_request(
         headers=headers,
         timeout=30.0,
     )
-    if resp.status_code >= 400:
-        logger.error(
-            "CheckBox refund receipt error: status=%s body=%s payload=%s",
-            resp.status_code, resp.text, body,
-        )
+    _log_http_error(resp, payload=body)
     resp.raise_for_status()
     data = resp.json()
     receipt_id = data.get("id")

--- a/docs/runbooks/checkbox-shift-debug.md
+++ b/docs/runbooks/checkbox-shift-debug.md
@@ -1,0 +1,104 @@
+# CheckBox: диагностика смены и добивание refund_request id=1
+
+## Симптом
+
+`POST /api/admin/refund-requests/1/process` → HTTP 502:
+
+```
+{"detail":"CheckBox refund failed: Client error '400 Bad Request' for url 'https://api.checkbox.ua/api/v1/shifts'"}
+```
+
+Старый `_ensure_shift()` распознавал только статус `OPENED`, начальная
+проверка смены глотала любые ошибки (`except Exception: pass`), а
+`raise_for_status()` терял тело 400-ответа. Если смена кассира висела в
+`CREATED`/`OPENING`/`CLOSING` (или GET-проверка падала), код слепо делал
+`POST /api/v1/shifts` и получал 400 «зміна вже відкрита» без какой-либо
+диагностики.
+
+После фикса `_ensure_shift()` покрывает все статусы (`null`, `CREATED`,
+`OPENING`, `OPENED`, `CLOSING`, `CLOSED`), а на 400 от `POST /shifts`
+перечитывает текущую смену кассира и переиспользует её. Тела всех 4xx/5xx
+ответов CheckBox теперь логируются (`CheckBox <METHOD> <URL> -> <status>
+body=...`).
+
+## Ручная диагностика (выполнять на прод-хосте)
+
+```bash
+# 1) Креды из контейнера
+docker compose exec -T backend sh -c 'echo "PIN=$CHECKBOX_CASHIER_PIN"; echo "LIC=$CHECKBOX_LICENSE_KEY"; echo "API=${CHECKBOX_API_URL:-https://api.checkbox.ua}"'
+
+# 2) Токен кассира
+TOKEN=$(curl -s -X POST "$API/api/v1/cashier/signinPinCode" \
+  -H "X-License-Key: $LIC" -H "Content-Type: application/json" \
+  -d "{\"pin_code\": \"$PIN\"}" | python3 -c 'import sys,json;print(json.load(sys.stdin)["access_token"])')
+
+# 3) Текущая смена кассира (главный вопрос: какой status?)
+curl -s "$API/api/v1/cashier/shift" -H "Authorization: Bearer $TOKEN" -H "X-License-Key: $LIC" | python3 -m json.tool
+
+# 4) Кассир и привязка к кассе
+curl -s "$API/api/v1/cashier/me" -H "Authorization: Bearer $TOKEN" -H "X-License-Key: $LIC" | python3 -m json.tool
+
+# 5) Точное тело 400 при открытии смены
+curl -si -X POST "$API/api/v1/shifts" -H "Authorization: Bearer $TOKEN" -H "X-License-Key: $LIC"
+```
+
+Альтернатива без кредов: `GET /api/admin/integrations/checkbox/health`
+(админ-JWT) — делает signin и показывает статус смены.
+
+### Интерпретация
+
+| Что видно | Значение | Что делает новый код |
+|---|---|---|
+| шаг 3 → `status=OPENED` | смена уже открыта | переиспользует её (`Using existing OPENED shift`) |
+| шаг 3 → `CREATED`/`OPENING` | смена открывается | ждёт до 30 с до `OPENED` |
+| шаг 3 → `CLOSING` | смена закрывается | ждёт `CLOSED`, открывает новую |
+| шаг 3 → `null`/`CLOSED` | смены нет | `POST /shifts`, ждёт `OPENED` |
+| шаг 5 → 400 `shift_already_opened` | гонка/устаревшее состояние | перечитывает смену кассира, переиспользует |
+| шаг 5 → 400 про лицензию/кассу | нет `X-License-Key` или кассир не привязан к кассе | чинить в кабинете CheckBox: лицензия, привязка кассира |
+| шаг 3/5 → 5xx | проблема на стороне CheckBox | см. «Резервный путь» ниже |
+
+## Прогон refund_request id=1 (после деплоя)
+
+```bash
+# откатить заявку в pending (liqpay_refund_id сохраняется)
+docker compose exec -T db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "UPDATE refund_request SET status='\''pending'\'', processed_at=NULL, failure_reason=NULL WHERE id=1;"'
+
+# дёрнуть процессинг
+curl -i -X POST https://admin.maximovtours.com/api/admin/refund-requests/1/process \
+  -H "Authorization: Bearer <ADMIN_JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"refund_amount": 3500, "void_fiscal": true}'
+
+# проверка
+docker compose exec -T db sh -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c "SELECT status, liqpay_refund_id, fiscal_receipt_id, fiscal_status FROM refund_request WHERE id=1;"'
+```
+
+Ожидаемо: HTTP 200; `status=completed`, `liqpay_refund_id=2870201631`
+(не изменился — идемпотентность), `fiscal_receipt_id` = новый UUID,
+`fiscal_status=done`. В логах backend:
+`LiqPay refund 2870201631 already done for request=1, skipping`,
+`Using existing OPENED shift ...` (или `CheckBox shift ... OPENED`),
+`CheckBox receipt ... DONE`.
+
+Если снова 502 — в логах backend теперь будет точное тело ответа CheckBox
+(`CheckBox POST https://api.checkbox.ua/... -> 4xx body=...`). Не подгонять
+схему вслепую — зафиксировать body и разбирать предметно.
+
+## Резервный путь (только если CheckBox сам отдаёт 5xx / не открывает смену)
+
+1. Пробить чек повернення вручную через кабинет CheckBox
+   (продажа → повернення по чеку продажи purchase 64).
+2. Записать результат в БД:
+
+```sql
+UPDATE refund_request
+SET fiscal_receipt_id = '<uuid ручного чека>',
+    fiscal_receipt_number = '<фіскальний номер>',
+    fiscal_status = 'manual',
+    status = 'completed',
+    processed_at = NOW(),
+    failure_reason = NULL
+WHERE id = 1;
+```
+
+3. Приложить к отчёту ссылку на чек и тело ошибки CheckBox из логов.

--- a/tests/test_checkbox_shift.py
+++ b/tests/test_checkbox_shift.py
@@ -1,0 +1,155 @@
+"""Tests for the CheckBox shift state machine in ``_ensure_shift``.
+
+The production failure mode: ``POST /api/v1/shifts`` returned 400 because the
+cashier already had a shift that the old code did not recognise (only the
+OPENED status was handled, and the initial check swallowed all errors).
+``_ensure_shift`` must now cover every shift status: null, CREATED, OPENING,
+OPENED, CLOSING, CLOSED.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from backend.services import checkbox
+
+
+class _FakeResponse:
+    def __init__(self, body: Any, status_code: int = 200, *, url: str = "", method: str = "GET") -> None:
+        self._body = body
+        self.status_code = status_code
+        self.text = str(body)
+        self.request = SimpleNamespace(method=method, url=url)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> Any:
+        return self._body
+
+
+class FakeHTTP:
+    """URL-suffix-routed fake for httpx.get/post.
+
+    Each GET route holds a queue of bodies; the queue is consumed one body per
+    call and the last body repeats once the queue is down to a single entry.
+    """
+
+    def __init__(self) -> None:
+        self.get_routes: dict[str, list[Any]] = {}
+        self.post_responses: list[_FakeResponse] = []
+        self.get_calls: list[str] = []
+        self.post_calls: list[str] = []
+
+    def get(self, url: str, headers=None, timeout=None) -> _FakeResponse:
+        self.get_calls.append(url)
+        for suffix, queue in self.get_routes.items():
+            if url.endswith(suffix):
+                body = queue.pop(0) if len(queue) > 1 else queue[0]
+                if isinstance(body, _FakeResponse):
+                    return body
+                return _FakeResponse(body, url=url)
+        raise AssertionError(f"unexpected GET {url}")
+
+    def post(self, url: str, json=None, headers=None, timeout=None) -> _FakeResponse:
+        self.post_calls.append(url)
+        if not self.post_responses:
+            raise AssertionError(f"unexpected POST {url}")
+        return self.post_responses.pop(0)
+
+
+@pytest.fixture
+def http(monkeypatch):
+    fake = FakeHTTP()
+    monkeypatch.setattr("backend.services.checkbox.httpx.get", fake.get)
+    monkeypatch.setattr("backend.services.checkbox.httpx.post", fake.post)
+    monkeypatch.setattr(
+        "backend.services.checkbox._auth_headers",
+        lambda: {"Authorization": "Bearer test"},
+    )
+    monkeypatch.setattr("backend.services.checkbox.time.sleep", lambda s: None)
+    monkeypatch.setattr(checkbox, "_active_shift_id", None)
+    return fake
+
+
+def test_opened_shift_is_reused(http):
+    http.get_routes["/cashier/shift"] = [{"id": "S1", "status": "OPENED"}]
+
+    assert checkbox._ensure_shift() == "S1"
+    assert http.post_calls == []
+
+
+def test_created_shift_is_awaited(http):
+    http.get_routes["/cashier/shift"] = [{"id": "S2", "status": "CREATED"}]
+    http.get_routes["/shifts/S2"] = [
+        {"id": "S2", "status": "CREATED"},
+        {"id": "S2", "status": "OPENED"},
+    ]
+
+    assert checkbox._ensure_shift() == "S2"
+    assert http.post_calls == []
+
+
+def test_no_shift_opens_new_one(http):
+    http.get_routes["/cashier/shift"] = [None]  # JSON null body
+    http.post_responses = [_FakeResponse({"id": "S3", "status": "CREATED"}, method="POST")]
+    http.get_routes["/shifts/S3"] = [{"id": "S3", "status": "OPENED"}]
+
+    assert checkbox._ensure_shift() == "S3"
+    assert len(http.post_calls) == 1
+
+
+def test_closed_shift_opens_new_one(http):
+    http.get_routes["/cashier/shift"] = [{"id": "S0", "status": "CLOSED"}]
+    http.post_responses = [_FakeResponse({"id": "S4", "status": "CREATED"}, method="POST")]
+    http.get_routes["/shifts/S4"] = [{"id": "S4", "status": "OPENED"}]
+
+    assert checkbox._ensure_shift() == "S4"
+    assert len(http.post_calls) == 1
+
+
+def test_closing_shift_waits_then_opens_new_one(http):
+    http.get_routes["/cashier/shift"] = [{"id": "S5", "status": "CLOSING"}]
+    http.get_routes["/shifts/S5"] = [
+        {"id": "S5", "status": "CLOSING"},
+        {"id": "S5", "status": "CLOSED"},
+    ]
+    http.post_responses = [_FakeResponse({"id": "S6", "status": "CREATED"}, method="POST")]
+    http.get_routes["/shifts/S6"] = [{"id": "S6", "status": "OPENED"}]
+
+    assert checkbox._ensure_shift() == "S6"
+    assert len(http.post_calls) == 1
+
+
+def test_post_400_falls_back_to_existing_shift(http):
+    """The production failure: POST /shifts 400 because a shift already exists."""
+    http.get_routes["/cashier/shift"] = [
+        None,  # initial check sees nothing (stale/race)
+        {"id": "S7", "status": "OPENING"},  # re-check after the 400
+    ]
+    http.post_responses = [
+        _FakeResponse(
+            {"message": "Зміна вже відкрита", "code": "shift_already_opened"},
+            status_code=400,
+            method="POST",
+        )
+    ]
+    http.get_routes["/shifts/S7"] = [{"id": "S7", "status": "OPENED"}]
+
+    assert checkbox._ensure_shift() == "S7"
+
+
+def test_shift_closing_while_waiting_for_open_raises(http):
+    http.get_routes["/cashier/shift"] = [{"id": "S8", "status": "CREATED"}]
+    http.get_routes["/shifts/S8"] = [{"id": "S8", "status": "CLOSED"}]
+
+    with pytest.raises(RuntimeError, match="moved to CLOSED"):
+        checkbox._ensure_shift()


### PR DESCRIPTION
Root cause of the 400 on POST /api/v1/shifts during refund processing: the old _ensure_shift only recognised an OPENED shift. Its initial GET /cashier/shift check was wrapped in 'except Exception: pass', so any intermediate shift state (CREATED/OPENING/CLOSING) or a failed check fell straight through to POST /api/v1/shifts, which CheckBox rejects with 400 when the cashier already has an active shift. raise_for_status() then discarded the response body, leaving only the useless 'Client error 400' message. (The exact 400 body could not be pulled in this session: the CI environment has no access to api.checkbox.ua or the prod host; the diagnosis follows from the shift state machine and is verifiable via docs/runbooks/checkbox-shift-debug.md.)

Fixes:
- _ensure_shift now covers every shift status: OPENED is reused, CREATED/OPENING is polled until OPENED (30s), CLOSING is polled until CLOSED and then a new shift is opened, CLOSED/null opens a new shift. Every branch logs what it does.
- On POST /shifts 400 the cashier's current shift is re-read and reused when it exists (handles races and stale state).
- The swallowing 'except Exception' around the initial shift check is removed; real errors now propagate with their bodies logged.
- _log_http_error logs method, URL, status and response body (plus the request payload for receipt POSTs) before every raise_for_status in _get_token, get_cashier_shift_status, shift calls, _create_receipt, _create_refund_receipt_request and _poll_receipt.
- _poll_receipt logs 'CheckBox receipt <id> DONE' on success.

Add tests for the shift state machine (incl. the POST-400 fallback) and a runbook with the manual diagnostic commands and the recovery procedure for refund_request id=1.

https://claude.ai/code/session_01Jg4eWMieokzj4iomMLUHZZ