### PR TITLE
Respect tour booking terms when setting reservation deadline

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -123,8 +123,12 @@ def _cancel_expired_loop():
         conn = get_connection()
         cur = conn.cursor()
         try:
+            # deadline IS NULL means the tour's booking terms allow the booking
+            # to be held indefinitely (NO_EXPIRY / NO_BOOKING) — never auto-cancel
+            # those. NULL < NOW() is already NULL (false) in SQL, but the explicit
+            # guard keeps the intent clear.
             cur.execute(
-                "SELECT id FROM purchase WHERE status='reserved' AND deadline < NOW()",
+                "SELECT id FROM purchase WHERE status='reserved' AND deadline IS NOT NULL AND deadline < NOW()",
             )
             purchase_ids = [row[0] for row in cur.fetchall()]
 

--- a/backend/routers/purchase.py
+++ b/backend/routers/purchase.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, EmailStr, Field
 
 from ..auth import optional_scope, require_admin_token, require_scope
 from ..database import get_connection
+from ..models import BookingTermsEnum
 from ..ticket_utils import free_ticket
 from ..services import link_sessions
 from ._ticket_link_helpers import (
@@ -657,7 +658,7 @@ def _create_purchase(
 
     # Determine route/pricelist and ordered stops
     cur.execute(
-        "SELECT route_id, pricelist_id, date FROM tour WHERE id=%s",
+        "SELECT route_id, pricelist_id, date, booking_terms FROM tour WHERE id=%s",
         (data.tour_id,),
     )
     row = cur.fetchone()
@@ -667,6 +668,15 @@ def _create_purchase(
     route_id = row[0]
     pricelist_id = row[1] if len(row) > 1 else None
     tour_date = row[2] if len(row) > 2 else None
+    booking_terms_value = row[3] if len(row) > 3 else None
+    try:
+        booking_terms = (
+            BookingTermsEnum(booking_terms_value)
+            if booking_terms_value is not None
+            else BookingTermsEnum.EXPIRE_AFTER_48H
+        )
+    except ValueError:
+        booking_terms = BookingTermsEnum.EXPIRE_AFTER_48H
 
     if pricelist_id is None:
         cur.execute("SELECT pricelist_id FROM tour WHERE id=%s", (data.tour_id,))
@@ -769,12 +779,31 @@ def _create_purchase(
                 (new_amount, purchase_id),
             )
     else:
-        # 1) create purchase record using first passenger as customer name
+        # 1) create purchase record using first passenger as customer name.
+        # The reservation deadline (after which _cancel_expired_loop frees the
+        # seats) depends on the tour's booking terms:
+        #   EXPIRE_AFTER_48H  -> 48h after booking
+        #   EXPIRE_BEFORE_48H -> 48h before departure
+        #   NO_EXPIRY         -> no deadline, booking never auto-expires
+        #   NO_BOOKING        -> no deadline (reservation is not time-limited)
+        deadline_sql = "NOW() + interval '48 hours'"
+        deadline_params: list = []
+        if booking_terms in (
+            BookingTermsEnum.NO_EXPIRY,
+            BookingTermsEnum.NO_BOOKING,
+        ):
+            deadline_sql = "NULL"
+        elif booking_terms == BookingTermsEnum.EXPIRE_BEFORE_48H:
+            departure_dt = combine_departure_datetime(
+                tour_date, stop_departures.get(data.departure_stop_id)
+            )
+            deadline_sql = "%s::timestamptz - interval '48 hours'"
+            deadline_params = [departure_dt]
         cur.execute(
-            """
+            f"""
             INSERT INTO purchase
               (customer_name, customer_email, customer_phone, amount_due, deadline, status, update_at, payment_method)
-            VALUES (%s,%s,%s,%s,NOW() + interval '1 day',%s,NOW(),%s)
+            VALUES (%s,%s,%s,%s,{deadline_sql},%s,NOW(),%s)
             RETURNING id
             """,
             (
@@ -782,6 +811,7 @@ def _create_purchase(
                 data.passenger_email,
                 data.passenger_phone,
                 total_price,
+                *deadline_params,
                 status,
                 payment_method,
             ),


### PR DESCRIPTION
Reserved purchases were always created with a hardcoded deadline of NOW() + 1 day, ignoring the tour's booking_terms. The background _cancel_expired_loop then cancelled any reserved purchase past its deadline, so even bookings on tours configured as "Не сгорает (оплата при посадке)" (NO_EXPIRY) were auto-cancelled.

Compute the deadline from the tour's booking_terms instead:
  - EXPIRE_AFTER_48H  -> 48h after booking
  - EXPIRE_BEFORE_48H -> 48h before departure
  - NO_EXPIRY / NO_BOOKING -> no deadline (never auto-expires)

Also guard the cancel loop with `deadline IS NOT NULL` so null deadlines are never selected for cancellation.


Claude-Session: https://claude.ai/code/session_01GcWmcx5md4bEwJjYacrbBJ