### PR TITLE
Make refund processing survive rebuild and retry on prod

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -97,6 +97,64 @@ def _ensure_purchase_schema_compatibility(cur) -> None:
     )
 
 
+def _ensure_ticket_link_tokens_schema(cur) -> None:
+    """Create the ticket-link-token schema when migration 006 was marked but not applied."""
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS public.ticket_link_tokens (
+            jti UUID PRIMARY KEY,
+            ticket_id INTEGER NOT NULL,
+            purchase_id INTEGER,
+            scopes JSONB NOT NULL,
+            lang VARCHAR(16) NOT NULL,
+            expires_at TIMESTAMPTZ NOT NULL,
+            revoked_at TIMESTAMPTZ
+        )
+        """
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ticket_link_tokens_ticket_id ON public.ticket_link_tokens (ticket_id)"
+    )
+
+
+def _ensure_refund_request_schema(cur) -> None:
+    """Create the refund-request schema when migration 025 was marked but not applied."""
+    cur.execute("ALTER TYPE public.sales_category ADD VALUE IF NOT EXISTS 'refund_requested'")
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS public.refund_request (
+            id                     SERIAL PRIMARY KEY,
+            purchase_id            INTEGER NOT NULL REFERENCES public.purchase(id),
+            ticket_ids             INTEGER[] NOT NULL DEFAULT '{}',
+            amount_requested       NUMERIC(12,2),
+            amount_refunded        NUMERIC(12,2),
+            currency               TEXT DEFAULT 'UAH',
+            status                 TEXT NOT NULL DEFAULT 'pending',
+            requested_at           TIMESTAMP NOT NULL DEFAULT NOW(),
+            requested_by           TEXT NOT NULL,
+            reason                 TEXT,
+            admin_actor            TEXT,
+            processed_at           TIMESTAMP,
+            liqpay_refund_id       TEXT,
+            liqpay_response        JSONB,
+            fiscal_receipt_id      TEXT,
+            fiscal_receipt_number  TEXT,
+            fiscal_status          TEXT,
+            failure_reason         TEXT
+        )
+        """
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_refund_request_status ON public.refund_request(status)"
+    )
+    cur.execute(
+        "CREATE INDEX IF NOT EXISTS idx_refund_request_purchase ON public.refund_request(purchase_id)"
+    )
+    cur.execute(
+        "ALTER TABLE public.purchase ADD COLUMN IF NOT EXISTS refund_requested_at TIMESTAMP"
+    )
+
+
 def _ensure_open_ticket_schema(cur) -> None:
     """Create the open-date return ticket schema when migration 024 was marked but not applied."""
     cur.execute(
@@ -164,6 +222,8 @@ def run_migrations() -> None:
 
     _ensure_purchase_schema_compatibility(cur)
     _ensure_open_ticket_schema(cur)
+    _ensure_ticket_link_tokens_schema(cur)
+    _ensure_refund_request_schema(cur)
     conn.commit()
     cur.close()
     conn.close()

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,9 +1,12 @@
+import logging
 import os
 import time
 import psycopg2
 from psycopg2 import sql
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
+logger = logging.getLogger("backend.database")
 
 # Determine database host from environment. When running under docker-compose
 # a DB_HOST variable is typically provided and points to the "db" service.
@@ -119,7 +122,19 @@ def _ensure_ticket_link_tokens_schema(cur) -> None:
 
 def _ensure_refund_request_schema(cur) -> None:
     """Create the refund-request schema when migration 025 was marked but not applied."""
-    cur.execute("ALTER TYPE public.sales_category ADD VALUE IF NOT EXISTS 'refund_requested'")
+    # Extend sales_category enum on a separate autocommit connection so the
+    # new value is durably visible to any later use without polluting the
+    # current transaction. ALTER TYPE ... ADD VALUE has surprising visibility
+    # rules inside a transaction block — outside of one it just works.
+    side = psycopg2.connect(DATABASE_URL)
+    side.autocommit = True
+    try:
+        with side.cursor() as side_cur:
+            side_cur.execute(
+                "ALTER TYPE public.sales_category ADD VALUE IF NOT EXISTS 'refund_requested'"
+            )
+    finally:
+        side.close()
     cur.execute(
         """
         CREATE TABLE IF NOT EXISTS public.refund_request (
@@ -220,11 +235,27 @@ def run_migrations() -> None:
         )
         conn.commit()
 
-    _ensure_purchase_schema_compatibility(cur)
-    _ensure_open_ticket_schema(cur)
-    _ensure_ticket_link_tokens_schema(cur)
-    _ensure_refund_request_schema(cur)
-    conn.commit()
+    # Each guard runs in its own savepoint so a failure in one does not
+    # poison the connection and skip the others. Without savepoints a single
+    # psycopg2 error aborts the whole transaction and every subsequent guard
+    # silently no-ops, which is exactly the regression we kept hitting on
+    # prod: schema_migrations said "applied", the tables did not exist, and
+    # a single guard failure hid the rest.
+    for name, guard in (
+        ("purchase", _ensure_purchase_schema_compatibility),
+        ("open_ticket", _ensure_open_ticket_schema),
+        ("ticket_link_tokens", _ensure_ticket_link_tokens_schema),
+        ("refund_request", _ensure_refund_request_schema),
+    ):
+        try:
+            cur.execute("SAVEPOINT guard")
+            guard(cur)
+            cur.execute("RELEASE SAVEPOINT guard")
+            conn.commit()
+            logger.info("Schema guard %s applied", name)
+        except Exception as exc:
+            conn.rollback()
+            logger.error("Schema guard %s failed: %s", name, exc)
     cur.close()
     conn.close()
 

--- a/backend/routers/refund_admin.py
+++ b/backend/routers/refund_admin.py
@@ -315,10 +315,10 @@ def _execute_refund(
         if not request_row:
             raise HTTPException(status_code=404, detail="Refund request not found")
 
-        if request_row.get("status") not in {"pending"}:
+        if request_row.get("status") not in {"pending", "failed"}:
             raise HTTPException(
                 status_code=409,
-                detail=f"Refund request is not pending (status={request_row.get('status')})",
+                detail=f"Refund request cannot be processed (status={request_row.get('status')})",
             )
 
         purchase = _load_purchase_for_refund(cur, int(request_row["purchase_id"]))
@@ -458,6 +458,28 @@ def _execute_refund(
                 )
                 raise HTTPException(status_code=502, detail=error) from exc
 
+            # Persist the fiscal id immediately so a downstream failure in the
+            # seat/inventory transaction cannot roll it back. Without this the
+            # CheckBox receipt exists but our DB forgets it and a retry would
+            # issue a second receipt.
+            if fiscal_receipt_id or fiscal_status:
+                cur.execute(
+                    """
+                    UPDATE refund_request
+                       SET fiscal_receipt_id = %s,
+                           fiscal_receipt_number = %s,
+                           fiscal_status = %s
+                     WHERE id = %s
+                    """,
+                    (
+                        fiscal_receipt_id,
+                        fiscal_receipt_number,
+                        fiscal_status,
+                        request_id,
+                    ),
+                )
+                conn.commit()
+
         # ---- Apply seat & purchase changes inside a fresh DB transaction ----
         cur2 = conn.cursor()
         try:
@@ -530,6 +552,12 @@ def _execute_refund(
     except Exception as exc:
         conn.rollback()
         logger.exception("Unhandled error processing refund request=%s", request_id)
+        # Don't leave the row stuck in 'processing' — flip it to 'failed' so
+        # an admin can retry once they've fixed the underlying cause.
+        try:
+            _record_failure(request_id, f"Unhandled error: {exc}")
+        except Exception:
+            logger.exception("Failed to record failure for request=%s", request_id)
         raise HTTPException(status_code=500, detail=str(exc))
     finally:
         cur.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,14 @@ services:
     ports:
       # ONLY localhost — nginx will proxy
       - "127.0.0.1:${BACKEND_PORT:-8000}:8000"
+    # Force IPv4 — CheckBox returns AAAA records but our host has no IPv6 egress,
+    # httpx mistakes the resulting connect failure for "name resolution".
+    sysctls:
+      - net.ipv6.conf.all.disable_ipv6=1
+      - net.ipv6.conf.default.disable_ipv6=1
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
 
   frontend:
     build:


### PR DESCRIPTION
## Summary

Brings the admin refund flow into a state where a fresh `git pull && docker compose build && up -d` on prod is enough to make `/admin/refund-requests/{id}/process` work end-to-end (LiqPay refund + CheckBox return receipt + seat/inventory cleanup), and to make retries safe.

## Why we kept tripping

On prod `schema_migrations` was marked as having applied migrations whose tables/enum values never actually materialised — `ticket_link_tokens`, `refund_request`, the `refund_requested` enum value. There were already runtime guards for `purchase` and `open_ticket` for exactly this reason, but nothing for the two newer schemas, so `free_ticket()` and `POST /public/purchase/{id}/refund-request` blew up with `UndefinedTable`.

Separately, when CheckBox issued a receipt successfully but the following inventory step failed (e.g. `free_ticket` against the missing `ticket_link_tokens` table), the `fiscal_receipt_id` was rolled back together with everything else — even though the fiscal document was already in CheckBox. A retry would have issued a duplicate.

And on the host networking side, CheckBox returns AAAA records but the container has no IPv6 egress; `httpx` surfaces the resulting connect failure as `Temporary failure in name resolution`, hiding the real cause.

## What changed

### `backend/database.py`
- Add startup schema guards for `ticket_link_tokens` and `refund_request` (idempotent, mirror the pattern already used for `purchase`/`open_ticket`).
- Run each guard inside its own `SAVEPOINT` and log every application. Previously a single guard raising silently aborted the whole transaction so the rest no-oped — that masked exactly the kind of regression these guards are supposed to catch.
- Add the `sales_category` enum value on a side autocommit connection (`ALTER TYPE ... ADD VALUE` has surprising visibility rules inside a long transaction).

### `backend/routers/refund_admin.py`
- Persist `fiscal_receipt_id` immediately after a successful CheckBox call, with its own commit, **before** opening the inventory transaction. The earlier code only wrote it inside `mark_completed()` under the same transaction as `free_ticket()`.
- Convert any unhandled exception out of `_execute_refund` into a `failed` row instead of leaving it stuck in `processing`, so the admin can press the button again.
- Allow `/process` to accept a retry from `status='failed'` in addition to `pending`.

### `docker-compose.yml`
- Disable IPv6 in the backend container via `sysctls` and pin DNS to public resolvers. This makes the `httpx → CheckBox` path use the IPv4 records CheckBox also publishes, instead of trying unreachable IPv6 first.

## Test plan

- [ ] Pull on prod, `docker compose down && docker compose build backend && docker compose up -d`.
- [ ] Confirm in `docker compose logs backend` that the three `Schema guard … applied` lines fire for `ticket_link_tokens`, `refund_request`, `open_ticket`.
- [ ] `\dt` shows `refund_request`, `ticket_link_tokens`, `open_ticket`; `SELECT enum_range(NULL::sales_category)` includes `refund_requested`.
- [ ] `docker compose exec backend python3 -c "import socket; print([a[4][0] for a in socket.getaddrinfo('api.checkbox.ua', 443, type=socket.SOCK_STREAM)])"` shows only IPv4 addresses.
- [ ] On a fresh paid purchase: customer requests refund from the cabinet, admin clicks **Вернуть через LiqPay** — request transitions to `completed`, `fiscal_receipt_id` and `liqpay_refund_id` are both populated, seats are freed.
- [ ] Force a failure (e.g. temporarily revoke CheckBox token) — request lands in `failed` with `liqpay_refund_id` already persisted, and a subsequent retry skips LiqPay and only re-runs CheckBox + inventory.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uq374St8LjTriU4whiupug)_